### PR TITLE
Fixes Shards vs. Remote Access and Borrow

### DIFF
--- a/server/game/cards/02-AoA/ShardOfGreed.js
+++ b/server/game/cards/02-AoA/ShardOfGreed.js
@@ -5,10 +5,10 @@ class ShardOfGreed extends Card {
         this.action({
             gameAction: ability.actions.gainAmber((context) => ({
                 amount:
-                    context.player === this.owner
-                        ? context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length
-                        : context.player.cardsInPlay.filter((card) => card.hasTrait('shard'))
-                              .length + 1
+                    1 +
+                    context.player.cardsInPlay.filter(
+                        (card) => card !== context.source && card.hasTrait('shard')
+                    ).length
             }))
         });
     }

--- a/server/game/cards/02-AoA/ShardOfHate.js
+++ b/server/game/cards/02-AoA/ShardOfHate.js
@@ -4,7 +4,11 @@ class ShardOfHate extends Card {
     setupCardAbilities(ability) {
         this.action({
             gameAction: ability.actions.sequentialForEach((context) => ({
-                num: context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length,
+                num:
+                    1 +
+                    context.player.cardsInPlay.filter(
+                        (card) => card !== context.source && card.hasTrait('shard')
+                    ).length,
                 action: ability.actions.stun({
                     promptForSelect: {
                         activePromptTitle: 'Choose a creature to stun',

--- a/server/game/cards/02-AoA/ShardOfHope.js
+++ b/server/game/cards/02-AoA/ShardOfHope.js
@@ -3,20 +3,32 @@ const Card = require('../../Card.js');
 class ShardOfHope extends Card {
     setupCardAbilities(ability) {
         this.action({
-            condition: (context) => !!context.player.opponent && context.player.opponent.amber > 0,
-            target: {
-                mode: 'exactly',
-                controller: 'self',
-                numCards: (context) =>
-                    Math.min(
-                        context.player.opponent.amber,
-                        context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length
-                    ),
-                gameAction: ability.actions.capture()
-            },
-            effect: 'make {1} of their creatures capture an amber from {2}',
+            condition: (context) => !!context.player.opponent,
+            gameAction: ability.actions.sequentialForEach((context) => ({
+                num: Math.min(
+                    context.player.opponent.amber,
+                    1 +
+                        context.player.cardsInPlay.filter(
+                            (card) => card !== context.source && card.hasTrait('shard')
+                        ).length
+                ),
+                action: ability.actions.capture({
+                    promptForSelect: {
+                        activePromptTitle: 'Choose a creature to capture',
+                        cardType: 'creature',
+                        controller: 'self'
+                    }
+                })
+            })),
+            effect: 'capture {1} amber from {2}',
             effectArgs: (context) => [
-                context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length,
+                Math.min(
+                    context.player.opponent.amber,
+                    1 +
+                        context.player.cardsInPlay.filter(
+                            (card) => card !== context.source && card.hasTrait('shard')
+                        ).length
+                ),
                 context.player.opponent
             ]
         });

--- a/server/game/cards/02-AoA/ShardOfKnowledge.js
+++ b/server/game/cards/02-AoA/ShardOfKnowledge.js
@@ -4,7 +4,11 @@ class ShardOfKnowledge extends Card {
     setupCardAbilities(ability) {
         this.action({
             gameAction: ability.actions.draw((context) => ({
-                amount: context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length
+                amount:
+                    1 +
+                    context.player.cardsInPlay.filter(
+                        (card) => card !== context.source && card.hasTrait('shard')
+                    ).length
             }))
         });
     }

--- a/server/game/cards/02-AoA/ShardOfLife.js
+++ b/server/game/cards/02-AoA/ShardOfLife.js
@@ -6,7 +6,10 @@ class ShardOfLife extends Card {
             target: {
                 mode: 'exactly',
                 numCards: (context) =>
-                    context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length,
+                    1 +
+                    context.player.cardsInPlay.filter(
+                        (card) => card !== context.source && card.hasTrait('shard')
+                    ).length,
                 location: 'discard',
                 controller: 'self',
                 gameAction: ability.actions.returnToDeck({ shuffle: true })

--- a/server/game/cards/02-AoA/ShardOfPain.js
+++ b/server/game/cards/02-AoA/ShardOfPain.js
@@ -6,7 +6,11 @@ class ShardOfPain extends Card {
             effect: 'deal 1 damage to a creature for each friendly shard',
             gameAction: ability.actions.allocateDamage((context) => ({
                 controller: 'opponent',
-                numSteps: context.player.cardsInPlay.filter((card) => card.hasTrait('shard')).length
+                numSteps:
+                    1 +
+                    context.player.cardsInPlay.filter(
+                        (card) => card !== context.source && card.hasTrait('shard')
+                    ).length
             }))
         });
     }

--- a/server/game/cards/02-AoA/ShardOfStrength.js
+++ b/server/game/cards/02-AoA/ShardOfStrength.js
@@ -7,8 +7,11 @@ class ShardOfStrength extends Card {
                 cardType: 'creature',
                 controller: 'self',
                 gameAction: ability.actions.addPowerCounter((context) => ({
-                    amount: context.player.cardsInPlay.filter((card) => card.hasTrait('shard'))
-                        .length
+                    amount:
+                        1 +
+                        context.player.cardsInPlay.filter(
+                            (card) => card !== context.source && card.hasTrait('shard')
+                        ).length
                 }))
             }
         });

--- a/test/server/cards/02-AoA/ShardOfGreed.spec.js
+++ b/test/server/cards/02-AoA/ShardOfGreed.spec.js
@@ -8,13 +8,13 @@ describe('Shard of Greed', function () {
                     inPlay: ['shard-of-greed', 'seeker-needle', 'shard-of-hope']
                 },
                 player2: {
-                    hand: ['remote-access', 'shard-of-knowledge'],
+                    hand: ['remote-access', 'shard-of-knowledge', 'borrow'],
                     inPlay: ['dextre']
                 }
             });
         });
 
-        it('should grant the player an amber for each friendly shard', function () {
+        it('should grant the player an amber for each friendly shard, including itself', function () {
             this.player1.clickCard(this.shardOfGreed);
             expect(this.player1).toHavePrompt('Shard of Greed');
             this.player1.clickPrompt("Use this card's action ability");
@@ -29,7 +29,8 @@ describe('Shard of Greed', function () {
             this.player2.clickCard(this.shardOfGreed);
             expect(this.player2.amber).toBe(2);
         });
-        it('should work properly when Remote Accessed and theres another shard in play', function () {
+
+        it('should work properly when Remote Accessed and there is another friendly shard in play', function () {
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
             this.player2.play(this.shardOfKnowledge);
@@ -37,6 +38,15 @@ describe('Shard of Greed', function () {
             expect(this.player2).toHavePrompt('Remote Access');
             this.player2.clickCard(this.shardOfGreed);
             expect(this.player2.amber).toBe(3);
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfGreed);
+            this.player2.useAction(this.shardOfGreed);
+            expect(this.player2.amber).toBe(2);
         });
     });
 });

--- a/test/server/cards/02-AoA/ShardOfHate.spec.js
+++ b/test/server/cards/02-AoA/ShardOfHate.spec.js
@@ -1,0 +1,103 @@
+describe('Shard of Hate', function () {
+    describe("Shard of Hate's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['blypyp'],
+                    inPlay: [
+                        'mindwarper',
+                        'mindworm',
+                        'shard-of-hate',
+                        'shard-of-greed',
+                        'seeker-needle',
+                        'shard-of-hope'
+                    ]
+                },
+                player2: {
+                    hand: ['remote-access', 'borrow'],
+                    inPlay: ['dextre', 'mother', 'archimedes', 'shard-of-knowledge']
+                }
+            });
+        });
+
+        it('should stun an enemy creatures', function () {
+            this.player1.useAction(this.shardOfHate);
+            expect(this.player1).toBeAbleToSelect(this.mother);
+            expect(this.player1).toBeAbleToSelect(this.dextre);
+            expect(this.player1).toBeAbleToSelect(this.archimedes);
+            expect(this.player1).not.toBeAbleToSelect(this.mindwarper);
+            expect(this.player1).not.toBeAbleToSelect(this.mindworm);
+            this.player1.clickCard(this.mother);
+            this.player1.clickCard(this.mother);
+            this.player1.clickCard(this.dextre);
+
+            expect(this.mother.stunned).toBe(true);
+            expect(this.dextre.stunned).toBe(true);
+            expect(this.archimedes.stunned).toBe(false);
+            expect(this.mindwarper.stunned).toBe(false);
+            expect(this.mindworm.stunned).toBe(false);
+
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfHate);
+            expect(this.player2).not.toBeAbleToSelect(this.mother);
+            expect(this.player2).not.toBeAbleToSelect(this.dextre);
+            expect(this.player2).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mindwarper);
+            expect(this.player2).toBeAbleToSelect(this.mindworm);
+            this.player2.clickCard(this.mindwarper);
+            this.player2.clickCard(this.mindworm);
+
+            expect(this.mother.stunned).toBe(false);
+            expect(this.dextre.stunned).toBe(false);
+            expect(this.archimedes.stunned).toBe(false);
+            expect(this.mindwarper.stunned).toBe(true);
+            expect(this.mindworm.stunned).toBe(true);
+
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfHate);
+            this.player2.useAction(this.shardOfHate);
+            expect(this.player2).not.toBeAbleToSelect(this.mother);
+            expect(this.player2).not.toBeAbleToSelect(this.dextre);
+            expect(this.player2).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mindwarper);
+            expect(this.player2).toBeAbleToSelect(this.mindworm);
+            this.player2.clickCard(this.mindwarper);
+            this.player2.clickCard(this.mindworm);
+
+            expect(this.mother.stunned).toBe(false);
+            expect(this.dextre.stunned).toBe(false);
+            expect(this.archimedes.stunned).toBe(false);
+            expect(this.mindwarper.stunned).toBe(true);
+            expect(this.mindworm.stunned).toBe(true);
+
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        describe('when there are no enemy creatures in play', function () {
+            beforeEach(function () {
+                this.player2.moveCard(this.dextre, 'discard');
+                this.player2.moveCard(this.mother, 'discard');
+                this.player2.moveCard(this.archimedes, 'discard');
+            });
+
+            it('should not prompt', function () {
+                this.player1.useAction(this.shardOfHate);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+    });
+});

--- a/test/server/cards/02-AoA/ShardOfHope.spec.js
+++ b/test/server/cards/02-AoA/ShardOfHope.spec.js
@@ -1,0 +1,115 @@
+describe('Shard of Hope', function () {
+    describe("Shard of Hope's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 4,
+                    house: 'sanctum',
+                    hand: ['gatekeeper'],
+                    inPlay: [
+                        'the-vaultkeeper',
+                        'lord-golgotha',
+                        'shard-of-hope',
+                        'shard-of-greed',
+                        'seeker-needle',
+                        'shard-of-hope'
+                    ]
+                },
+                player2: {
+                    amber: 5,
+                    hand: ['remote-access', 'borrow'],
+                    inPlay: ['dextre', 'mother', 'archimedes', 'shard-of-knowledge']
+                }
+            });
+        });
+
+        it('should capture 1 maber for each friendly shard', function () {
+            this.player1.useAction(this.shardOfHope);
+            expect(this.player1).toBeAbleToSelect(this.theVaultkeeper);
+            expect(this.player1).toBeAbleToSelect(this.lordGolgotha);
+            expect(this.player1).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player1).not.toBeAbleToSelect(this.dextre);
+            expect(this.player1).not.toBeAbleToSelect(this.mother);
+            this.player1.clickCard(this.theVaultkeeper);
+            this.player1.clickCard(this.theVaultkeeper);
+            this.player1.clickCard(this.lordGolgotha);
+
+            expect(this.theVaultkeeper.amber).toBe(2);
+            expect(this.lordGolgotha.amber).toBe(1);
+            expect(this.player1.amber).toBe(4);
+            expect(this.player2.amber).toBe(2);
+
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfHope);
+            expect(this.player2).not.toBeAbleToSelect(this.theVaultkeeper);
+            expect(this.player2).not.toBeAbleToSelect(this.lordGolgotha);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            this.player2.clickCard(this.mother);
+
+            expect(this.mother.amber).toBe(2);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(6);
+
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfHope);
+            this.player2.useAction(this.shardOfHope);
+            expect(this.player2).not.toBeAbleToSelect(this.theVaultkeeper);
+            expect(this.player2).not.toBeAbleToSelect(this.lordGolgotha);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            this.player2.clickCard(this.mother);
+
+            expect(this.mother.amber).toBe(2);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(6);
+
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        describe('when opponent has no amber', function () {
+            beforeEach(function () {
+                this.player2.player.amber = 0;
+            });
+
+            it('should not prompt', function () {
+                this.player1.useAction(this.shardOfHope);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+
+        describe('when opponent has less amber than shard', function () {
+            beforeEach(function () {
+                this.player2.player.amber = 1;
+            });
+
+            it('should prompt for only 1 creature', function () {
+                this.player1.useAction(this.shardOfHope);
+                this.player1.clickCard(this.lordGolgotha);
+
+                expect(this.lordGolgotha.amber).toBe(1);
+                expect(this.player1.amber).toBe(4);
+                expect(this.player2.amber).toBe(0);
+
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+    });
+});

--- a/test/server/cards/02-AoA/ShardOfKnowledge.spec.js
+++ b/test/server/cards/02-AoA/ShardOfKnowledge.spec.js
@@ -1,0 +1,48 @@
+describe('Shard of Strength', function () {
+    describe("Shard of Strength's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'logos',
+                    hand: ['dextre', 'urchin'],
+                    inPlay: [
+                        'shard-of-knowledge',
+                        'shard-of-greed',
+                        'seeker-needle',
+                        'shard-of-hope'
+                    ]
+                },
+                player2: {
+                    hand: ['remote-access', 'borrow', 'lamindra'],
+                    inPlay: ['mother', 'archimedes', 'shard-of-greed']
+                }
+            });
+        });
+
+        it('should draw a card for each friendly shard', function () {
+            expect(this.player1.player.hand.length).toBe(2);
+            this.player1.useAction(this.shardOfKnowledge);
+            expect(this.player1.player.hand.length).toBe(5);
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            expect(this.player2.player.hand.length).toBe(3);
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfKnowledge);
+            expect(this.player2.player.hand.length).toBe(4);
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            expect(this.player2.player.hand.length).toBe(3);
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfKnowledge);
+            this.player2.useAction(this.shardOfKnowledge);
+            expect(this.player2.player.hand.length).toBe(4);
+        });
+    });
+});

