### PR TITLE
mongodb: use data-volume for x-platform compat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
   mongo:
     image: mongo
     volumes:
-      - ./mongodb:/data/db
+      - mongodb:/data/db
 volumes:
+  mongodb:
   node_modules:


### PR DESCRIPTION
According to [1] Mapping data to your harddrive does not work on Windows & OS X.
Using data-volumes we can achieve persistent storage and it should work cross-platform.

Persistent against docker-compose down.
Will be wiped by docker-compose down -v

[1] https://hub.docker.com/_/mongo (scroll down to Caveats)