### PR TITLE
Fix for Redlock 'Check' timing issue

### DIFF
--- a/server/game/cards/02-AoA/Redlock.js
+++ b/server/game/cards/02-AoA/Redlock.js
@@ -4,7 +4,8 @@ class Redlock extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onPhaseEnded: (event, context) =>
+                    event.phase === 'main' &&
                     context.player === this.game.activePlayer &&
                     this.game.cardsPlayed.filter(card => card.type === 'creature').length === 0
             },


### PR DESCRIPTION
Changed Redlock effect to trigger at the end of main phase rather than end of round, so that the amber is added before check would be declared

Fixes #428 