### PR TITLE
Fixes Imperial Traitor not revealing when hand has no sanctum

### DIFF
--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -2,6 +2,11 @@ class BaseCardSelector {
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
         this.cardType = properties.cardType;
+        this.selectorCondition = properties.selectorCondition;
+        if (!this.selectorCondition) {
+            // eslint-disable-next-line no-unused-vars
+            this.selectorCondition = (selectedCards, context) => true;
+        }
         this.optional = properties.optional;
         this.location = this.buildLocation(properties.location);
         this.controller = properties.controller || 'any';
@@ -16,19 +21,6 @@ class BaseCardSelector {
         let location = property || ['play area'];
         if (!Array.isArray(location)) {
             location = [location];
-        }
-
-        let index = location.indexOf('province');
-        if (index > -1) {
-            location.splice(
-                index,
-                1,
-                'province 1',
-                'province 2',
-                'province 3',
-                'province 4',
-                'stronghold province'
-            );
         }
 
         return location;
@@ -117,8 +109,11 @@ class BaseCardSelector {
         return this.findPossibleCards(context).filter((card) => this.canTarget(card, context));
     }
 
-    hasEnoughSelected(selectedCards) {
-        return this.optional || selectedCards.length > 0;
+    hasEnoughSelected(selectedCards, context) {
+        return (
+            (this.optional || selectedCards.length > 0) &&
+            this.selectorCondition(selectedCards, context)
+        );
     }
 
     hasEnoughTargets(context) {

--- a/server/game/CardSelectors/ExactlyXCardSelector.js
+++ b/server/game/CardSelectors/ExactlyXCardSelector.js
@@ -29,7 +29,10 @@ class ExactlyXCardSelector extends BaseCardSelector {
     }
 
     hasEnoughSelected(selectedCards, context) {
-        return selectedCards.length === this.getNumCards(context);
+        return (
+            selectedCards.length === this.getNumCards(context) &&
+            this.selectorCondition(selectedCards, context)
+        );
     }
 
     hasReachedLimit(selectedCards, context) {

--- a/server/game/cards/01-Core/ImperialTraitor.js
+++ b/server/game/cards/01-Core/ImperialTraitor.js
@@ -10,7 +10,8 @@ class ImperialTraitor extends Card {
                 mode: 'upTo',
                 numCards: 1,
                 location: 'hand',
-                cardCondition: (card) => card.hasHouse('sanctum'),
+                selectorCondition: (selectedCards) =>
+                    selectedCards.length === 0 || selectedCards[0].hasHouse('sanctum'),
                 gameAction: ability.actions.purge()
             }
         });

--- a/test/server/cards/01-Core/ImperialTraitor.spec.js
+++ b/test/server/cards/01-Core/ImperialTraitor.spec.js
@@ -1,0 +1,89 @@
+describe('Imperial Traitor', function () {
+    describe("Imperial Traitor's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'shadows',
+                    hand: ['imperial-traitor']
+                },
+                player2: {
+                    inPlay: ['francus'],
+                    hand: ['foggify', 'dextre', 'protect-the-weak', 'gub', 'epic-quest', 'bulwark'],
+                    discard: ['grey-monk']
+                }
+            });
+        });
+
+        it('should be optional', function () {
+            this.player1.play(this.imperialTraitor);
+            this.player1.clickPrompt('Done');
+            expect(this.foggify.location).toBe('hand');
+            expect(this.dextre.location).toBe('hand');
+            expect(this.gub.location).toBe('hand');
+            expect(this.epicQuest.location).toBe('hand');
+            expect(this.bulwark.location).toBe('hand');
+            expect(this.protectTheWeak.location).toBe('hand');
+        });
+
+        it('should be able to choose a sanctum card and purge it', function () {
+            this.player1.play(this.imperialTraitor);
+            this.player1.clickCard(this.epicQuest);
+            this.player1.clickPrompt('Done');
+            expect(this.foggify.location).toBe('hand');
+            expect(this.dextre.location).toBe('hand');
+            expect(this.gub.location).toBe('hand');
+            expect(this.epicQuest.location).toBe('purged');
+            expect(this.bulwark.location).toBe('hand');
+            expect(this.protectTheWeak.location).toBe('hand');
+        });
+
+        it('should not be able to click Done if a sanctum card is available, but not the selected one', function () {
+            this.player1.play(this.imperialTraitor);
+            expect(this.player1).toHavePromptButton('Done');
+            this.player1.clickCard(this.dextre);
+            expect(this.player1).not.toHavePromptButton('Done');
+            this.player1.clickCard(this.dextre);
+            this.player1.clickCard(this.bulwark);
+            expect(this.player1).toHavePromptButton('Done');
+        });
+    });
+
+    describe('when no sanctum is in hand', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'shadows',
+                    hand: ['imperial-traitor']
+                },
+                player2: {
+                    inPlay: ['francus'],
+                    hand: ['foggify', 'dextre', 'archimedes', 'gub', 'ember-imp', 'gateway-to-dis'],
+                    discard: ['grey-monk']
+                }
+            });
+        });
+
+        it('should be optional', function () {
+            this.player1.play(this.imperialTraitor);
+            this.player1.clickPrompt('Done');
+            expect(this.foggify.location).toBe('hand');
+            expect(this.dextre.location).toBe('hand');
+            expect(this.gub.location).toBe('hand');
+            expect(this.archimedes.location).toBe('hand');
+            expect(this.emberImp.location).toBe('hand');
+            expect(this.gatewayToDis.location).toBe('hand');
+        });
+
+        it('should not be able to click Done if a sanctum card is not available, but another one is selected', function () {
+            this.player1.play(this.imperialTraitor);
+            expect(this.player1).toHavePromptButton('Done');
+            this.player1.clickCard(this.foggify);
+            expect(this.player1).not.toHavePromptButton('Done');
+            this.player1.clickCard(this.foggify);
+            this.player1.clickCard(this.gub);
+            expect(this.player1).not.toHavePromptButton('Done');
+            this.player1.clickCard(this.gub);
+            expect(this.player1).toHavePromptButton('Done');
+        });
+    });
+});


### PR DESCRIPTION
Applied the same selectorCondition created for dark tidings which makes cards selectable, but Done is not enabled.
Fixes #1840