### PR TITLE
DeckSummary.jsx to use table CSS (#342)

### DIFF
--- a/client/Components/Decks/DeckSummary.jsx
+++ b/client/Components/Decks/DeckSummary.jsx
@@ -77,8 +77,8 @@ class DeckSummary extends React.Component {
                 }
             }
 
-                cardsToRender.push(
-            	<div className='cards-no-break' key={ key }>
+            cardsToRender.push(
+                <div className='cards-no-break' key={ key }>
                     <div className='card-group-title'>{ key + ' (' + count.toString() + ')' }</div>
                     <div key={ key } className='card-group'>{ cards }</div>
                 </div>);

--- a/client/Components/Decks/DeckSummary.jsx
+++ b/client/Components/Decks/DeckSummary.jsx
@@ -37,7 +37,6 @@ class DeckSummary extends React.Component {
     }
 
     getCardsToRender() {
-        let titlesToRender = [];
         let cardsToRender = [];
         let groupedCards = {};
 
@@ -76,18 +75,16 @@ class DeckSummary extends React.Component {
                     cards.push(cardToRender);
                     count += parseInt(card.count);
                 }
-
-                titlesToRender.push(
-                    <div key={ `${key}-title` } className='card-group-title'>{ key + ' (' + count.toString() + ')' }</div>
-                );
+            }
 
                 cardsToRender.push(
-                    <div key={ key } className='card-group cards-no-break'>{ cards }</div>
-                );
-            }
+            	<div className='cards-no-break' key={ key }>
+                    <div className='card-group-title'>{ key + ' (' + count.toString() + ')' }</div>
+                    <div key={ key } className='card-group'>{ cards }</div>
+                </div>);
         }
 
