### PR TITLE
Mimicry omega fix

### DIFF
--- a/server/game/cards/01-Core/Mimicry.js
+++ b/server/game/cards/01-Core/Mimicry.js
@@ -26,6 +26,10 @@ class Mimicry extends Card {
                             card.abilities.reactions.find(ability => ability.properties.name === 'Play').properties
                         ));
                     }
+
+                    if(card.hasKeyword('omega')) {
+                        this.game.cardsPlayed.push(card);
+                    }
                 }
 
                 return {


### PR DESCRIPTION
fixes #1071 - mimicry used on omega now properly ends turn