### PR TITLE
Fix two warnings that were occurring during development.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
-            "sourceMaps": false,
-            "outDir": null
+            "sourceMaps": false
         },
         {
             "name": "Launch (Game Server)",
@@ -53,8 +52,7 @@
                 "NODE_ENV": "development"
             },
             "console": "internalConsole",
-            "sourceMaps": false,
-            "outDir": null
+            "sourceMaps": false
         },
         {
             "name": "Attach",
@@ -64,7 +62,6 @@
             "address": "localhost",
             "restart": false,
             "sourceMaps": false,
-            "outDir": null,
             "localRoot": "${workspaceRoot}",
             "remoteRoot": null
         },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-webpack": "^2.0.4",
     "moment": "^2.18.1",
     "mongodb": "^2.2.31",
-    "monk": "^3.1.3",
+    "monk": "^4.0.0",
     "node-noop": "^1.0.0",
     "node-pre-gyp": "^0.10.0",
     "node-sass": "^4.9.4",


### PR DESCRIPTION
* outDir deprecated in launch.json  (Removed - not used)
* "the options [safe] is not supported" (Updated monk to version 4)