### PR TITLE
Display own upgrades over the top of opponents battleline.

### DIFF
--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -97,6 +97,7 @@
 
     &.our-side {
         margin: 0;
+        z-index: 20;
 
         .taunt {
             margin-top: -15px;

--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -97,7 +97,7 @@
 
     &.our-side {
         margin: 0;
-        z-index: 20;
+        z-index: $layer-our-player-board;
 
         .taunt {
             margin-top: -15px;

--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -97,7 +97,7 @@
 
     &.our-side {
         margin: 0;
-        z-index: $layer-our-player-board;
+        z-index: $layer-player-board-our-side;
 
         .taunt {
             margin-top: -15px;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -7,7 +7,7 @@ $scrollbar-width: 20px;
 
 $layer-bottom: 1;
 $layer-cards: 10;
-$layer-our-player-board: 15;
+$layer-player-board-our-side: 15;
 $layer-pile-header: 20;
 $layer-card-collection: 100;
 $layer-prompt: 110;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -7,6 +7,7 @@ $scrollbar-width: 20px;
 
 $layer-bottom: 1;
 $layer-cards: 10;
+$layer-our-player-board: 15;
 $layer-pile-header: 20;
 $layer-card-collection: 100;
 $layer-prompt: 110;


### PR DESCRIPTION
Fixes #2076

Not sure if there's a reason we've avoided layering things in this order before now? 

Changes this:
![image](https://user-images.githubusercontent.com/2436007/100344046-21b6c680-2fd8-11eb-9f28-b1cc309d5433.png)

To this:
![image](https://user-images.githubusercontent.com/2436007/100344053-25e2e400-2fd8-11eb-9332-91bc3abd1d93.png)
