### PR TITLE
Check if "context.target" was set in getNeighbors(). When creature is…

### DIFF
--- a/server/game/cards/02-AoA/Smite.js
+++ b/server/game/cards/02-AoA/Smite.js
@@ -21,7 +21,7 @@ class SmiteAbilityResolver extends AbilityResolver {
         if(this.cancelled) {
             return;
         }
-        if (!this.context.target) {
+        if(!this.context.target) {
             return;
         }
         this.neighbors = this.context.target.neighbors;

--- a/server/game/cards/02-AoA/Smite.js
+++ b/server/game/cards/02-AoA/Smite.js
@@ -21,6 +21,9 @@ class SmiteAbilityResolver extends AbilityResolver {
         if(this.cancelled) {
             return;
         }
+        if (!this.context.target) {
+            return;
+        }
         this.neighbors = this.context.target.neighbors;
     }
 

--- a/test/server/cards/02-AoA/Smite.spec.js
+++ b/test/server/cards/02-AoA/Smite.spec.js
@@ -25,6 +25,16 @@ describe('Smite', function() {
                 expect(this.murmook.tokens.damage).toBe(2);
                 expect(this.troll.tokens.damage).toBe(2);
             });
+
+            it('should remove creature\'s stun', function() {
+                this.sequis.stunned = true;
+                this.player1.play(this.smite);
+                expect(this.player1).toHavePrompt('Smite');
+                this.player1.clickCard(this.sequis);
+                expect(this.sequis.stunned).toBe(false);
+                expect(this.player1).not.toHavePrompt('Sequis');
+            });
+
         });
     });
 });


### PR DESCRIPTION
… stunned, for example, or there are not other creatures to fight, the effect would not complete and target was undefined. (#276)