### PR TITLE
Fixed SpanglerBox where control source is different then properties source

### DIFF
--- a/server/game/gamesteps/handlermenuprompt.js
+++ b/server/game/gamesteps/handlermenuprompt.js
@@ -92,7 +92,7 @@ class HandlerMenuPrompt extends UiPrompt {
         }
         return [{
             type: 'targeting',
-            source: this.context.source.getShortSummary(),
+            source: this.properties.source.getShortSummary(),
             targets: targets.map(target => target.getShortSummary())
         }];
     }


### PR DESCRIPTION
HandlerMenuPrompt should use properties.source as a return value in getAdditionalPromptControls.

It is a small change, but it has impact, since this is an UiPrompt. I am testing locally more.