### PR TITLE
Fix to Thorium Plasmate

### DIFF
--- a/server/game/GameActions/MoveOnBattlelineAction.js
+++ b/server/game/GameActions/MoveOnBattlelineAction.js
@@ -59,9 +59,10 @@ class MoveOnBattlelineAction extends CardGameAction {
         return super.createEvent('onCardMovedInBattleline', { card: card, context: context }, () => {
             let player = card.controller;
             let cardIndex = player.cardsInPlay.indexOf(card);
+            let cardInsertionIndex = this.moveIndex > cardIndex ? this.moveIndex - 1 : this.moveIndex;
 
             player.cardsInPlay.splice(cardIndex, 1);
-            player.cardsInPlay.splice(this.moveIndex, 0, card);
+            player.cardsInPlay.splice(cardInsertionIndex, 0, card);
         });
     }
 }

--- a/test/server/cards/03-WC/ThoriumPlasmate.spec.js
+++ b/test/server/cards/03-WC/ThoriumPlasmate.spec.js
@@ -77,6 +77,35 @@ describe('Throium Plasmate', function() {
                 });
             });
         });
+
+        describe('when moving a card to the right of where it started', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'logos',
+                        amber: 1,
+                        hand: ['thorium-plasmate'],
+                        inPlay: ['narp', 'brain-eater']
+                    },
+                    player2: {
+                        amber: 3,
+                        inPlay: ['little-niff', 'alaka', 'shorty', 'krump']
+                    }
+                });
+            });
+
+            it('should be able to correctly move cards in the battleline', function() {
+                this.player1.play(this.thoriumPlasmate);
+                this.player1.clickCard(this.alaka);
+                expect(this.player1).toHavePrompt('Select a card to move this card next to');
+                this.player1.clickCard(this.shorty);
+                expect(this.player1).toHavePrompt('Which side to you want to move this card to?');
+                this.player1.clickPrompt('Right');
+                expect(this.player2.player.creaturesInPlay.length).toBe(3);
+                expect(this.player2.player.cardsInPlay[0]).toBe(this.littleNiff);
+                expect(this.player2.player.cardsInPlay[1]).toBe(this.shorty);
+                expect(this.player2.player.cardsInPlay[2]).toBe(this.krump);
+            });
+        });
     });
 });
-

--- a/test/server/cards/03-WC/Weasand.spec.js
+++ b/test/server/cards/03-WC/Weasand.spec.js
@@ -99,7 +99,7 @@ describe('Weasand', function() {
                 expect(this.player2).toHavePrompt('Select a card to move this card next to');
                 this.player2.clickCard(this.weasand);
                 expect(this.player2).toHavePrompt('Which side to you want to move this card to?');
-                this.player2.clickPrompt('Left');
+                this.player2.clickPrompt('Right');
                 expect(this.dodger.tokens.damage).toBe(2);
                 expect(this.dodger.location).toBe('play area');
                 expect(this.weasand.location).toBe('discard');


### PR DESCRIPTION
MoveOnBattlelineAction was determining a new index for moved cards based on a battleline with the card being moved still in it.

The "move" happens by first splicing out the card to be moved then splicing it back it. This means we should calculate our "slice back in" index assuming the moved card is not in the battleline.

Fixes #939