### PR TITLE
Redis retuns array directly, not an object

### DIFF
--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -387,7 +387,7 @@ class GameServer {
     }
 
     onCardData(cardData) {
-        this.cardData = cardData.cardData;
+        this.cardData = cardData;
     }
 
     onConnection(ioSocket) {


### PR DESCRIPTION
Redis switch broke the onCardData hook.

Previous call returned a object with a cardData attribute,
new version now directly returns the card array.