--- a/test/server/cards/02-AoA/ShardOfLife.spec.js
+++ b/test/server/cards/02-AoA/ShardOfLife.spec.js
@@ -1,0 +1,105 @@
+describe('Shard of Life', function () {
+    describe("Shard of Life's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'untamed',
+                    hand: ['regrowth'],
+                    inPlay: [
+                        'dharna',
+                        'shard-of-life',
+                        'shard-of-greed',
+                        'seeker-needle',
+                        'shard-of-hope'
+                    ],
+                    discard: ['duskwitch', 'fanghouse', 'fogbank', 'key-charge']
+                },
+                player2: {
+                    hand: ['remote-access', 'borrow'],
+                    inPlay: ['shard-of-knowledge'],
+                    discard: ['dextre', 'mother', 'archimedes']
+                }
+            });
+        });
+
+        it('should return 3 discarded cards to deck', function () {
+            this.player1.useAction(this.shardOfLife);
+            expect(this.player1).toBeAbleToSelect(this.duskwitch);
+            expect(this.player1).toBeAbleToSelect(this.fanghouse);
+            expect(this.player1).toBeAbleToSelect(this.fogbank);
+            expect(this.player1).toBeAbleToSelect(this.keyCharge);
+            expect(this.player1).not.toBeAbleToSelect(this.dharna);
+            expect(this.player1).not.toBeAbleToSelect(this.regrowth);
+            expect(this.player1).not.toBeAbleToSelect(this.dextre);
+            expect(this.player1).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player1).not.toBeAbleToSelect(this.mother);
+            this.player1.clickCard(this.duskwitch);
+            this.player1.clickCard(this.fogbank);
+            this.player1.clickCard(this.keyCharge);
+            this.player1.clickPrompt('Done');
+
+            expect(this.duskwitch.location).toBe('deck');
+            expect(this.fogbank.location).toBe('deck');
+            expect(this.keyCharge.location).toBe('deck');
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfLife);
+            expect(this.player2).not.toBeAbleToSelect(this.duskwitch);
+            expect(this.player2).not.toBeAbleToSelect(this.fanghouse);
+            expect(this.player2).not.toBeAbleToSelect(this.fogbank);
+            expect(this.player2).not.toBeAbleToSelect(this.keyCharge);
+            expect(this.player2).not.toBeAbleToSelect(this.borrow);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            this.player2.clickCard(this.archimedes);
+            this.player2.clickPrompt('Done');
+
+            expect(this.mother.location).toBe('deck');
+            expect(this.archimedes.location).toBe('deck');
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfLife);
+            this.player2.useAction(this.shardOfLife);
+            expect(this.player2).not.toBeAbleToSelect(this.duskwitch);
+            expect(this.player2).not.toBeAbleToSelect(this.fanghouse);
+            expect(this.player2).not.toBeAbleToSelect(this.fogbank);
+            expect(this.player2).not.toBeAbleToSelect(this.keyCharge);
+            expect(this.player2).not.toBeAbleToSelect(this.remoteAccess);
+            expect(this.player2).toBeAbleToSelect(this.borrow);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            this.player2.clickCard(this.archimedes);
+            this.player2.clickPrompt('Done');
+
+            expect(this.mother.location).toBe('deck');
+            expect(this.archimedes.location).toBe('deck');
+        });
+
+        describe('when there are no cards in discard', function () {
+            beforeEach(function () {
+                this.player2.moveCard(this.duskwitch, 'deck');
+                this.player2.moveCard(this.fanghouse, 'deck');
+                this.player2.moveCard(this.fogbank, 'deck');
+                this.player2.moveCard(this.keyCharge, 'deck');
+            });
+
+            it('should not prompt', function () {
+                this.player1.useAction(this.shardOfLife);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+    });
+});

