### PR TITLE
Added additional tests for Fangtooth cavern

### DIFF
--- a/test/server/cards/03-WC/FangtoothCavern.spec.js
+++ b/test/server/cards/03-WC/FangtoothCavern.spec.js
@@ -5,10 +5,10 @@ describe('Fangtooth Cavern', function() {
                 this.setupTest({
                     player1: {
                         house: 'untamed',
-                        inPlay: ['fangtooth-cavern','mighty-tiger', 'dextre']
+                        inPlay: ['fangtooth-cavern','dust-pixie', 'dextre']
                     },
                     player2: {
-                        inPlay: ['dust-imp', 'dust-pixie']
+                        inPlay: ['dust-imp', 'mighty-tiger']
                     }
                 });
             });
@@ -24,7 +24,7 @@ describe('Fangtooth Cavern', function() {
                 this.player2.clickPrompt('dis');
                 this.player2.endTurn();
                 expect(this.dustImp.location).toBe('play area');
-                this.player1.clickPrompt('untamed');
+                this.player1.clickPrompt('logos');
                 this.player1.endTurn();
                 expect(this.player1).toBeAbleToSelect(this.dustImp);
                 expect(this.player1).not.toBeAbleToSelect(this.mightyTiger);


### PR DESCRIPTION
Switched controller of mighty-tiger & dust-pixie, to check if controller of card doesn't matter for Fangtooth cavern effect.
Switched selected house to logos, to check if cavern passive effect is working regardless of chosen house.