### PR TITLE
Fixes UnitedAction not considering upgrades

### DIFF
--- a/server/game/cards/03-WC/UnitedAction.js
+++ b/server/game/cards/03-WC/UnitedAction.js
@@ -5,7 +5,7 @@ class UnitedAction extends Card {
         this.play({
             effect: 'allow them to play from any house ​for which they have a card in play',
             gameAction: ability.actions.forRemainderOfTurn(context => {
-                let housesInPlay = context.game.getHousesInPlay(context.game.cardsInPlay, true, context.player);
+                let housesInPlay = context.game.getHousesInPlay(context.game.cardsInPlay, true, card => card.owner === context.player);
                 return {
                     effect: [
                         ability.effects.canPlay(card => housesInPlay.some(house => card.hasHouse(house))),

--- a/server/game/cards/03-WC/UnitedAction.js
+++ b/server/game/cards/03-WC/UnitedAction.js
@@ -4,12 +4,15 @@ class UnitedAction extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow them to play from any house ​for which they have a card in play',
-            gameAction: ability.actions.forRemainderOfTurn(context => ({
-                effect: [
-                    ability.effects.canPlay(card => context.game.getHousesInPlay(context.player.cardsInPlay).some(house => card.getHouses().includes(house))),
-                    ability.effects.playerCannot('use')
-                ]
-            }))
+            gameAction: ability.actions.forRemainderOfTurn(context => {
+                let housesInPlay = context.game.getHousesInPlay(context.game.cardsInPlay, true, context.player);
+                return {
+                    effect: [
+                        ability.effects.canPlay(card => housesInPlay.some(house => card.hasHouse(house))),
+                        ability.effects.playerCannot('use')
+                    ]
+                };
+            })
         });
     }
 }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1017,9 +1017,9 @@ class Game extends EventEmitter {
      * @param {Array} cards - which cards to consider. Default are all cards.
      * @param {boolean} upgrade - if upgrades should be counted. Default is false.
      */
-    getHousesInPlay(cards = this.cardsInPlay, upgrade = false) {
-        return Constants.Houses.filter(house => cards.some(card => card.hasHouse(house)
-            || (upgrade && card.upgrades && card.upgrades.some(upgrade => upgrade.hasHouse(house)))));
+    getHousesInPlay(cards = this.cardsInPlay, upgrade = false, player = null) {
+        return Constants.Houses.filter(house => cards.some(card => ((!player || card.owner === player) && card.hasHouse(house))
+            || (upgrade && card.upgrades && card.upgrades.some(upgrade => (!player || upgrade.owner === player) && upgrade.hasHouse(house)))));
     }
 
     firstThingThisTurn() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1016,10 +1016,11 @@ class Game extends EventEmitter {
      *
      * @param {Array} cards - which cards to consider. Default are all cards.
      * @param {boolean} upgrade - if upgrades should be counted. Default is false.
+     * @param {filter} filter - an extra filter to apply to the card.
      */
-    getHousesInPlay(cards = this.cardsInPlay, upgrade = false, player = null) {
-        return Constants.Houses.filter(house => cards.some(card => ((!player || card.owner === player) && card.hasHouse(house))
-            || (upgrade && card.upgrades && card.upgrades.some(upgrade => (!player || upgrade.owner === player) && upgrade.hasHouse(house)))));
+    getHousesInPlay(cards = this.cardsInPlay, upgrade = false, filter = null) {
+        return Constants.Houses.filter(house => cards.some(card => ((!filter || filter(card)) && card.hasHouse(house))
+            || (upgrade && card.upgrades && card.upgrades.some(upgrade => (!filter || filter(upgrade)) && upgrade.hasHouse(house)))));
     }
 
     firstThingThisTurn() {

--- a/test/server/cards/03-WC/UnitedAction.spec.js
+++ b/test/server/cards/03-WC/UnitedAction.spec.js
@@ -6,10 +6,10 @@ describe('United Action', function() {
                     player1: {
                         house: 'staralliance',
                         inPlay: ['lieutenant-khrkhar', 'safe-place'],
-                        hand: ['united-action', 'phase-shift', 'shadow-self', 'armsmaster-molina']
+                        hand: ['united-action', 'phase-shift', 'shadow-self', 'armsmaster-molina', 'rocket-boots']
                     },
                     player2: {
-                        inPlay: ['urchin','crash-muldoon'],
+                        inPlay: ['urchin', 'crash-muldoon'],
                         amber: 3
                     }
                 });
@@ -24,38 +24,84 @@ describe('United Action', function() {
             });
 
             it('should not allow cards to use used', function() {
-                this.player1.clickCard(this.lieutenantKhrkhar);
-
-                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+                expect(this.player1).not.toBeAbleToSelect(this.lieutenantKhrkhar);
             });
 
-            describe('and a in-house card is played', function() {
-                beforeEach(function() {
-                    this.player1.clickCard(this.armsmasterMolina);
-                });
+            it('should allow an in-house card to be played', function() {
+                this.player1.play(this.armsmasterMolina);
+            });
 
-                it('should allow the card to be played', function() {
-                    expect(this.player1).toHavePrompt('Play Armsmaster Molina:');
+            it('should allow an out of house card to be played', function() {
+                this.player1.play(this.shadowSelf);
+            });
+
+            it('should not allow an out of house card that is not represented in play to be played', function() {
+                expect(this.player1).not.toBeAbleToSelect(this.phaseShift);
+            });
+        });
+
+        describe('when played', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'logos',
+                        inPlay: ['lieutenant-khrkhar', 'safe-place'],
+                        hand: ['united-action', 'phase-shift', 'shadow-self', 'armsmaster-molina', 'rocket-boots']
+                    },
+                    player2: {
+                        inPlay: ['urchin', 'crash-muldoon'],
+                        amber: 3
+                    }
                 });
             });
 
-            describe('and a out of house card is played', function() {
+            describe('and an upgrade is attached to a friendly creature', function() {
                 beforeEach(function() {
-                    this.player1.clickCard(this.shadowSelf);
+                    this.player1.playUpgrade(this.rocketBoots, this.lieutenantKhrkhar);
+                    this.player1.endTurn();
+
+                    this.player2.clickPrompt('shadows');
+                    this.player2.endTurn();
+
+                    this.player1.clickPrompt('staralliance');
+                    this.player1.play(this.unitedAction);
                 });
 
-                it('should allow the card to be played', function() {
-                    expect(this.player1).toHavePrompt('Play Shadow Self:');
+                it('should allow an out of house card represented by the upgrade to be played', function() {
+                    this.player1.play(this.phaseShift);
+                });
+            });
+        });
+
+        describe('when played', function() {
+            beforeEach(function() {
+                this.setupTest({
+                    player1: {
+                        house: 'logos',
+                        inPlay: ['lieutenant-khrkhar', 'safe-place'],
+                        hand: ['united-action', 'phase-shift', 'shadow-self', 'armsmaster-molina', 'rocket-boots']
+                    },
+                    player2: {
+                        inPlay: ['urchin', 'crash-muldoon'],
+                        amber: 3
+                    }
                 });
             });
 
-            describe('and an out of house card is played that is not represented in play', function() {
+            describe('and an upgrade is attached to an enemy creature', function() {
                 beforeEach(function() {
-                    this.player1.clickCard(this.phaseShift);
+                    this.player1.playUpgrade(this.rocketBoots, this.urchin);
+                    this.player1.endTurn();
+
+                    this.player2.clickPrompt('shadows');
+                    this.player2.endTurn();
+
+                    this.player1.clickPrompt('staralliance');
+                    this.player1.play(this.unitedAction);
                 });
 
-                it('should allow the card to be played', function() {
-                    expect(this.player1).not.toHavePrompt('Play this action');
+                it('should allow an out of house card represented by the upgrade to be played', function() {
+                    this.player1.play(this.phaseShift);
                 });
             });
         });


### PR DESCRIPTION
Fixes #1150
This was a bit trickier as upgrades are only counted on cardsInPlay, so I cannot pass player.cardsInPlay to getHousesInPlay. I added a new player filter to the game's getHousesInPlay function