### PR TITLE
Fix Chant of Hubris not allowing to pick a creature without amber

### DIFF
--- a/server/game/GameActions/RemoveTokenAction.js
+++ b/server/game/GameActions/RemoveTokenAction.js
@@ -27,6 +27,10 @@ class RemoveTokenAction extends CardGameAction {
         return this.all ? card.tokens[this.type] || 0 : this.amount;
     }
 
+    checkEventCondition(event) {
+        return !!event.card.tokens[event.type] && super.checkEventCondition(event);
+    }
+
     canAffect(card, context) {
         return this.getAmount(card) > 0 && card.location === 'play area' && super.canAffect(card, context);
     }

--- a/server/game/cards/03-WC/ChantOfHubris.js
+++ b/server/game/cards/03-WC/ChantOfHubris.js
@@ -3,10 +3,9 @@ const Card = require('../../Card.js');
 class ChantOfHubris extends Card {
     setupCardAbilities(ability) {
         this.play({
-            condition: context => context.game.creaturesInPlay.length > 1 && context.game.creaturesInPlay.some(card => card.hasToken('amber')),
+            condition: context => context.game.creaturesInPlay.length > 1,
             target: {
                 cardType: 'creature',
-                cardCondition: card => card.hasToken('amber'),
                 gameAction: ability.actions.removeAmber()
             },
             then: preContext => ({

--- a/server/game/cards/03-WC/Mug.js
+++ b/server/game/cards/03-WC/Mug.js
@@ -6,10 +6,10 @@ class Mug extends Card {
             target: {
                 activePromptTitle: 'Choose a captured amber to move to your pool.',
                 cardType: 'creature',
-                gameAction: [
+                gameAction: ability.actions.sequential([
                     ability.actions.returnAmber(context => ({ amount: 1, recipient: context.player })),
                     ability.actions.dealDamage({ amount: 2 })
-                ]
+                ])
             },
             effect: 'move 1 amber from {0} to their pool and deal 2 damage to it'
         });

--- a/test/server/cards/03-WC/ChantOfHubris.spec.js
+++ b/test/server/cards/03-WC/ChantOfHubris.spec.js
@@ -16,20 +16,10 @@ describe('Chant of Hubris', function() {
                 });
             });
 
-            it('should not prompt for any creature, since creatures have no ambers on them.', function() {
-                this.player1.play(this.chantOfHubris);
-
-                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
-                expect(this.player1.amber).toBe(2);
-            });
-
             it('should not prompt for any creature, since no other creature to place amber', function() {
                 this.archimedes.tokens.amber = 9;
-
                 this.player1.play(this.chantOfHubris);
-
                 expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
-                expect(this.player1.amber).toBe(2);
             });
         });
     });
@@ -60,7 +50,9 @@ describe('Chant of Hubris', function() {
 
                 expect(this.player1).toHavePrompt('Choose a creature');
                 expect(this.player1).toBeAbleToSelect(this.archimedes);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
                 expect(this.player1).toBeAbleToSelect(this.shooler);
+                expect(this.player1).toBeAbleToSelect(this.gub);
 
                 this.player1.clickCard(this.archimedes);
 
@@ -144,6 +136,23 @@ describe('Chant of Hubris', function() {
 
                 expect(this.gub.tokens.amber).toBe(1);
                 expect(this.shooler.hasToken('amber')).toBe(false);
+            });
+
+            it('should allow picking a creature without amber', function() {
+                this.player1.play(this.chantOfHubris);
+                expect(this.player1.amber).toBe(2);
+
+                expect(this.player1).toHavePrompt('Choose a creature');
+                expect(this.player1).toBeAbleToSelect(this.archimedes);
+                expect(this.player1).toBeAbleToSelect(this.dextre);
+                expect(this.player1).toBeAbleToSelect(this.shooler);
+                expect(this.player1).toBeAbleToSelect(this.gub);
+
+                this.player1.clickCard(this.dextre);
+
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+
+                expect(this.dextre.tokens.amber).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
According to https://archonarcana.com/Mug , Mug allows picking creatures without amber

![image](https://user-images.githubusercontent.com/2104075/80171841-d1026980-85c1-11ea-89db-52c31db3978f.png)

![image](https://user-images.githubusercontent.com/2104075/80171872-e24b7600-85c1-11ea-938f-15568e1803ce.png)

I believe Chant of Hubris should follow the same guide as the text is the same.

![image](https://user-images.githubusercontent.com/2104075/80219936-86acd700-8619-11ea-9f6f-5d4a10352d8c.png)
