### PR TITLE
Bandaid fix for unserializable ward message

### DIFF
--- a/server/game/GameActions/DealDamageAction.js
+++ b/server/game/GameActions/DealDamageAction.js
@@ -76,7 +76,7 @@ class DealDamageAction extends CardGameAction {
                 context.game.addMessage(
                     "{0}'s ward token prevents the damage dealt by {1} and is discarded",
                     damageDealtEvent.card,
-                    damageDealtEvent.damageSource
+                    damageDealtEvent ? 'a bonus icon' : damageDealtEvent.damageSource
                 );
                 damageDealtEvent.card.unward();
                 return;

--- a/test/server/cards/04-MM/NewFrontiers.spec.js
+++ b/test/server/cards/04-MM/NewFrontiers.spec.js
@@ -21,6 +21,18 @@ describe('New Frontiers', function () {
             expect(this.player1.amber).toBe(1);
         });
 
+        it('can poke a ward without killing the server', function () {
+            this.newFrontiers.cardData.enhancements = ['damage'];
+            this.player1.reap(this.medicIngram);
+            this.player1.clickCard(this.medicIngram);
+            expect(this.medicIngram.tokens.ward).toBe(1);
+            this.player1.play(this.newFrontiers);
+            this.player1.clickCard(this.medicIngram);
+            expect(this.medicIngram.tokens.ward).toBeUndefined();
+            expect(this.player1).toHavePrompt('Choose a house');
+            expect(this.player1.amber).toBe(2);
+        });
+
         it('should archive selected house cards and discard the others', function () {
             this.player1.moveCard(this.flaxia, 'deck');
             this.player1.moveCard(this.medicIngram, 'deck');

--- a/test/server/cards/04-MM/NewFrontiers.spec.js
+++ b/test/server/cards/04-MM/NewFrontiers.spec.js
@@ -21,18 +21,6 @@ describe('New Frontiers', function () {
             expect(this.player1.amber).toBe(1);
         });
 
-        it('can poke a ward without killing the server', function () {
-            this.newFrontiers.cardData.enhancements = ['damage'];
-            this.player1.reap(this.medicIngram);
-            this.player1.clickCard(this.medicIngram);
-            expect(this.medicIngram.tokens.ward).toBe(1);
-            this.player1.play(this.newFrontiers);
-            this.player1.clickCard(this.medicIngram);
-            expect(this.medicIngram.tokens.ward).toBeUndefined();
-            expect(this.player1).toHavePrompt('Choose a house');
-            expect(this.player1.amber).toBe(2);
-        });
-
         it('should archive selected house cards and discard the others', function () {
             this.player1.moveCard(this.flaxia, 'deck');
             this.player1.moveCard(this.medicIngram, 'deck');

--- a/test/server/wards.spec.js
+++ b/test/server/wards.spec.js
@@ -1,0 +1,27 @@
+describe('Wards', function () {
+    describe('Wards', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'staralliance',
+                    inPlay: ['flaxia', 'medic-ingram', 'bumblebird', 'ancient-bear'],
+                    hand: ['new-frontiers']
+                },
+                player2: {
+                    amber: 2
+                }
+            });
+        });
+
+        it('can be removed by a damage bonus icon', function () {
+            this.newFrontiers.cardData.enhancements = ['damage'];
+            this.player1.reap(this.medicIngram);
+            this.player1.clickCard(this.medicIngram);
+            expect(this.medicIngram.tokens.ward).toBe(1);
+
+            this.player1.play(this.newFrontiers);
+            this.player1.clickCard(this.medicIngram);
+            expect(this.medicIngram.tokens.ward).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
This seems to be what was breaking the server - the "damage source" for bonus damage icons has a reference to "game", so it breaks if you try to serialize it in a message within the game.