### PR TITLE
Fix chant of hubris allowing the same card as second target

### DIFF
--- a/server/game/cards/03-WC/ChantOfHubris.js
+++ b/server/game/cards/03-WC/ChantOfHubris.js
@@ -16,7 +16,7 @@ class ChantOfHubris extends Card {
                         messageArgs: card => [preContext.player, preContext.source, card],
                         cardType: 'creature',
                         activePromptTitle: 'Choose another creature',
-                        cardCondition: card => card !== preContext.event.card
+                        cardCondition: card => card !== preContext.target
                     }
                 })
             })

--- a/test/server/cards/03-WC/ChantOfHubris.spec.js
+++ b/test/server/cards/03-WC/ChantOfHubris.spec.js
@@ -66,6 +66,7 @@ describe('Chant of Hubris', function() {
 
                 expect(this.player1).toHavePrompt('Choose another creature');
 
+                expect(this.player1).not.toBeAbleToSelect(this.archimedes);
                 expect(this.player1).toBeAbleToSelect(this.dextre);
                 expect(this.player1).toBeAbleToSelect(this.gub);
                 expect(this.player1).toBeAbleToSelect(this.shooler);
@@ -88,6 +89,7 @@ describe('Chant of Hubris', function() {
 
                 expect(this.player1).toHavePrompt('Choose another creature');
 
+                expect(this.player1).not.toBeAbleToSelect(this.archimedes);
                 expect(this.player1).toBeAbleToSelect(this.dextre);
                 expect(this.player1).toBeAbleToSelect(this.gub);
                 expect(this.player1).toBeAbleToSelect(this.shooler);
@@ -110,6 +112,7 @@ describe('Chant of Hubris', function() {
 
                 expect(this.player1).toHavePrompt('Choose another creature');
 
+                expect(this.player1).not.toBeAbleToSelect(this.shooler);
                 expect(this.player1).toBeAbleToSelect(this.dextre);
                 expect(this.player1).toBeAbleToSelect(this.gub);
                 expect(this.player1).toBeAbleToSelect(this.archimedes);
@@ -132,6 +135,7 @@ describe('Chant of Hubris', function() {
 
                 expect(this.player1).toHavePrompt('Choose another creature');
 
+                expect(this.player1).not.toBeAbleToSelect(this.shooler);
                 expect(this.player1).toBeAbleToSelect(this.dextre);
                 expect(this.player1).toBeAbleToSelect(this.gub);
                 expect(this.player1).toBeAbleToSelect(this.archimedes);


### PR DESCRIPTION
Card text says "Play: Move 1 A from a creature to another creature.",