### PR TITLE
Changes to Exhaust action

### DIFF
--- a/server/game/GameActions/ExhaustAction.js
+++ b/server/game/GameActions/ExhaustAction.js
@@ -1,6 +1,10 @@
 const CardGameAction = require('./CardGameAction');
 
 class ExhaustAction extends CardGameAction {
+    setDefaultProperties() {
+        this.used = true;
+    }
+
     setup() {
         this.name = 'exhaust';
         this.targetType = ['creature', 'artifact'];
@@ -15,7 +19,11 @@ class ExhaustAction extends CardGameAction {
     }
 
     getEvent(card, context) {
-        return super.createEvent('onCardExhausted', { card: card, context: context }, () => card.exhaust());
+        let eventName = 'onCardExhausted';
+        if(!this.used) {
+            eventName = 'onCardExhaustedWithoutUse';
+        }
+        return super.createEvent(eventName, { card: card, context: context }, () => card.exhaust());
     }
 }
 

--- a/server/game/GameActions/ResolveAbilityAction.js
+++ b/server/game/GameActions/ResolveAbilityAction.js
@@ -31,8 +31,8 @@ class ResolveAbilityAction extends CardAction {
         return this.ability && super.canAffect(card, context);
     }
 
-    getEvent(card, context) {
-        return super.createEvent('onAction', { card: card, context: context }, () => {
+    getEvent(card, context) { 
+        return super.createEvent('unnamedEvent', { card: card, context: context }, () => {
             let newContext = Object.assign(this.ability.createContext(context.player), {
                 isResolveAbility: true,
                 secondResolution: this.secondResolution

--- a/server/game/GameActions/ResolveAbilityAction.js
+++ b/server/game/GameActions/ResolveAbilityAction.js
@@ -31,7 +31,7 @@ class ResolveAbilityAction extends CardAction {
         return this.ability && super.canAffect(card, context);
     }
 
-    getEvent(card, context) { 
+    getEvent(card, context) {
         return super.createEvent('unnamedEvent', { card: card, context: context }, () => {
             let newContext = Object.assign(this.ability.createContext(context.player), {
                 isResolveAbility: true,

--- a/server/game/cards/01-Core/Bigtwig.js
+++ b/server/game/cards/01-Core/Bigtwig.js
@@ -13,7 +13,7 @@ class Bigtwig extends Card {
                 cardType: 'creature',
                 gameAction: [
                     ability.actions.stun(),
-                    ability.actions.exhaust()
+                    ability.actions.exhaust({used: false})
                 ]
             },
             effect: 'stun and exhaust {0}'

--- a/server/game/cards/01-Core/EvasionSigil.js
+++ b/server/game/cards/01-Core/EvasionSigil.js
@@ -19,7 +19,7 @@ class EvasionSigil extends Card {
                     let topCard = player.deck.length ? player.deck[0] : '';
                     let cancelFight = topCard && topCard.hasHouse(context.game.activePlayer.activeHouse);
                     if(cancelFight) {
-                        return { target: context.event.context.source };
+                        return {target: context.event.context.source, used: false};
                     }
                     return { target: [] };
                 }),

--- a/server/game/cards/01-Core/ExperimentalTherapy.js
+++ b/server/game/cards/01-Core/ExperimentalTherapy.js
@@ -7,7 +7,9 @@ class ExperimentalTherapy extends Card {
         });
         this.play({
             gameAction: [
-                ability.actions.exhaust(context => ({ target: context.source.parent })),
+                ability.actions.exhaust(context => ({
+                    target: context.source.parent,
+                    used: false })),
                 ability.actions.stun(context => ({ target: context.source.parent }))
             ]
         });

--- a/server/game/cards/01-Core/NocturnalManeuver.js
+++ b/server/game/cards/01-Core/NocturnalManeuver.js
@@ -7,12 +7,12 @@ class NocturnalManeuver extends Card {
                 mode: 'upTo',
                 numCards: 3,
                 cardType: 'creature',
-                gameAction: ability.actions.exhaust()
+                gameAction: ability.actions.exhaust({used: false})
             }
         });
     }
 }
 
-NocturnalManeuver.id = 'nocturnal-maneuver'; // This is a guess at what the id might be - please check it!!!
+NocturnalManeuver.id = 'nocturnal-maneuver';
 
 module.exports = NocturnalManeuver;

--- a/server/game/cards/02-AoA/BonerotVenom.js
+++ b/server/game/cards/02-AoA/BonerotVenom.js
@@ -5,9 +5,7 @@ class BonerotVenom extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('constant', {
                 when: {
-                    onReap: event => event.card === this.parent,
-                    onFight: event => event.card === this.parent,
-                    onAction: event => event.card === this.parent
+                    onCardExhausted: event => (event.card === this.parent)
                 },
                 gameAction: ability.actions.dealDamage({ amount: 2 })
             })

--- a/server/game/cards/02-AoA/ContainmentField.js
+++ b/server/game/cards/02-AoA/ContainmentField.js
@@ -3,11 +3,12 @@ const Card = require('../../Card.js');
 class ContainmentField extends Card {
     setupCardAbilities(ability) {
         this.whileAttached({
-            effect: [
-                ability.effects.gainAbility('action', { gameAction: ability.actions.destroy() }),
-                ability.effects.gainAbility('reap', { gameAction: ability.actions.destroy() }),
-                ability.effects.gainAbility('fight', { gameAction: ability.actions.destroy() })
-            ]
+            effect: ability.effects.gainAbility('constant', {
+                when: {
+                    onCardExhausted: event => (event.card === this.parent)
+                },
+                gameAction: ability.actions.destroy()
+            })
         });
     }
 }

--- a/server/game/cards/02-AoA/SeismoEntangler.js
+++ b/server/game/cards/02-AoA/SeismoEntangler.js
@@ -8,10 +8,10 @@ class SeismoEntangler extends Card {
             },
             effect: 'stop creatures from {1} reaping next turn',
             effectArgs: context => context.house,
-            gameAction: ability.actions.lastingEffect({
+            gameAction: ability.actions.lastingEffect(context => ({
                 targetController: 'opponent',
-                effect: ability.effects.cardCannot('reap')
-            })
+                effect: ability.effects.cardCannot('reap', cannotContext => cannotContext.source.hasHouse(context.house))
+            }))
         });
     }
 }

--- a/server/game/cards/02-AoA/TheFlex.js
+++ b/server/game/cards/02-AoA/TheFlex.js
@@ -8,7 +8,7 @@ class TheFlex extends Card {
                 controller: 'self',
                 cardCondition: card => card.hasHouse('brobnar') && !card.exhausted,
                 gameAction: [
-                    ability.actions.exhaust(),
+                    ability.actions.exhaust({used: false}),
                     ability.actions.gainAmber(context => ({
                         target: context.player,
                         amount: Math.floor(context.target.power / 2)

--- a/test/server/cards/02-AoA/BonerotVenom.spec.js
+++ b/test/server/cards/02-AoA/BonerotVenom.spec.js
@@ -1,0 +1,99 @@
+describe('Bonerot Venom', function() {
+    integration(function() {
+        describe('Bonerot Venom\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'shadows',
+                        hand: ['bonerot-venom','nocturnal-maneuver'],
+                        inPlay: ['mack-the-knife']
+                    },
+                    player2: {
+                        house: 'untamed',
+                        inPlay: ['mindwarper', 'blypyp'],
+                        hand: ['nocturnal-maneuver']
+                    }
+                });
+            });
+            it('should apply to a creature', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+            });
+            it('should deal 2 damage to mack the knife when he reaps', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.reap(this.mackTheKnife);
+                expect(this.mackTheKnife.tokens.damage).toBe(2);
+                expect(this.player1.amber).toBe(2);
+            });
+            it('should deal 2 damage to mack the knife when he uses his action ability', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.clickCard(this.mackTheKnife);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                expect(this.player1).toHavePrompt('Mack the Knife');
+                expect(this.player1).toBeAbleToSelect(this.mindwarper);
+                expect(this.player1).toBeAbleToSelect(this.blypyp);
+                expect(this.player1).toBeAbleToSelect(this.mackTheKnife);
+                this.player1.clickCard(this.mindwarper);
+                expect(this.mindwarper.tokens.damage).toBe(1);
+                expect(this.mackTheKnife.tokens.damage).toBe(2);
+                expect(this.player1.amber).toBe(1);
+            });
+            it('should deal 2 damage to mack the knife when he fights mindwarper who is elusive', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.clickCard(this.mackTheKnife);
+                this.player1.clickPrompt('Fight with this creature');
+                expect(this.player1).toBeAbleToSelect(this.mindwarper);
+                expect(this.player1).toBeAbleToSelect(this.blypyp);
+                this.player1.clickCard(this.mindwarper);
+                expect(this.mackTheKnife.tokens.damage).toBe(2);
+            });
+            it('should deal 2 damage to mack the knife and kill him when he fights blypyp who is not elusive', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.clickCard(this.mackTheKnife);
+                this.player1.clickPrompt('Fight with this creature');
+                expect(this.player1).toBeAbleToSelect(this.mindwarper);
+                expect(this.player1).toBeAbleToSelect(this.blypyp);
+                this.player1.clickCard(this.blypyp);
+                expect(this.mackTheKnife.location).toBe('discard');
+            });
+            it('should not trigger if exhausted by other means via the other player', function() {
+                this.nm2 = this.player2.hand[0];
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.endTurn();
+                this.player2.clickPrompt('untamed');
+                this.player2.play(this.nm2);
+                expect(this.player2).toBeAbleToSelect(this.mackTheKnife);
+                this.player2.clickCard(this.mackTheKnife);
+                this.player2.clickPrompt('done');
+                expect(this.mackTheKnife.tokens.damage).not.toBe(2);
+            });
+            it('should not trigger if exhausted by other means by its controller', function() {
+                this.player1.playUpgrade(this.bonerotVenom, this.mackTheKnife);
+                expect(this.mackTheKnife.location).toBe('play area');
+                expect(this.mackTheKnife.upgrades).toContain(this.bonerotVenom);
+                this.player1.endTurn();
+                this.player2.clickPrompt('untamed');
+                this.player2.endTurn();
+                this.player1.clickPrompt('untamed');
+                this.player1.play(this.nocturnalManeuver);
+                expect(this.player1).toBeAbleToSelect(this.mackTheKnife);
+                this.player1.clickCard(this.mackTheKnife);
+                this.player1.clickPrompt('done');
+                expect(this.mackTheKnife.exhausted).toBe(true);
+                expect(this.mackTheKnife.tokens.damage).not.toBe(2);
+            });
+
+        });
+    });
+});

