### PR TITLE
Fixes Stilt Kin message

### DIFF
--- a/server/game/cards/03-WC/StiltKin.js
+++ b/server/game/cards/03-WC/StiltKin.js
@@ -12,7 +12,8 @@ class StiltKin extends Card {
             gameAction: ability.actions.sequential([
                 ability.actions.ready(),
                 ability.actions.fight()
-            ])
+            ]),
+            effect: 'ready and fight with {0}'
         });
     }
 }

--- a/test/server/cards/03-WC/StiltKin.spec.js
+++ b/test/server/cards/03-WC/StiltKin.spec.js
@@ -1,4 +1,4 @@
-describe('stilt-kin(WC)', function () {
+describe('stilt-kin', function () {
     describe('stilt-kin ability', function () {
         beforeEach(function () {
             this.setupTest({


### PR DESCRIPTION
Fixes #2123

```javascript
2020-12-09 13:52:01 ==================== House phase - player1 ====================
2020-12-09 13:52:01 player1 chooses brobnar as their active house this turn
2020-12-09 13:52:01 ==================== Main phase - player1 ====================
2020-12-09 13:52:01 player1 uses Stilt-Kin to reap with Stilt-Kin
2020-12-09 13:52:01 player1 plays Cowfyne
2020-12-09 13:52:01 player1 uses Stilt-Kin to ready and fight with Stilt-Kin
2020-12-09 13:52:01 player1 uses Stilt-Kin to make Stilt-Kin fight Troll
```