### PR TITLE
Docker-Compose Updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:latest
+FROM node:10
 RUN mkdir -p /usr/src/lobby
 WORKDIR /usr/src/lobby
 COPY package.json /usr/src/lobby/
 COPY package-lock.json /usr/src/lobby/
-RUN npm install
+RUN npm install --no-optional
 COPY . /usr/src/lobby
 EXPOSE 4000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - mongo
     command:
       - node
-      - "--inspect=0.0.0.0"
+      - "--inspect=0.0.0.0:9229"
       - "."
   node:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - "server/gamenode"      
   mongo:
     image: mongo
+    ports:
+      - "27017:27017"
     volumes:
       - mongodb:/data/db
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     restart: always
     build:
       context: .
-    image: keyteki:lobby
+    image: keyteki-lobby
     ports:
       - "4000:4000"
       - "9229:9229"
@@ -21,7 +21,7 @@ services:
     build:
       context: .
       dockerfile: ./server/gamenode/Dockerfile
-    image: keyteki:node
+    image: keyteki-node
     ports:
       - "9500:9500"
       - "9339:9339"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   mongo:
     image: mongo
     ports:
-      - "27017:27017"
+      - "27027:27017"
     volumes:
       - mongodb:/data/db
 volumes:

--- a/server/gamenode/Dockerfile
+++ b/server/gamenode/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:latest
+FROM node:10
 RUN mkdir -p /usr/src/node
 WORKDIR /usr/src/node
 COPY package.json /usr/src/node/
 COPY package-lock.json /usr/src/node/
 
-RUN npm install
+RUN npm install --no-optional
 COPY . /usr/src/node
 EXPOSE 9500
 


### PR DESCRIPTION
This PR includes a few updates - I've left the individual commits for each un-squashed in case we didn't want keep some of those changes. There are more details with each commit, but briefly:

- We pin the node major version to 10. This avoids an incompatibility between ZMQ and node@13. We also get to match up versions with production.
- Minor change to tag the lobby and game nodes with different image names (rather than distinguishing with versions). It looks like the images being built are actually identical (just different start-up commands and ports exposed) - if there's interest we could speed up build times considerably by having a single image that gets referenced by both services (i.e. still two containers, but just one image). This might be nice as the images are fairly large, ~1.7 GB, and nobody likes waiting for node modules to install twice :).
- I exposed the mongodb port so folks could connect with their own clients running outside the container to look at the keyteki data.

I didn't want to muddy the waters too much. I'll have a separate PR for mounting source files as volumes so folks can edit source files outside the containers and see their changes without having to rebuild everything.