### PR TITLE
Fix for Might Makes Right not considering power modifiers

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -418,6 +418,7 @@ class Card extends EffectSource {
         clone.location = this.location;
         clone.parent = this.parent;
         clone.clonedNeighbors = this.neighbors;
+        clone.modifiedPower = this.getPower();
         return clone;
     }
 

--- a/server/game/cards/02-AoA/MightMakesRight.js
+++ b/server/game/cards/02-AoA/MightMakesRight.js
@@ -15,7 +15,7 @@ class MightMakesRight extends Card {
                 gameAction: ability.actions.sacrifice()
             },
             then: {
-                condition: context => context.preThenEvents && context.preThenEvents.filter(event => !event.cancelled).reduce((total, event) => total + event.card.power, 0) >= 25 ? 1 : 0,
+                condition: context => context.preThenEvents && context.preThenEvents.filter(event => !event.cancelled).reduce((total, event) => total + event.clone.modifiedPower, 0) >= 25 ? 1 : 0,
                 gameAction: ability.actions.forgeKey(context => ({
                     modifier: -context.player.getCurrentKeyCost()
                 }))

--- a/test/server/cards/02-AoA/MightMakesRight.spec.js
+++ b/test/server/cards/02-AoA/MightMakesRight.spec.js
@@ -73,6 +73,32 @@ describe('Might Makes Right', function() {
                 this.setupTest({
                     player1: {
                         house: 'brobnar',
+                        amber: 1,
+                        inPlay: ['panpaca-anga', 'knoxx', 'lion-bautrem', 'marmo-swarm'],
+                        hand: ['might-makes-right']
+                    }
+                });
+            });
+
+            it('should allow key to be forged at zero cost if creatures of total power of 25 or more (including modifiers) are sacrificed', function() {
+                this.player1.play(this.mightMakesRight);
+                this.player1.clickCard(this.knoxx);
+                this.player1.clickCard(this.lionBautrem);
+                this.player1.clickCard(this.marmoSwarm);
+                this.player1.clickPrompt('Done');
+                expect(this.knoxx.location).toBe('discard');
+                expect(this.lionBautrem.location).toBe('discard');
+                expect(this.marmoSwarm.location).toBe('discard');
+                expect(this.player1.player.keys).toBe(1);
+                expect(this.player1.player.amber).toBe(2);
+            });
+        });
+
+        describe('Might Makes Right\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'brobnar',
                         amber: 2,
                         inPlay: ['groke', 'hebe-the-huge', 'archimedes', 'ganger-chieftain', 'bellowing-patrizate', 'king-of-the-crag'],
                         hand: ['might-makes-right']


### PR DESCRIPTION
Added modifiedPower field to card clone/snapshot, to capture actual effective power of card (including modifiers) at time of snapshot, and updated Might Makes Right to consider this value instead of printed power.
Also updated Might Makes Right test to consider this case (modified power of selected cards > 25, printed power < 25)

Fixes #264 
Fixes #332 
Fixes #414 