### PR TITLE
Update armor token while dealing damage

### DIFF
--- a/server/game/GameActions/DealDamageAction.js
+++ b/server/game/GameActions/DealDamageAction.js
@@ -56,6 +56,15 @@ class DealDamageAction extends CardGameAction {
             fightEvent: this.fightEvent,
             damagePrevented: damagePrevented
         };
+
+        // Update armor token
+        if(this.noGameStateCheck) {
+            card.removeToken('armor');
+            if(card.armor - card.armorUsed > 0) {
+                card.addToken('armor', card.armor - card.armorUsed);
+            }
+        }
+
         return super.createEvent('onDamageDealt', params, event => {
             if(event.amount === 0) {
                 return;


### PR DESCRIPTION
Update armor token while dealing damage if action says no game state update. It is consistent with damage token being added

Do you think it is better to put this in the event bellow?

Fixes #441