--- a/test/server/cards/02-AoA/ShardOfPain.spec.js
+++ b/test/server/cards/02-AoA/ShardOfPain.spec.js
@@ -14,7 +14,7 @@ describe('Shard of Pain', function () {
                     ]
                 },
                 player2: {
-                    hand: ['remote-access'],
+                    hand: ['remote-access', 'borrow'],
                     inPlay: ['dextre', 'mother', 'archimedes', 'shard-of-knowledge']
                 }
             });
@@ -32,6 +32,36 @@ describe('Shard of Pain', function () {
 
             expect(this.mother.tokens.damage).toBe(2);
             expect(this.dextre.tokens.damage).toBe(1);
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfPain);
+            expect(this.player2).not.toBeAbleToSelect(this.mother);
+            expect(this.player2).not.toBeAbleToSelect(this.dextre);
+            expect(this.player2).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.shooler);
+            this.player2.clickCard(this.shooler);
+            this.player2.clickCard(this.shooler);
+            expect(this.shooler.tokens.damage).toBe(2);
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfPain);
+            this.player2.useAction(this.shardOfPain);
+            expect(this.player2).not.toBeAbleToSelect(this.mother);
+            expect(this.player2).not.toBeAbleToSelect(this.dextre);
+            expect(this.player2).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.shooler);
+            this.player2.clickCard(this.shooler);
+            this.player2.clickCard(this.shooler);
+            expect(this.shooler.tokens.damage).toBe(2);
         });
 
         describe('when there are no enemy creatures in play', function () {

--- a/test/server/cards/02-AoA/ShardOfStrength.spec.js
+++ b/test/server/cards/02-AoA/ShardOfStrength.spec.js
@@ -1,0 +1,78 @@
+describe('Shard of Strength', function () {
+    describe("Shard of Strength's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'brobnar',
+                    hand: ['brammo'],
+                    inPlay: [
+                        'cowfyne',
+                        'foozle',
+                        'shard-of-strength',
+                        'shard-of-greed',
+                        'seeker-needle',
+                        'shard-of-hope'
+                    ]
+                },
+                player2: {
+                    hand: ['remote-access', 'borrow'],
+                    inPlay: ['dextre', 'mother', 'archimedes', 'shard-of-knowledge']
+                }
+            });
+        });
+
+        it('should give a friendly creature a +1 power counter for each friendly Shard', function () {
+            this.player1.useAction(this.shardOfStrength);
+            expect(this.player1).toBeAbleToSelect(this.cowfyne);
+            expect(this.player1).toBeAbleToSelect(this.foozle);
+            expect(this.player1).not.toBeAbleToSelect(this.dextre);
+            expect(this.player1).not.toBeAbleToSelect(this.archimedes);
+            expect(this.player1).not.toBeAbleToSelect(this.mother);
+            this.player1.clickCard(this.cowfyne);
+
+            expect(this.cowfyne.tokens.power).toBe(3);
+        });
+
+        it('should work properly when Remote Accessed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('logos');
+            this.player2.play(this.remoteAccess);
+            expect(this.player2).toHavePrompt('Remote Access');
+            this.player2.clickCard(this.shardOfStrength);
+            expect(this.player2).not.toBeAbleToSelect(this.cowfyne);
+            expect(this.player2).not.toBeAbleToSelect(this.foozle);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            expect(this.mother.tokens.power).toBe(2);
+        });
+
+        it('should work properly when Borrowed', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.borrow);
+            this.player2.clickCard(this.shardOfStrength);
+            this.player2.useAction(this.shardOfStrength);
+            expect(this.player2).not.toBeAbleToSelect(this.cowfyne);
+            expect(this.player2).not.toBeAbleToSelect(this.foozle);
+            expect(this.player2).toBeAbleToSelect(this.dextre);
+            expect(this.player2).toBeAbleToSelect(this.archimedes);
+            expect(this.player2).toBeAbleToSelect(this.mother);
+            this.player2.clickCard(this.mother);
+            expect(this.mother.tokens.power).toBe(2);
+        });
+
+        describe('when there are no friendly creatures in play', function () {
+            beforeEach(function () {
+                this.player1.moveCard(this.cowfyne, 'discard');
+                this.player1.moveCard(this.foozle, 'discard');
+            });
+
+            it('should not prompt', function () {
+                this.player1.useAction(this.shardOfStrength);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Calculate the number of shards as "1 + other shards". By doing this, cards such as Remote Access will count the used shard as theirs.
Fixes #2274
Fixes #2278