### PR TITLE
Using card.uuid as prompt identifier, instead of aggregating quantities.

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "Create",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "How much amber do you want to use from {{card}}?",
     "Do you wish to repeat this effect?": "Do you wish to repeat this effect?",
     "Do you wish to forge a key?": "Do you wish to forge a key?",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -374,7 +374,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "Create",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "How much amber do you want to use from {{card}}?",
     "Do you wish to repeat this effect?": "Do you wish to repeat this effect?",
     "Do you wish to forge a key?": "Do you wish to forge a key?",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Tus mensajes en la página de inicio se almacenan para que podamos mostrárselos a otros usuarios del sitio y para detectar patrones de conducta abusiva.  Tus mensajes también pueden ser moderados para eliminar contenido ofensivo, o borrados a nuestra discreción.",
     "Create": "Crear",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "¿Cuánto ámbar quieres usar de {{card}}?",
     "Do you wish to repeat this effect?": "¿Quieres repetir este efecto?",
     "Do you wish to forge a key?": "¿Quieres forjar una llave?",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Vos messages du chat room sont stockés afin que nous puissions les afficher à d'autres utilisateurs du site et détecter les modèles de comportement abusif.  Vos messages peuvent également être modérés pour supprimer du contenu offensant, ou supprimés complètement à notre discrétion.",
     "Create": "Créer",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "Combien d’aombres voulez-vous utiliser de {{card}} ?",
     "Do you wish to repeat this effect?": "Souhaitez-vous répéter cet effet ?",
     "Do you wish to forge a key?": "Souhaitez-vous forger une clé ?",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "Create",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "How much amber do you want to use from {{card}}?",
     "Do you wish to repeat this effect?": "Do you wish to repeat this effect?",
     "Do you wish to forge a key?": "Do you wish to forge a key?",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "생성",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "{{card}}에서 몇 개의 엠버를 사용하겠습니까?",
     "Do you wish to repeat this effect?": "이 효과를 반복하겠습니까?",
     "Do you wish to forge a key?": "키를 제작하겠습니까?",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Twoje wiadomości z głownej poczekalni są zbierane byśmy mogli je zaprezentować innym użytkownikom i wykrywać wzorce niepożądanych zachowań. Twoje wiadomości mogą być też modyfikowane, by usunąć obraźliwą zawartość albo nawet usunięte, zależnie od naszej decyzji.",
     "Create": "Stwórz",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "Jak wiele amber z karty {{card}} chcesz wykorzystać?",
     "Do you wish to repeat this effect?": "Czy chcesz powtórzyć ten efekt?",
     "Do you wish to forge a key?": "Czy chcesz wykuć klucz?",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Suas mensagens do lobby são armazenadas para que possamos mostrar para outros usuários do site e detectar padrões de comportamento abusivo.  Suas mensagens podem ser moderadas para remoção de conteúdo abusivo, ou removidas completamente a nosso critério.",
     "Create": "Criar",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "Quanto amber você deseja usar de {{card}}?",
     "Do you wish to repeat this effect?": "Você deseja repetir esse efeito?",
     "Do you wish to forge a key?": "Você deseja forjar uma chave?",

--- a/public/locales/th.json
+++ b/public/locales/th.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "Create",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "How much amber do you want to use from {{card}}?",
     "Do you wish to repeat this effect?": "Do you wish to repeat this effect?",
     "Do you wish to forge a key?": "Do you wish to forge a key?",

--- a/public/locales/zhhans.json
+++ b/public/locales/zhhans.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "Your lobby messages are stored so that we can display them to other users of the site and to detect patterns of abusive behaviour.  Your messages may also be moderated to remove offensive content, or deleted altogether at our discretion.",
     "Create": "Create",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "How much amber do you want to use from {{card}}?",
     "Do you wish to repeat this effect?": "Do you wish to repeat this effect?",
     "Do you wish to forge a key?": "Do you wish to forge a key?",