--- a/test/server/cards/02-AoA/SeismoEntangler.spec.js
+++ b/test/server/cards/02-AoA/SeismoEntangler.spec.js
@@ -1,0 +1,59 @@
+describe('Seismo-Entangler', function() {
+    integration(function() {
+        describe('Seismo-Entangler\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'logos',
+                        inPlay: ['seismo-entangler', 'dextre']
+                    },
+                    player2: {
+                        house: 'logos',
+                        inPlay: ['bumpsy', 'batdrone']
+                    }
+                });
+            });
+            it('should prompt to choose a house', function() {
+                this.player1.clickCard(this.seismoEntangler);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                expect(this.player1).toHavePrompt('Seismo-Entangler');
+                expect(this.player1.currentButtons).toContain('brobnar');
+                expect(this.player1.currentButtons).toContain('dis');
+                expect(this.player1.currentButtons).toContain('logos');
+                expect(this.player1.currentButtons).toContain('mars');
+                expect(this.player1.currentButtons).toContain('sanctum');
+                expect(this.player1.currentButtons).toContain('shadows');
+                expect(this.player1.currentButtons).toContain('untamed');
+            });
+            it('should not prevent its own creatures from reaping with logos', function() {
+                this.player1.clickCard(this.seismoEntangler);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                expect(this.player1).toHavePrompt('Seismo-Entangler');
+                this.player1.clickPrompt('logos');
+                this.player1.clickCard(this.dextre);
+                expect(this.player1).toHavePromptButton('Reap with this creature');
+            });
+            it('should prevent its opponent from reaping with logos', function() {
+                this.player1.clickCard(this.seismoEntangler);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                expect(this.player1).toHavePrompt('Seismo-Entangler');
+                this.player1.clickPrompt('logos');
+                this.player1.endTurn();
+                this.player2.clickPrompt('logos');
+                this.player2.clickCard(this.batdrone);
+                expect(this.player2).not.toHavePromptButton('Reap with this creature');
+            });
+
+            it('should not prevent its opponent from reaping with brobnar', function() {
+                this.player1.clickCard(this.seismoEntangler);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                expect(this.player1).toHavePrompt('Seismo-Entangler');
+                this.player1.clickPrompt('logos');
+                this.player1.endTurn();
+                this.player2.clickPrompt('brobnar');
+                this.player2.clickCard(this.bumpsy);
+                expect(this.player2).toHavePromptButton('Reap with this creature');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Exhaust Action now returns "onCardExhausted" event by default (aka on use), but can be passed {used: false} to return "onCardExhaustedWithoutUse" event.

This allows efficiency in cards like Containment Field and Bonerot Venom, because we can simply look for the "onCardExhausted" event and know that it has been used.

Cards that manually trigger the exhaust event have been updated to be passed {used: false}.

Test for Bonerot Venom added.
Fixes #198 
Fixes #188 