### PR TITLE
Add "PreKey" phase to allow for start of turn effects if key phase is suppressed.

### DIFF
--- a/server/game/cards/02-AoA/DirectorOfZyx.js
+++ b/server/game/cards/02-AoA/DirectorOfZyx.js
@@ -4,7 +4,7 @@ class DirectorOfZyx extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onPhaseStarted: (event, context) => event.phase === 'key' && context.player === this.game.activePlayer
+                onPhaseStarted: (event, context) => event.phase === 'main' && context.player === this.game.activePlayer
             },
             gameAction: ability.actions.archive(context => ({
                 target: context.player.deck[0]

--- a/server/game/cards/02-AoA/DirectorOfZyx.js
+++ b/server/game/cards/02-AoA/DirectorOfZyx.js
@@ -4,7 +4,7 @@ class DirectorOfZyx extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onPhaseStarted: (event, context) => event.phase === 'main' && context.player === this.game.activePlayer
+                onPhaseStarted: (event, context) => event.phase === 'preKey' && context.player === this.game.activePlayer
             },
             gameAction: ability.actions.archive(context => ({
                 target: context.player.deck[0]

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -9,6 +9,7 @@ const Spectator = require('./spectator.js');
 const AnonymousSpectator = require('./anonymousspectator.js');
 const GamePipeline = require('./gamepipeline.js');
 const SetupPhase = require('./gamesteps/setup/setupphase');
+const preKeyPhase = require('./gamesteps/prekey/preKeyPhase');
 const KeyPhase = require('./gamesteps/key/KeyPhase');
 const HousePhase = require('./gamesteps/house/HousePhase');
 const MainPhase = require('./gamesteps/main/MainPhase');
@@ -582,6 +583,7 @@ class Game extends EventEmitter {
      */
     beginRound() {
         this.raiseEvent('onBeginRound');
+        this.queueStep(new preKeyPhase(this));
         this.queueStep(new KeyPhase(this));
         this.queueStep(new HousePhase(this));
         this.queueStep(new MainPhase(this));

--- a/server/game/gamesteps/prekey/preKeyPhase.js
+++ b/server/game/gamesteps/prekey/preKeyPhase.js
@@ -1,0 +1,17 @@
+const Phase = require('../phase.js');
+const SimpleStep = require('../simplestep.js');
+
+class preKeyPhase extends Phase {
+    constructor(game) {
+        super(game, 'preKey');
+        this.initialise([
+            new SimpleStep(game, () => this.preKey())
+        ]);
+    }
+
+    preKey() {
+
+    }
+}
+
+module.exports = preKeyPhase;


### PR DESCRIPTION
I'm not sure if this is the best approach to the situation, but it seems not impossible that there will be other effects that we need to worry about that could be adversely affected if the key phase is skipped.

Fixes #356 