### PR TITLE
Fix for Nerve Blast does not inform which creature took damage (#407)

### DIFF
--- a/server/game/cards/01-Core/NerveBlast.js
+++ b/server/game/cards/01-Core/NerveBlast.js
@@ -8,6 +8,10 @@ class NerveBlast extends Card {
                 target: {
                     cardType: 'creature',
                     gameAction: ability.actions.dealDamage({ amount: 2 })
+                },
+                message: '{0} uses {1} to deal 2 damage to {2}',
+                messageArgs: context => {
+                    return [context.player, context.source, context.target];
                 }
             }
         });


### PR DESCRIPTION
Added message to Nerve Blast to show which creature was targeted when dealing damage.

Fixes #407 