### PR TITLE
fixing master the theory

### DIFF
--- a/server/game/CardSelectors/ExactlyXCardSelector.js
+++ b/server/game/CardSelectors/ExactlyXCardSelector.js
@@ -25,7 +25,7 @@ class ExactlyXCardSelector extends BaseCardSelector {
     }
 
     hasEnoughSelected(selectedCards, context) {
-        return selectedCards.length === this.getNumCards(context);
+        return selectedCards.length === this.getNumCards(context) || this.optional;
     }
 
     hasReachedLimit(selectedCards, context) {

--- a/server/game/cards/02-AoA/MasterTheTheory.js
+++ b/server/game/cards/02-AoA/MasterTheTheory.js
@@ -6,16 +6,16 @@ class MasterTheTheory extends Card {
             condition:  () => this.controller.creaturesInPlay.length === 0,
             effect: ' to archive a card for each creature {1} has in play ({2}).',
             effectArgs: context => [context.player.opponent, context.player.opponent.creaturesInPlay.length],
-            gameAction: ability.actions.sequentialForEach(context => ({
-                num: context.player.opponent.creaturesInPlay.length,
-                action: ability.actions.archive({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a card to archive',
-                        location: 'hand',
-                        controller: 'self'
-                    }
-                })
-            }))
+            targets: {
+                cards: {
+                    mode: 'exactly',
+                    numCards: context => (context.player.opponent.creaturesInPlay.length),
+                    controller: 'self',
+                    location: 'hand',
+                    gameAction: ability.actions.archive(),
+                    optional: true
+                }
+            }
         });
     }
 }

--- a/test/server/cards/02-AoA/MasterTheTheory.spec.js
+++ b/test/server/cards/02-AoA/MasterTheTheory.spec.js
@@ -1,0 +1,50 @@
+describe('Master The Theory', function() {
+    integration(function() {
+        describe('Master The Theory\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'logos',
+                        hand: ['master-the-theory', 'combat-pheromones', 'soft-landing', 'dextre'],
+                        inPlay: []
+                    },
+                    player2: {
+                        inPlay: ['mindwarper','zorg']
+                    }
+                });
+            });
+
+            it('should prompt the player to select cards', function() {
+                this.player1.play(this.masterTheTheory);
+                expect(this.player1).toHavePrompt('Choose 2 cards');
+                expect(this.player1).toBeAbleToSelect(this.combatPheromones);
+                expect(this.player1).toBeAbleToSelect(this.softLanding);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+            });
+
+            it('should allow the player to select 0 cards', function() {
+                this.player1.play(this.masterTheTheory);
+                expect(this.player1.currentButtons).toContain('Done');
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should archive the 2 of their cards', function() {
+                this.player1.play(this.masterTheTheory);
+                this.player1.clickCard(this.dextre);
+                this.player1.clickCard(this.combatPheromones);
+                this.player1.clickPrompt('Done');
+                expect(this.dextre.location).toBe('archives');
+                expect(this.combatPheromones.location).toBe('archives');
+                expect(this.player1.hand.length).toBe(1);
+            });
+
+            it('should archive the 1 of their cards', function() {
+                this.player1.play(this.masterTheTheory);
+                this.player1.clickCard(this.combatPheromones);
+                this.player1.clickPrompt('Done');
+                expect(this.combatPheromones.location).toBe('archives');
+                expect(this.player1.hand.length).toBe(2);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This is a fix for the issue:
https://github.com/keyteki/keyteki/issues/375 

To make this fix, I had to update the ExactXSelector to support an optional number of cards.  This was needed because the UpToSelector does not support a function for numCards. This seemed approach seemed safer, because otherwise all of the cards that use upTo would need to be updated.

I tested this change by:
1) Creating a test game where I confirmed the new behavior for Master The Theory Works
2) I tested Twin Bolt Emission (since it uses 'exact' ) I confirmed it is not broken, and still requires 2 targets, but does fail  if there is only 1.
3) I added a test class for Master The Theory.

(Note I posted this twice, because the first time I accidentally included my other changes into this fix.)