### PR TITLE
Doctor Driscoll

### DIFF
--- a/server/game/cards/03-WC/DoctorDriscoll.js
+++ b/server/game/cards/03-WC/DoctorDriscoll.js
@@ -1,0 +1,24 @@
+const Card = require('../../Card.js');
+
+class DoctorDriscoll extends Card {
+    setupCardAbilities(ability) {
+        this.action({
+            target: {
+                activePromptTitle: 'Choose a creature to heal',
+                condition: context => context.game.creaturesInPlay.some(card => card.hasToken('damage')),
+                cardType: 'creature',
+                gameAction: ability.actions.heal({ amount: 2 })
+            },
+            then: {
+                message: '{0} gains {3} amber due to {1} healing {3} damage',
+                messageArgs: context => context.preThenEvent.amount,
+                gameAction: ability.actions.gainAmber(context => ({ amount: context.preThenEvent.amount }))
+            }
+        });
+    }
+}
+
+DoctorDriscoll.id = 'doctor-driscoll';
+
+module.exports = DoctorDriscoll;
+

--- a/test/server/cards/03-WC/DoctorDriscoll.spec.js
+++ b/test/server/cards/03-WC/DoctorDriscoll.spec.js
@@ -1,0 +1,47 @@
+describe('Doctor Driscoll', function() {
+    integration(function() {
+        describe('Doctor Driscoll\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'staralliance',
+                        inPlay: ['doctor-driscoll', 'crash-muldoon']
+                    },
+                    player2: {
+                        inPlay: ['dust-pixie', 'flaxia']
+                    }
+                });
+            });
+
+            it('should gain no amber if a creature without damage is chosen', function() {
+                this.player1.fightWith(this.crashMuldoon, this.dustPixie);
+                this.player1.clickCard(this.doctorDriscoll);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                this.player1.clickCard(this.doctorDriscoll);
+                expect(this.player1.amber).toBe(0);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+
+            it('should gain 1 amber when only 1 damage can be healed', function() {
+                this.player1.fightWith(this.crashMuldoon, this.dustPixie);
+                this.player1.clickCard(this.doctorDriscoll);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                this.player1.clickCard(this.crashMuldoon);
+                expect(this.crashMuldoon.hasToken('damage')).toBe(false);
+                expect(this.player1.amber).toBe(1);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+
+            it('should gain 2 amber when 2 damage is healed', function() {
+                this.player1.fightWith(this.crashMuldoon, this.flaxia);
+                this.player1.clickCard(this.doctorDriscoll);
+                this.player1.clickPrompt('Use this card\'s Action ability');
+                this.player1.clickCard(this.flaxia);
+                expect(this.flaxia.tokens.damage).toBe(1);
+                expect(this.player1.amber).toBe(2);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
Would we want to skip the prompt to select a creature to heal when nothing is damaged?

This is how Guardian Demon behaves, but I wasn't sure how to still allow you to use the action in this case. Similar to how you can use Mindwarper's action when your opponent has no aember or no creatures.