--- a/public/locales/zhhant.json
+++ b/public/locales/zhhant.json
@@ -381,7 +381,6 @@
     "privacy.lobby": "紀錄大廳訊息的目的是為了讓訊息可以展示給其他玩家, 並避免濫用行為. 我們也可能視情況對你的訊息進行審核或刪除令人反感的內容.",
     "Create": "創建",
     "{{card}}": "{{card}}",
-    "{{card}} ({{quantity}})": "{{card}} ({{quantity}})",
     "How much amber do you want to use from {{card}}?": "你想從 {{card}} 使用多少琥魄?",
     "Do you wish to repeat this effect?": "你想要重複這個效果嗎?",
     "Do you wish to forge a key?": "你想要鍛造鑰匙嗎?",

--- a/server/game/gamesteps/handlermenuprompt.js
+++ b/server/game/gamesteps/handlermenuprompt.js
@@ -45,10 +45,6 @@ class HandlerMenuPrompt extends UiPrompt {
             new AbilityContext({ game: game, player: player, source: this.source });
     }
 
-    getButtonArg(card) {
-        return card.id + '_' + card.printedHouse;
-    }
-
     activeCondition(player) {
         return player === this.player;
     }
@@ -56,30 +52,12 @@ class HandlerMenuPrompt extends UiPrompt {
     activePrompt() {
         let buttons = [];
         if (this.properties.cards) {
-            let cardQuantities = {};
-            _.each(this.properties.cards, (card) => {
-                let arg = this.getButtonArg(card);
-                if (cardQuantities[arg]) {
-                    cardQuantities[arg] += 1;
-                } else {
-                    cardQuantities[arg] = 1;
-                }
-            });
-
-            let cards = _.uniq(this.properties.cards, (card) => this.getButtonArg(card));
-            buttons = _.map(cards, (card) => {
+            buttons = _.map(this.properties.cards, (card) => {
                 let text = '{{card}}';
                 let values = {
                     card: card.name
                 };
-
-                let arg = this.getButtonArg(card);
-                if (cardQuantities[arg] > 1) {
-                    values.quantity = cardQuantities[arg].toString();
-                    text = text + ' ({{quantity}})';
-                }
-
-                return { text: text, arg: arg, card: card, values: values };
+                return { text: text, arg: card.uuid, card: card, values: values };
             });
         }
 
@@ -136,7 +114,7 @@ class HandlerMenuPrompt extends UiPrompt {
 
     menuCommand(player, arg) {
         if (_.isString(arg)) {
-            let card = _.find(this.properties.cards, (card) => this.getButtonArg(card) === arg);
+            let card = _.find(this.properties.cards, (card) => card.uuid === arg);
             if (card && this.properties.cardHandler) {
                 this.properties.cardHandler(card);
                 this.complete();


### PR DESCRIPTION
This feature used to work for mavericks, but with Enhancements, it become more complex to aggregate, so it is better to have duplicate buttons.

Fixes #1791 

Screenshots bellow shows a prompt with 3 buttons:
- Exchange Officer in "native" house SA
- Exchange Officer maverick Shadows with Enhancements 
- Exchange Officer maverick Shadows without Enhancements

![image](https://user-images.githubusercontent.com/2104075/87867022-f0115d00-c95e-11ea-9ccf-3037d8a4c342.png)

![image](https://user-images.githubusercontent.com/2104075/87867028-f9022e80-c95e-11ea-84eb-3e23f81000d1.png)

![image](https://user-images.githubusercontent.com/2104075/87867031-015a6980-c95f-11ea-8b5d-34c493af32d0.png)

![image](https://user-images.githubusercontent.com/2104075/87867032-0c14fe80-c95f-11ea-94f0-7ec0dcf27377.png)

I think a good enhancement would be:
1) Put a house icon next to the card name when it is maverick
2) Write a blue text when the card has Enhancement

What do you think, @cryogen ?