-        return [titlesToRender, cardsToRender];
+        return cardsToRender;
     }
 
     isNumeric(n) {
@@ -145,11 +142,8 @@ class DeckSummary extends React.Component {
                     <div className='col-xs-2 col-sm-3 no-x-padding'>{ this.props.deck.agenda && this.props.deck.agenda.code ? <img className='img-responsive' src={ '/img/cards/' + this.props.deck.agenda.code + '.png' } /> : null }</div>
                 </div>
                 <div className='col-xs-12 no-x-padding'>
-                    <div className='card-group-cards'>
-                        { cardsToRender[0] }
-                    </div>
-                    <div className='card-group-cards'>
-                        { cardsToRender[1] }
+                    <div className='cards'>
+                        { cardsToRender }
                     </div>
                 </div>
             </div>);

--- a/client/Components/Decks/DeckSummary.jsx
+++ b/client/Components/Decks/DeckSummary.jsx
@@ -37,10 +37,9 @@ class DeckSummary extends React.Component {
     }
 
     getCardsToRender() {
+        let titlesToRender = [];
         let cardsToRender = [];
         let groupedCards = {};
-        let countCards = {};
-        let maxCountCards = 0;
 
         for(const card of this.props.deck.cards) {
             let house = card.card.house;
@@ -50,14 +49,9 @@ class DeckSummary extends React.Component {
 
             if(!groupedCards[house]) {
                 groupedCards[house] = [card];
-                countCards[house] = 1;
-                maxCountCards = Math.max(maxCountCards, countCards[house]);
             } else {
                 groupedCards[house].push(card);
-                countCards[house] = countCards[house] + 1;
             }
-
-            maxCountCards = Math.max(maxCountCards, countCards[house]);
         }
 
         // Traverse props.deck.houses to guarantee the card boxes will have the same order as the house icons
@@ -67,35 +61,33 @@ class DeckSummary extends React.Component {
             let cardList = groupedCards[house];
             let cards = [];
             let count = 0;
-            let i = 0;
 
-            for(const card of cardList) {
-                let cardToRender = (<div key={ card.id }>
-                    <span>{ card.count + 'x ' }</span>
-                    <span className='card-link' onMouseOver={ this.onCardMouseOver } onMouseOut={ this.onCardMouseOut }
-                        data-card_id={ card.card.id } data-card_house={ house }>
-                        { card.card.name }
-                    </span>
-                    { card.maverick ? <img className='small-maverick' src='/img/maverick.png' width='12px' height='12px' /> : null }
-                </div>);
+            if(cardList) {
+                for(const card of cardList) {
+                    let cardToRender = (<div key={ card.id }>
+                        <span>{ card.count + 'x ' }</span>
+                        <span className='card-link' onMouseOver={ this.onCardMouseOver } onMouseOut={ this.onCardMouseOut }
+                            data-card_id={ card.card.id } data-card_house={ house }>
+                            { card.card.name }
+                        </span>
+                        { card.maverick ? <img className='small-maverick' src='/img/maverick.png' width='12px' height='12px' /> : null }
+                    </div>);
 
-                cards.push(cardToRender);
-                count += parseInt(card.count);
-                i++;
+                    cards.push(cardToRender);
+                    count += parseInt(card.count);
+                }
+
+                titlesToRender.push(
+                    <div key={ `${key}-title` } className='card-group-title'>{ key + ' (' + count.toString() + ')' }</div>
+                );
+
+                cardsToRender.push(
+                    <div key={ key } className='card-group cards-no-break'>{ cards }</div>
+                );
             }
-
-            while(i++ < maxCountCards) {
-                cards.push(<div className='cards-no-break' key={ key + '-' + i }>&nbsp;</div>);
-            }
-
-            cardsToRender.push(
-                <div className='cards-no-break' key={ key }>
-                    <div className='card-group-title'>{ key + ' (' + count.toString() + ')' }</div>
-                    <div key={ key } className='card-group'>{ cards }</div>
-                </div>);
         }
 
-        return cardsToRender;
+        return [titlesToRender, cardsToRender];
     }
 
     isNumeric(n) {
@@ -153,8 +145,11 @@ class DeckSummary extends React.Component {
                     <div className='col-xs-2 col-sm-3 no-x-padding'>{ this.props.deck.agenda && this.props.deck.agenda.code ? <img className='img-responsive' src={ '/img/cards/' + this.props.deck.agenda.code + '.png' } /> : null }</div>
                 </div>
                 <div className='col-xs-12 no-x-padding'>
-                    <div className='cards'>
-                        { cardsToRender }
+                    <div className='card-group-cards'>
+                        { cardsToRender[0] }
+                    </div>
+                    <div className='card-group-cards'>
+                        { cardsToRender[1] }
                     </div>
                 </div>
             </div>);

--- a/less/deckbuilder.less
+++ b/less/deckbuilder.less
@@ -26,7 +26,7 @@
 }
 
 .decklist {
-  height: 220px;
+  height: 200px;
 }
 
 .decklist > img {
@@ -35,8 +35,7 @@
 }
 
 .cards-no-break {
-  display: table-cell;
-  width: 33.3333%;
+  break-inside: avoid;
 }
 
 .card-group {
@@ -45,28 +44,20 @@
   margin: 5px 5px 5px 0;
   padding: 10px;
   border: 1px solid rgba(71, 58, 56, 0.65);
+  display: inline-block;
 }
 
 .card-group-title {
   background-color: @header-background;
   color: white;
-  margin: 0px 5px 0 0;
+  margin: 5px 5px 0 0;
   padding: 5px 1px;
   border: 1px solid @header-border;
   border-radius: 4px 4px 0 0;
   border-bottom: none;
   text-align: center;
   position: relative;
-  top: 0px;
-  display: table-cell;
-  width: 33.3333%;
-}
-
-.card-group-cards {
-  column-count: 2;
-  border-spacing: 10px 0px;
-  display: table;
-  width: 100%;
+  top: 5px;
 }
 
 .cards {

--- a/less/deckbuilder.less
+++ b/less/deckbuilder.less
@@ -26,7 +26,7 @@
 }
 
 .decklist {
-  height: 200px;
+  height: 220px;
 }
 
 .decklist > img {
@@ -35,7 +35,8 @@
 }
 
 .cards-no-break {
-  break-inside: avoid;
+  display: table-cell;
+  width: 33.3333%;
 }
 
 .card-group {
@@ -49,14 +50,23 @@
 .card-group-title {
   background-color: @header-background;
   color: white;
-  margin: 5px 5px 0 0;
+  margin: 0px 5px 0 0;
   padding: 5px 1px;
   border: 1px solid @header-border;
   border-radius: 4px 4px 0 0;
   border-bottom: none;
   text-align: center;
   position: relative;
-  top: 5px;
+  top: 0px;
+  display: table-cell;
+  width: 33.3333%;
+}
+
+.card-group-cards {
+  column-count: 2;
+  border-spacing: 10px 0px;
+  display: table;
+  width: 100%;
 }
 
 .cards {


### PR DESCRIPTION
DeckSummary.jsx to use table CSS instead of columns and 'page-break: avoid' (#342)
It handles DIV expansion better. Useful for large card names (when i18n is in place)