### PR TITLE
Fixes Ransack not discarding when stealing didn't trigger

### DIFF
--- a/server/game/cards/04-MM/Ransack.js
+++ b/server/game/cards/04-MM/Ransack.js
@@ -3,39 +3,29 @@ const Card = require('../../Card.js');
 class Ransack extends Card {
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.steal(),
+            gameAction: [
+                ability.actions.steal(),
+                ability.actions.discard((context) => ({
+                    target: context.player.deck.length ? context.player.deck[0] : null
+                }))
+            ],
+            effectStyle: 'append',
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                condition: (context) => context.player.deck.length > 0,
-                message: '{0} discards the top card of their deck due to {1}: {3}{4}{5}{6}',
-                messageArgs: (context) => {
-                    let topCard = context.player.deck[0];
-                    if (topCard) {
-                        if (
-                            !topCard.hasHouse('shadows') ||
-                            context.source.location !== 'being played'
-                        ) {
-                            return [topCard];
-                        }
-
-                        return [topCard, '. ', context.source, "'s ability resolves again"];
-                    }
-
-                    return [];
-                },
+                message: '{0} uses {1} to resolve its effect again',
                 gameAction: [
-                    ability.actions.discard((context) => ({
-                        target: context.player.deck.length > 0 ? context.player.deck[0] : []
-                    })),
-                    ability.actions.resolveAbility((context) => ({
-                        target:
-                            context.source.location === 'being played' &&
-                            context.player.deck.length &&
-                            context.player.deck[0].hasHouse('shadows')
-                                ? context.source
-                                : [],
-                        ability: preThenContext.ability
-                    }))
+                    ability.actions.resolveAbility((context) => {
+                        let event = context.preThenEvents.find((event) => !!event.card);
+                        return {
+                            target:
+                                context.source.location === 'being played' &&
+                                event &&
+                                event.card.hasHouse('shadows')
+                                    ? context.source
+                                    : [],
+                            ability: preThenContext.ability
+                        };
+                    })
                 ]
             })
         });

--- a/test/server/cards/04-MM/Ransack.spec.js
+++ b/test/server/cards/04-MM/Ransack.spec.js
@@ -43,6 +43,17 @@ describe('Ransack', function () {
         expect(this.player1.player.discard.length).toBe(8);
     });
 
+    it('should not steal and stop if deck is empty', function () {
+        this.player2.amber = 0;
+        this.player1.player.deck = [];
+        this.player1.play(this.ransack);
+
+        expect(this.player1.amber).toBe(0);
+        expect(this.player2.amber).toBe(0);
+
+        expect(this.player1.player.discard.length).toBe(8);
+    });
+
     it('should steal and stop if top card is not shadows', function () {
         this.player1.moveCard(this.dextre, 'deck');
         this.player1.play(this.ransack);

--- a/test/server/cards/04-MM/Ransack.spec.js
+++ b/test/server/cards/04-MM/Ransack.spec.js
@@ -5,7 +5,15 @@ describe('Ransack', function () {
                 house: 'shadows',
                 hand: ['ransack', 'twin-bolt-emission'],
                 inPlay: ['nexus', 'gorm-of-omm', 'library-of-babble'],
-                discard: ['dextre', 'urchin', 'umbra']
+                discard: [
+                    'dextre',
+                    'urchin',
+                    'umbra',
+                    'lamindra',
+                    'shadow-self',
+                    'miasma',
+                    'miasma-bomb'
+                ]
             },
             player2: {
                 amber: 3,
@@ -14,12 +22,35 @@ describe('Ransack', function () {
         });
     });
 
-    it('should trigger when played', function () {
+    it('should discard even if no stealing happen', function () {
+        this.player2.amber = 0;
+        this.player1.moveCard(this.dextre, 'deck');
+        this.player1.play(this.ransack);
+
+        expect(this.player1.amber).toBe(0);
+        expect(this.player2.amber).toBe(0);
+
+        expect(this.dextre.location).toBe('discard');
+    });
+
+    it('should steal 1 and stop if deck is empty', function () {
+        this.player1.player.deck = [];
+        this.player1.play(this.ransack);
+
+        expect(this.player1.amber).toBe(1);
+        expect(this.player2.amber).toBe(2);
+
+        expect(this.player1.player.discard.length).toBe(8);
+    });
+
+    it('should steal and stop if top card is not shadows', function () {
         this.player1.moveCard(this.dextre, 'deck');
         this.player1.play(this.ransack);
 
         expect(this.player1.amber).toBe(1);
         expect(this.player2.amber).toBe(2);
+
+        expect(this.dextre.location).toBe('discard');
     });
 
     it('should resolve the ability again if the top card is shadows', function () {
@@ -30,5 +61,29 @@ describe('Ransack', function () {
 
         expect(this.player1.amber).toBe(2);
         expect(this.player2.amber).toBe(1);
+
+        expect(this.urchin.location).toBe('discard');
+        expect(this.dextre.location).toBe('discard');
+    });
+
+    it('should resolve the ability multiple times, even though opponent has no more amber to steal', function () {
+        this.player1.moveCard(this.dextre, 'deck');
+        this.player1.moveCard(this.lamindra, 'deck');
+        this.player1.moveCard(this.shadowSelf, 'deck');
+        this.player1.moveCard(this.miasma, 'deck');
+        this.player1.moveCard(this.miasmaBomb, 'deck');
+        this.player1.moveCard(this.urchin, 'deck');
+
+        this.player1.play(this.ransack);
+
+        expect(this.player1.amber).toBe(3);
+        expect(this.player2.amber).toBe(0);
+
+        expect(this.urchin.location).toBe('discard');
+        expect(this.miasmaBomb.location).toBe('discard');
+        expect(this.miasma.location).toBe('discard');
+        expect(this.shadowSelf.location).toBe('discard');
+        expect(this.lamindra.location).toBe('discard');
+        expect(this.dextre.location).toBe('discard');
     });
 });


### PR DESCRIPTION
Fixes #1944

Sample game message:
```
2021-01-05 16:25:46 ==================== House phase - player1 ====================
2021-01-05 16:25:46 player1 chooses shadows as their active house this turn
2021-01-05 16:25:46 ==================== Main phase - player1 ====================
2021-01-05 16:25:46 player1 plays Ransack
2021-01-05 16:25:46 player1 uses Ransack to steal 1 amber from player2; and discard Urchin
2021-01-05 16:25:46 player1 uses Ransack to resolve its effect again
2021-01-05 16:25:46 player1 uses Ransack to steal 1 amber from player2; and discard Miasma Bomb
2021-01-05 16:25:46 player1 uses Ransack to resolve its effect again
2021-01-05 16:25:46 player1 uses Ransack to steal 1 amber from player2; and discard Miasma
2021-01-05 16:25:46 player1 uses Ransack to resolve its effect again
2021-01-05 16:25:46 player1 uses Ransack to discard Shadow Self
2021-01-05 16:25:46 player1 uses Ransack to resolve its effect again
2021-01-05 16:25:46 player1 uses Ransack to discard Lamindra
2021-01-05 16:25:46 player1 uses Ransack to resolve its effect again
2021-01-05 16:25:46 player1 uses Ransack to discard Dextre
```