### PR TITLE
fix for 'amber.' relabel

### DIFF
--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -51,6 +51,9 @@ class Messages extends React.Component {
                     case 'amber':
                         token = 'Æmber';
                         break;
+                    case 'amber.':
+                        token = 'Æmber.';
+                        break;
                     case 'forgedkeyblue':
                         token = 'blue key';
                         break;


### PR DESCRIPTION
Allows "amber." to relabel to 'Æmber.'
Fixes #1056 
