### PR TITLE
Forced 'exact' on Old/Ancient Yurk play effect.

### DIFF
--- a/server/game/cards/02-AoA/AncientYurk.js
+++ b/server/game/cards/02-AoA/AncientYurk.js
@@ -5,6 +5,7 @@ class AncientYurk extends Card {
         this.play({
             target: {
                 controller: 'self',
+                mode: 'exactly',
                 location: 'hand',
                 numCards: 3,
                 gameAction: ability.actions.discard()

--- a/server/game/cards/02-AoA/OldYurk.js
+++ b/server/game/cards/02-AoA/OldYurk.js
@@ -5,6 +5,7 @@ class OldYurk extends Card {
         this.play({
             target: {
                 controller: 'self',
+                mode: 'exactly',
                 location: 'hand',
                 numCards: 2,
                 gameAction: ability.actions.discard()


### PR DESCRIPTION
Action can still be cancelled, but cannot be confirmed without selecting 2 cards (old yurk) or 3 cards (ancient yurk)

https://github.com/keyteki/keyteki/issues/153