### PR TITLE
Fangtooth Cavern fix

### DIFF
--- a/server/game/cards/03-WC/FangtoothCavern.js
+++ b/server/game/cards/03-WC/FangtoothCavern.js
@@ -10,7 +10,7 @@ class FangtoothCavern extends Card {
             target: {
                 mode: 'mostStat',
                 cardType: 'creature',
-                controller: 'opponent',
+                controller: 'any',
                 numCards: 1,
                 cardStat: card => -card.power,
                 gameAction: ability.actions.destroy()


### PR DESCRIPTION
Fangtooth Cavern reads "At the end of your turn, destroy the least powerful creature.". Controller should be "any". I've not yet tested it, as I have a while must yet see how to setup keyteki :) But I suspect that this simple change is correct.