### PR TITLE
Fixes messaging of delayed effect + gameaction

### DIFF
--- a/server/game/DelayedEffect.js
+++ b/server/game/DelayedEffect.js
@@ -50,7 +50,7 @@ class DelayedEffect {
 
         if (this.message) {
             this.game.addMessage(
-                this.message,
+                this.message + 'ROMANO JOSÉ',
                 this.context.player,
                 this.source,
                 this.target || event.card

--- a/server/game/DelayedEffect.js
+++ b/server/game/DelayedEffect.js
@@ -50,7 +50,7 @@ class DelayedEffect {
 
         if (this.message) {
             this.game.addMessage(
-                this.message + 'ROMANO JOSÉ',
+                this.message,
                 this.context.player,
                 this.source,
                 this.target || event.card

--- a/server/game/GameActions/LastingEffectAction.js
+++ b/server/game/GameActions/LastingEffectAction.js
@@ -15,7 +15,9 @@ class LastingEffectAction extends GameAction {
         this.when = null;
         this.gameAction = null;
         this.message = null;
+        this.messageArgs = [];
         this.match = null;
+        this.preferActionPromptMessage = false;
         this.multipleTrigger = true;
     }
 
@@ -37,6 +39,8 @@ class LastingEffectAction extends GameAction {
                     when: this.when,
                     gameAction: this.gameAction,
                     message: this.message,
+                    messageArgs: this.messageArgs,
+                    preferActionPromptMessage: this.preferActionPromptMessage,
                     multipleTrigger: this.multipleTrigger,
                     context: context
                 })

--- a/server/game/cards/04-MM/Commandeer.js
+++ b/server/game/cards/04-MM/Commandeer.js
@@ -9,10 +9,14 @@ class Commandeer extends Card {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source
                 },
+                preferActionPromptMessage: true,
                 gameAction: ability.actions.capture({
                     promptForSelect: {
                         cardType: 'creature',
-                        controller: 'self'
+                        controller: 'self',
+                        message:
+                            '{0} uses {1} to capture amber from their opponent and place on {2}',
+                        messageArgs: (card) => [context.player, context.source, card]
                     }
                 })
             }))

--- a/server/game/cards/04-MM/WildBounty.js
+++ b/server/game/cards/04-MM/WildBounty.js
@@ -8,8 +8,8 @@ class WildBounty extends Card {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source
                 },
-                effect: 'resolve the bonus icons of {1} an additional time',
-                effectArgs: (context) => context.event.card,
+                message: '{0} uses {1} to resolve the bonus icons of {2} an additional time',
+                messageArgs: (context) => [context.player, context.source, context.event.card],
                 multipleTrigger: false,
                 gameAction: ability.actions.resolveBonusIcons((context) => ({
                     target: context.event.card

--- a/test/server/cards/04-MM/Commandeer.spec.js
+++ b/test/server/cards/04-MM/Commandeer.spec.js
@@ -13,6 +13,7 @@ describe('Commandeer', function () {
                 }
             });
         });
+
         it('should capture when you play a card', function () {
             this.player1.play(this.commandeer);
             expect(this.commandeer.location).toBe('discard');


### PR DESCRIPTION
Fixes #2109 

Commandeer:

```javascript
2020-12-04 16:39:43 player1 plays Commandeer
2020-12-04 16:39:43 player1 gains an amber due to Commandeer's bonus icon
2020-12-04 16:39:43 player1 uses Commandeer to capture an amber after playing a card for the remainder of the turn
2020-12-04 16:39:43 player1 plays Sequis
2020-12-04 16:39:43 player1 uses Commandeer to capture amber from their opponent and place on Sequis
```

Wild Bounty (message was not being printed)

```javascript
2020-12-04 16:40:10 player1 plays Wild Bounty
2020-12-04 16:40:10 player1 uses Wild Bounty to apply a lasting effect
2020-12-04 16:40:10 player1 plays Fertility Chant
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 uses Wild Bounty to resolve the bonus icons of Fertility Chant an additional time
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 gains an amber due to Fertility Chant's bonus icon
2020-12-04 16:40:10 player1 uses Fertility Chant to cause player2 to gain 2 amber
```