### PR TITLE
Draft for SBA

### DIFF
--- a/server/game/cards/03-WC/SelfBolsteringAutomata.js
+++ b/server/game/cards/03-WC/SelfBolsteringAutomata.js
@@ -6,7 +6,7 @@ class SelfBolsteringAutomata extends Card {
             condition: context => context.player.creaturesInPlay.length > 1,
             effect: 'heal all damage from {0}, exhaust it and move it to a flank',
             effectArgs: () => this,
-            gameAction: [
+            gameAction: ability.actions.sequential([
                 ability.actions.heal({ fully: true }),
                 ability.actions.exhaust(),
                 ability.actions.moveToFlank(),
@@ -15,8 +15,9 @@ class SelfBolsteringAutomata extends Card {
                     cancel: true,
                     postHandler: context => context.source.moribund = false
                 }))
-            ],
+            ]),
             then: context => ({
+                condition: context => context.preThenEvent.amount >= 1 && context.preThenEvent.card.exhausted,
                 gameAction: ability.actions.addPowerCounter({ target: context.source, amount: 2 })
             })
         });

--- a/test/server/cards/01-Core/Protectrix.spec.js
+++ b/test/server/cards/01-Core/Protectrix.spec.js
@@ -40,6 +40,26 @@ describe('Protectrix', function() {
                 expect(this.commanderRemiel.tokens.damage).toBe(undefined);
                 expect(this.titanMechanic.tokens.damage).toBe(3);
             });
+            it('should NOT make a creature invincible if it DOES NOT heals damage off it.', function() {
+                this.player1.play(this.poke);
+                expect(this.player1).toHavePrompt('Poke');
+                expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
+                expect(this.player1).toBeAbleToSelect(this.protectrix);
+                expect(this.player1).not.toBeAbleToSelect(this.dextre);
+                this.player1.clickCard(this.protectrix);
+                expect(this.protectrix.tokens.damage).toBe(1);
+                this.player1.endTurn();
+                this.player2.clickPrompt('sanctum');
+                this.player2.reap(this.protectrix);
+                expect(this.player2).toHavePrompt('Choose a creature');
+                expect(this.player2).toBeAbleToSelect(this.commanderRemiel);
+                expect(this.player2).toBeAbleToSelect(this.protectrix);
+                this.player2.clickCard(this.commanderRemiel);
+                expect(this.commanderRemiel.tokens.damage).toBe(undefined);
+                this.player2.fightWith(this.commanderRemiel,this.dextre);
+                expect(this.dextre.location).toBe('deck');
+                expect(this.commanderRemiel.location).toBe('discard');
+            });
         });
     });
 });

--- a/test/server/cards/03-WC/SelfBolsteringAutomata.spec.js
+++ b/test/server/cards/03-WC/SelfBolsteringAutomata.spec.js
@@ -16,7 +16,7 @@ describe('Self-Bolstering Automata', function() {
             });
 
             describe('when other creatures are in play', function() {
-                describe('and automata is destroyed', function() {
+                describe('and automata is destroyed fighting', function() {
                     beforeEach(function() {
                         this.player1.fightWith(this.selfBolsteringAutomata, this.troll);
                         this.player1.clickPrompt('right');
@@ -26,6 +26,29 @@ describe('Self-Bolstering Automata', function() {
                         expect(this.selfBolsteringAutomata.tokens.damage).toBe(undefined);
                         expect(this.selfBolsteringAutomata.location).toBe('play area');
                         expect(this.selfBolsteringAutomata.exhausted).toBe(true);
+                        expect(this.player1.player.cardsInPlay[1]).toBe(this.selfBolsteringAutomata);
+                    });
+
+                    it('should NOT gain 2 +1 power counters (as it was exhausted from the fight)', function() {
+                        expect(this.selfBolsteringAutomata.tokens.power).toBe(undefined);
+                    });
+                });
+            });
+
+            describe('when other creatures are in play', function() {
+                describe('and automata is destroyed being attacked', function() {
+                    beforeEach(function() {
+                        this.player1.endTurn();
+                        this.player2.clickPrompt('brobnar');
+                        this.player2.fightWith(this.troll, this.selfBolsteringAutomata);
+                        this.player2.clickPrompt('right');
+                    });
+
+                    it('should fully heal automata, not destroy it, exhaust it and move it to the right flank', function() {
+                        expect(this.selfBolsteringAutomata.tokens.damage).toBe(undefined);
+                        expect(this.selfBolsteringAutomata.location).toBe('play area');
+                        expect(this.selfBolsteringAutomata.exhausted).toBe(true);
+                        expect(this.selfBolsteringAutomata.tokens.power).toBe(2);
                         expect(this.player1.player.cardsInPlay[1]).toBe(this.selfBolsteringAutomata);
                     });
 


### PR DESCRIPTION
Bug that I'm trying to fix:

SBA says that when it's destroyed and it's not the only creature on the battle line, it should be:

- Moved to a flank (which is always doable, since if it's alone it wouldn't trigger at all)
- Healed fully (which is doable if it dies by damage in combat, but not if it dies by removal like deathquark)
- Exhausted (which is doable if it is not already exhausted eg. it died after attacking a creature)

If ALL conditions are met, then the SBA gets the power counters.

Tried to write some tests but can't seem to make them work. They look ok to me so I'm not sure if the bug is in the card or in the test.