### PR TITLE
MM: Star Alliance - Matter Maker

### DIFF
--- a/server/game/cards/04-MM/MatterMaker.js
+++ b/server/game/cards/04-MM/MatterMaker.js
@@ -4,10 +4,7 @@ class MatterMaker extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
             targetController: 'current',
-            effect: ability.effects.canPlayNonHouse(({
-                house: '*',
-                condition: card => card.type === 'upgrade'
-            }))
+            effect: ability.effects.canPlay( card => card.type === 'upgrade' )
         });
     }
 }

--- a/server/game/cards/04-MM/MatterMaker.js
+++ b/server/game/cards/04-MM/MatterMaker.js
@@ -4,7 +4,7 @@ class MatterMaker extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
             targetController: 'current',
-            effect: ability.effects.canPlay( card => card.type === 'upgrade' )
+            effect: ability.effects.canPlay(card => card.type === 'upgrade')
         });
     }
 }

--- a/server/game/cards/04-MM/MatterMaker.js
+++ b/server/game/cards/04-MM/MatterMaker.js
@@ -1,0 +1,17 @@
+const Card = require('../../Card.js');
+
+class MatterMaker extends Card {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'current',
+            effect: ability.effects.canPlayNonHouse(({
+                house: '*',
+                condition: card => card.type === 'upgrade'
+            }))
+        });
+    }
+}
+
+MatterMaker.id = 'matter-maker';
+
+module.exports = MatterMaker;

--- a/test/server/cards/04-MM/MatterMaker.spec.js
+++ b/test/server/cards/04-MM/MatterMaker.spec.js
@@ -1,0 +1,41 @@
+describe('matter-maker', function() {
+    integration(function() {
+        describe('Matter Makers\'s ability', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'staralliance',
+                        inPlay: ['troll'],
+                        hand: ['camouflage','matter-maker','stunner']
+                    },
+                    player2: {
+                        amber: 1,
+                        inPlay: ['umbra']
+                    }
+                });
+            });
+
+            it('should enable playing matter maker should enable the play of camouflage and stunner', function() {
+                this.player1.play(this.matterMaker);
+                this.player1.playUpgrade(this.camouflage, this.troll);
+                this.player1.playUpgrade(this.stunner, this.troll);
+                expect(this.troll.upgrades).toContain(this.camouflage);
+                expect(this.troll.upgrades).toContain(this.stunner);
+            });
+
+            it('show allow playing staralliance upgrades on non-starliance turns', function() {
+                this.player1.play(this.matterMaker);
+                this.player1.endTurn();
+
+                this.player2.clickPrompt('shadows');
+                this.player2.endTurn();
+
+                this.player1.clickPrompt('untamed');
+                this.player1.playUpgrade(this.camouflage, this.troll);
+                this.player1.playUpgrade(this.stunner, this.troll);
+                expect(this.troll.upgrades).toContain(this.camouflage);
+                expect(this.troll.upgrades).toContain(this.stunner);
+            });
+        });
+    });
+});

--- a/test/server/cards/04-MM/MatterMaker.spec.js
+++ b/test/server/cards/04-MM/MatterMaker.spec.js
@@ -6,7 +6,7 @@ describe('matter-maker', function() {
                     player1: {
                         house: 'staralliance',
                         inPlay: ['troll'],
-                        hand: ['camouflage','matter-maker','stunner']
+                        hand: ['camouflage','matter-maker','stunner','alaka','ballcano']
                     },
                     player2: {
                         amber: 1,
@@ -23,7 +23,7 @@ describe('matter-maker', function() {
                 expect(this.troll.upgrades).toContain(this.stunner);
             });
 
-            it('show allow playing staralliance upgrades on non-starliance turns', function() {
+            it('should allow playing staralliance upgrades on non-starliance turns', function() {
                 this.player1.play(this.matterMaker);
                 this.player1.endTurn();
 
@@ -35,6 +35,12 @@ describe('matter-maker', function() {
                 this.player1.playUpgrade(this.stunner, this.troll);
                 expect(this.troll.upgrades).toContain(this.camouflage);
                 expect(this.troll.upgrades).toContain(this.stunner);
+            });
+
+            it('should only allow upgrades to be played out of house', function() {
+                this.player1.play(this.matterMaker);
+                expect(this.player1).not.toBeAbleToPlay(this.alaka);
+                expect(this.player1).not.toBeAbleToPlay(this.ballcano);
             });
         });
     });


### PR DESCRIPTION
Added Matter Maker card per issue:
https://github.com/keyteki/keyteki/issues/1172

Validation done:
* New test case passes
* Lint passes

Note: I could not find documentation that "*" would work for 'house:', but it does. 

I also tried:
* leaving it out
* the value ''
* providing a function doing something like done in Val Jerico - like: `(card, context) => context.player.activeHouse`. But it seems that "house" does not accept a function. 

However, using "*" does pass the test for both Star Alliance and Non-Star Alliance turns.
