### PR TITLE
fix for archived opp creature behaviour

### DIFF
--- a/server/game/cards/02-AoA/DestructiveAnalysis.js
+++ b/server/game/cards/02-AoA/DestructiveAnalysis.js
@@ -17,7 +17,7 @@ class DestructiveAnalysis extends Card {
                         ability.actions.purge(),
                         ability.actions.dealDamage(context => ({
                             target: preThenContext.target,
-                            amount: context.target.length * 2
+                            amount: context.target.filter(card => card.owner === card.controller).length * 2
                         }))
                     ]
                 }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -347,6 +347,10 @@ class Player extends GameObject {
         } else if(card.owner !== this) {
             card.owner.moveCard(card, targetLocation, options);
             return;
+        } else if(card.location === 'archives' && card.controller !== card.owner) {
+            card.controller = card.owner;
+            targetLocation = 'hand';
+            targetPile = this.getSourceList(targetLocation);
         } else {
             card.controller = card.owner;
         }

--- a/test/server/cards/01-Core/SampleCollection.spec.js
+++ b/test/server/cards/01-Core/SampleCollection.spec.js
@@ -9,7 +9,7 @@ describe('Sample Collection', function() {
                         hand: ['sample-collection', 'phase-shift', 'labwork', 'wild-wormhole']
                     },
                     player2: {
-                        inPlay: ['troll', 'bumpsy', 'hebe-the-huge']
+                        inPlay: ['troll', 'bumpsy', 'hebe-the-huge', 'tantadlin']
                     }
                 });
                 this.player1.play(this.phaseShift);
@@ -58,8 +58,7 @@ describe('Sample Collection', function() {
                 expect(this.player1.archives).toContain(this.bumpsy);
                 expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
             });
-
-            it('should return creatures to the opponents hand when removed from archives', function() {
+            it('should return creatures to the opponents hand when you pick up your archives', function() {
                 this.player2.player.keys = 2;
                 this.player1.play(this.sampleCollection);
                 this.player1.clickCard(this.troll);
@@ -76,6 +75,30 @@ describe('Sample Collection', function() {
                 expect(this.player2.hand).toContain(this.troll);
                 expect(this.wildWormhole.location).toBe('hand');
                 expect(this.player1.hand).toContain(this.wildWormhole);
+            });
+        });
+        describe('Sample Collection\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'mars',
+                        hand: ['sample-collection'],
+                        inPlay: ['batdrone']
+                    },
+                    player2: {
+                        inPlay: ['troll', 'bumpsy', 'hebe-the-huge', 'tantadlin']
+                    }
+                });
+            });
+            it('should return creatures to the opponents hand when removed from archives by tantadlin', function() {
+                this.player2.player.keys = 1;
+                this.player1.play(this.sampleCollection);
+                this.player1.clickCard(this.troll);
+                this.player1.endTurn();
+                expect(this.troll.location).toBe('archives');
+                this.player2.clickPrompt('untamed');
+                this.player2.fightWith(this.tantadlin, this.batdrone);
+                expect(this.player2.hand).toContain(this.troll);
             });
         });
     });

--- a/test/server/cards/02-AoA/DestructiveAnalysis.spec.js
+++ b/test/server/cards/02-AoA/DestructiveAnalysis.spec.js
@@ -1,0 +1,78 @@
+describe('Destructive Analysis', function() {
+    integration(function() {
+        describe('Destructive Analysis\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'mars',
+                        hand: ['sample-collection', 'destructive-analysis'],
+                        archives: ['tunk']
+                    },
+                    player2: {
+                        inPlay: ['troll', 'dextre', 'bumpsy', 'sequis'],
+                        archives: ['raiding-knight']
+                    }
+                });
+                this.player2.player.keys = 1;
+                this.player1.play(this.sampleCollection);
+                expect(this.player1).toHavePrompt('Sample Collection');
+                expect(this.player1).toBeAbleToSelect(this.troll);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+                expect(this.player1).toBeAbleToSelect(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.sequis);
+                this.player1.clickCard(this.troll);
+                expect(this.troll.location).toBe('archives');
+                expect(this.player1.archives).toContain(this.troll);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+            it('should allow purging of any number of cards to deal 2D to a creature', function() {
+                expect(this.tunk.location).toBe('archives');
+                this.player1.play(this.destructiveAnalysis);
+                expect(this.player1).toHavePrompt('Destructive Analysis');
+                expect(this.player1).toBeAbleToSelect(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.sequis);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+                this.player1.clickCard(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.tunk);
+                expect(this.player1).toBeAbleToSelect(this.troll);
+                expect(this.player1).not.toBeAbleToSelect(this.raidingKnight);
+                this.player1.clickCard(this.tunk);
+                this.player1.clickPrompt('done');
+                expect(this.tunk.location).toBe('purged');
+                expect(this.bumpsy.tokens.damage).toBe(4);
+            });
+            it('should return archived opponent cards to their hands and deal no additional damage ', function() {
+                expect(this.tunk.location).toBe('archives');
+                this.player1.play(this.destructiveAnalysis);
+                expect(this.player1).toHavePrompt('Destructive Analysis');
+                expect(this.player1).toBeAbleToSelect(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.sequis);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+                this.player1.clickCard(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.tunk);
+                expect(this.player1).toBeAbleToSelect(this.troll);
+                expect(this.player1).not.toBeAbleToSelect(this.raidingKnight);
+                this.player1.clickCard(this.troll);
+                this.player1.clickPrompt('done');
+                expect(this.troll.location).not.toBe('purged');
+                expect(this.player2.hand).toContain(this.troll);
+                expect(this.player1.hand).not.toContain(this.troll);
+                expect(this.bumpsy.tokens.damage).toBe(2);
+            });
+            it('should allow you to select no creatures', function() {
+                expect(this.tunk.location).toBe('archives');
+                this.player1.play(this.destructiveAnalysis);
+                expect(this.player1).toHavePrompt('Destructive Analysis');
+                expect(this.player1).toBeAbleToSelect(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.sequis);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+                this.player1.clickCard(this.bumpsy);
+                expect(this.player1).toBeAbleToSelect(this.tunk);
+                expect(this.player1).toBeAbleToSelect(this.troll);
+                expect(this.player1).not.toBeAbleToSelect(this.raidingKnight);
+                this.player1.clickPrompt('done');
+                expect(this.bumpsy.tokens.damage).toBe(2);
+            });
+        });
+    });
+});


### PR DESCRIPTION
If you have an opponents creature in your archive, and it leaves, it will now return to their hand in all cases (including if removed by dysania or tantadlin).
modified destructive analysis to only deal damage based on actual purged creatures (aka your own) rather than *all* creatures, as if it is an opponent's, it doesn't get purged and no damage is dealt.
added test for destructive analysis.
Modified test for sample collection for Tantadlin edge case.

Fixes #308 