### PR TITLE
Minor fixes to mass mutation cards

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -506,5 +506,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Reserva de quem",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/th.json
+++ b/public/locales/th.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/zhhans.json
+++ b/public/locales/zhhans.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/public/locales/zhhant.json
+++ b/public/locales/zhhant.json
@@ -517,5 +517,5 @@
     "Discard a card from your archives or archive a card": "Discard a card from your archives or archive a card",
     "Which player's pool": "Which player's pool",
     "Stun an enemy creature": "Stun an enemy creature",
-    "Stun each enemy mutant creature": "Stun each enemy mutant creature"
+    "Stun all enemy mutants": "Stun all enemy mutants"
 }

--- a/server/game/cards/01-Core/GrimReminder.js
+++ b/server/game/cards/01-Core/GrimReminder.js
@@ -9,7 +9,9 @@ class GrimReminder extends Card {
             effect: 'archive all {1} creatures from their discard pile',
             effectArgs: (context) => [context.house],
             gameAction: ability.actions.archive((context) => ({
-                target: context.player.discard.filter((card) => card.hasHouse(context.house))
+                target: context.player.discard.filter(
+                    (card) => card.type === 'creature' && card.hasHouse(context.house)
+                )
             }))
         });
     }

--- a/server/game/cards/04-MM/BurningGlare.js
+++ b/server/game/cards/04-MM/BurningGlare.js
@@ -13,7 +13,7 @@ class BurningGlare extends Card {
                             controller: 'opponent'
                         }
                     }),
-                    'Stun each enemy mutant creature': ability.actions.stun((context) => ({
+                    'Stun all enemy mutants': ability.actions.stun((context) => ({
                         target: context.game.creaturesInPlay.filter(
                             (card) => card.hasTrait('mutant') && card.controller !== context.player
                         )

--- a/server/game/cards/04-MM/EtansJar.js
+++ b/server/game/cards/04-MM/EtansJar.js
@@ -6,6 +6,8 @@ class EtansJar extends Card {
             target: {
                 mode: 'card-name'
             },
+            effect: 'prevent cards named {1} from being played',
+            effectArgs: (context) => [context.cardName],
             gameAction: ability.actions.lastingEffect((context) => ({
                 until: {
                     onCardMoved: (event) =>

--- a/test/server/cards/04-MM/BurningGlare.spec.js
+++ b/test/server/cards/04-MM/BurningGlare.spec.js
@@ -19,7 +19,7 @@ describe('Burning Glare', function () {
             this.player1.play(this.burningGlare);
             expect(this.player1).toHavePrompt('Select one');
             expect(this.player1).toHavePromptButton('Stun an enemy creature');
-            expect(this.player1).toHavePromptButton('Stun each enemy mutant creature');
+            expect(this.player1).toHavePromptButton('Stun all enemy mutants');
             this.player1.clickPrompt('Stun an enemy creature');
             expect(this.player1).toBeAbleToSelect(this.keyfrog);
             expect(this.player1).toBeAbleToSelect(this.dextre);
@@ -36,7 +36,7 @@ describe('Burning Glare', function () {
 
         it('should allow stunning all enemy mutant creatures', function () {
             this.player1.play(this.burningGlare);
-            this.player1.clickPrompt('Stun each enemy mutant creature');
+            this.player1.clickPrompt('Stun all enemy mutants');
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
             expect(this.keyfrog.stunned).toBe(false);
             expect(this.dextre.stunned).toBe(false);


### PR DESCRIPTION
A few small fixes:

- Burning glare text did not fit on a button (Not sure about with the new UI anyway, though)
- Etan's jar didn't tell the opponent what card they were banned from playing
- Grim reminder archived actions etc. as well as creatures.
 