### PR TITLE
Suppress vertical scrollbar on whole play area

### DIFF
--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -6,7 +6,7 @@
 
 .game-board {
     position: absolute;
-    bottom: 0;
+    bottom: 3px;
     left: 0;
     right: 0;
     top: $navbar-height;

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -30,7 +30,7 @@ body {
     top: 0;
     bottom: 0;
 
-    overflow-y: auto;
+    overflow-y: hidden;
 }
 
 a {

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -30,7 +30,7 @@ body {
     top: 0;
     bottom: 0;
 
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 a {


### PR DESCRIPTION
Several components cause the play area to exceed 100% body height. This leads to an unsightly (and useless) scrollbar that sits next to the message log (which has it's own scrollbar). Suppress the outer scrollbar as it's never of any use.

before:

![image](https://user-images.githubusercontent.com/2436007/98748889-835d1b00-23b2-11eb-8269-139e02ae0a16.png)

after:

![image](https://user-images.githubusercontent.com/2436007/98748900-8821cf00-23b2-11eb-8775-a3c015a302b4.png)
