### PR TITLE
Fix background image scaling on node admin page "refresh" button.

### DIFF
--- a/client/pages/NodesAdmin.jsx
+++ b/client/pages/NodesAdmin.jsx
@@ -96,7 +96,7 @@ class NodeAdmin extends React.Component {
                 <Panel title='Game Node Administration'>
                     {content}
 
-                    <button className='btn btn-default' onClick={this.onRefreshClick}>
+                    <button className='btn btn-default btn-short' onClick={this.onRefreshClick}>
                         Refresh
                     </button>
                 </Panel>

--- a/client/styles/index.scss
+++ b/client/styles/index.scss
@@ -85,6 +85,10 @@ a {
     }
 }
 
+.btn-short{
+    background-size: 100% 32px;
+}
+
 .btn-primary {
     background-image: url('~assets/img/button-primary.png');
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2436007/100644826-b94b4a80-3333-11eb-8532-d8053184daef.png)

It's a tiny bit squished on the edges, but better here than every single player prompt version being stretched.