### PR TITLE
Sinder should only allow selecting a creature

### DIFF
--- a/server/game/cards/04-MM/Sinder.js
+++ b/server/game/cards/04-MM/Sinder.js
@@ -5,6 +5,7 @@ class Sinder extends Card {
         this.reap({
             target: {
                 location: 'play area',
+                cardType: 'creature',
                 controller: 'self',
                 gameAction: ability.actions.destroy()
             }


### PR DESCRIPTION
Sinder
Reap: Destroy a friendly creature.

Currently allows selecting an artifact (or upgrade to be destroyed)