### PR TITLE
Fixes Mimic Gel not copying Deploy keyword

### DIFF
--- a/server/game/Effects/cannotrestriction.js
+++ b/server/game/Effects/cannotrestriction.js
@@ -1,14 +1,15 @@
 const EffectValue = require('./EffectValue');
 
 class CannotRestriction extends EffectValue {
-    constructor(type, condition) {
+    constructor(type, condition, effectTarget = null) {
         super();
         this.type = type;
         this.condition = condition;
+        this.effectTarget = effectTarget;
     }
 
-    getValue() {
-        return this;
+    getValue(target) {
+        return new CannotRestriction(this.type, this.condition, target);
     }
 
     isMatch(type, abilityContext) {
@@ -22,7 +23,7 @@ class CannotRestriction extends EffectValue {
             return false;
         }
 
-        return this.condition(context);
+        return this.condition(context, this.effectTarget);
     }
 }
 

--- a/server/game/cards/02-AoA/Lamindra.js
+++ b/server/game/cards/02-AoA/Lamindra.js
@@ -3,7 +3,7 @@ const Card = require('../../Card.js');
 class Lamindra extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            match: (card) => this.neighbors.includes(card),
+            match: (card, context) => context.source.neighbors.includes(card),
             effect: ability.effects.addKeyword({ elusive: 1 })
         });
     }

--- a/server/game/cards/03-WC/MimicGel.js
+++ b/server/game/cards/03-WC/MimicGel.js
@@ -9,9 +9,11 @@ class MimicGel extends Card {
             effect: ability.effects.cardCannot('play')
         });
 
-        this.interrupt({
+        this.reaction({
             when: {
-                onCardEntersPlay: (event, context) => event.card === context.source
+                onAbilityInitiated: (event, context) =>
+                    event.context.source === context.source &&
+                    event.context.ability.title === 'Play this creature'
             },
             location: 'any',
             target: {

--- a/server/game/cards/04-MM/ArdentHero.js
+++ b/server/game/cards/04-MM/ArdentHero.js
@@ -3,14 +3,17 @@ const Card = require('../../Card.js');
 class ArdentHero extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            effect: ability.effects.cardCannot('damage', (context) => {
-                if (context.source === this) {
+            effect: ability.effects.cardCannot('damage', (context, effectTarget) => {
+                if (context.source === effectTarget) {
                     return (
                         context.target &&
                         (context.target.power >= 5 || context.target.hasTrait('mutant'))
                     );
                 }
-                return context.source.power >= 5 || context.source.hasTrait('mutant');
+                return (
+                    context.source.type === 'creature' &&
+                    (context.source.power >= 5 || context.source.hasTrait('mutant'))
+                );
             })
         });
     }

--- a/test/server/cards/03-WC/EDAIEdie4x4.spec.js
+++ b/test/server/cards/03-WC/EDAIEdie4x4.spec.js
@@ -90,8 +90,10 @@ describe('EDAI Edie 4x4', function () {
             this.player2.play(this.harlandMindlock);
             this.player2.clickCard(this.edaiEdie4x4);
             this.player2.clickPrompt('Left');
-            this.player2.play(this.mimicGel);
+            this.player2.clickCard(this.mimicGel);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.edaiEdie4x4);
+            this.player2.clickPrompt('Left');
             this.player2.clickCard(this.foggify);
             expect(this.player2.player.archives.length).toBe(2);
             this.player2.endTurn();

--- a/test/server/cards/03-WC/MimicGel.spec.js
+++ b/test/server/cards/03-WC/MimicGel.spec.js
@@ -14,7 +14,14 @@ describe('Mimic Gel', function () {
                     hand: ['mimic-gel', 'phase-shift', 'dextre']
                 },
                 player2: {
-                    inPlay: ['panpaca-anga', 'flaxia', 'duskwitch', 'bumblebird', 'troll']
+                    inPlay: [
+                        'panpaca-anga',
+                        'flaxia',
+                        'duskwitch',
+                        'bumblebird',
+                        'troll',
+                        'lamindra'
+                    ]
                 }
             });
         });
@@ -40,7 +47,6 @@ describe('Mimic Gel', function () {
         it('should prompt the player to pick a creature when played', function () {
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             expect(this.player1).toHavePrompt('Mimic Gel');
             expect(this.player1).toBeAbleToSelect(this.batdrone);
             expect(this.player1).toBeAbleToSelect(this.panpacaAnga);
@@ -53,8 +59,8 @@ describe('Mimic Gel', function () {
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(true);
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             this.player1.clickCard(this.panpacaAnga);
+            this.player1.clickPrompt('Left');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(false);
             expect(this.mimicGel.hasTrait('beast')).toBe(true);
@@ -70,8 +76,8 @@ describe('Mimic Gel', function () {
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(true);
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             this.player1.clickCard(this.bumblebird);
+            this.player1.clickPrompt('Left');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(false);
             expect(this.mimicGel.hasTrait('beast')).toBe(true);
@@ -88,8 +94,8 @@ describe('Mimic Gel', function () {
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(true);
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             this.player1.clickCard(this.duskwitch);
+            this.player1.clickPrompt('Left');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(false);
             expect(this.mimicGel.hasTrait('human')).toBe(true);
@@ -106,8 +112,8 @@ describe('Mimic Gel', function () {
         it('should copy elusive and hazardous keyword', function () {
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             this.player1.clickCard(this.xenosBloodshadow);
+            this.player1.clickPrompt('Left');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.power).toBe(4);
             expect(this.mimicGel.armor).toBe(0);
@@ -124,8 +130,8 @@ describe('Mimic Gel', function () {
         it('should copy taunt keyword', function () {
             this.player1.clickCard(this.mimicGel);
             this.player1.clickPrompt('Play this creature');
-            this.player1.clickPrompt('Left');
             this.player1.clickCard(this.titanGuardian);
+            this.player1.clickPrompt('Left');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.hasTrait('shapeshifter')).toBe(false);
             expect(this.mimicGel.hasTrait('beast')).toBe(true);
@@ -143,6 +149,29 @@ describe('Mimic Gel', function () {
             expect(this.player2).toBeAbleToSelect(this.titanGuardian);
             expect(this.player2).not.toBeAbleToSelect(this.batdrone);
             expect(this.player2).not.toBeAbleToSelect(this.tantadlin);
+        });
+
+        it('should copy deploy keyword', function () {
+            this.player1.clickCard(this.mimicGel);
+            this.player1.clickPrompt('Play this creature');
+            this.player1.clickCard(this.lamindra);
+            this.player1.clickPrompt('Deploy Left');
+            this.player1.clickCard(this.tantadlin);
+            expect(this.mimicGel.location).toBe('play area');
+            expect(this.mimicGel.hasTrait('shapeshifter')).toBe(false);
+            expect(this.mimicGel.hasTrait('thief')).toBe(true);
+            expect(this.mimicGel.hasTrait('elf')).toBe(true);
+            expect(this.mimicGel.hasHouse('logos')).toBe(true);
+            expect(this.mimicGel.hasHouse('shadows')).toBe(false);
+            expect(this.mimicGel.getKeywordValue('deploy')).toBe(1);
+            expect(this.mimicGel.getKeywordValue('elusive')).toBe(1);
+            expect(this.mimicGel.neighbors).toContain(this.tantadlin);
+            expect(this.mimicGel.neighbors).toContain(this.batdrone);
+            expect(this.batdrone.getKeywordValue('elusive')).toBe(1);
+            expect(this.tantadlin.getKeywordValue('elusive')).toBe(1);
+            expect(this.mimicGel.power).toBe(1);
+            expect(this.mimicGel.armor).toBe(0);
+            expect(this.mimicGel.name).toBe('Lamindra');
         });
     });
 
@@ -173,32 +202,51 @@ describe('Mimic Gel', function () {
         });
 
         it('should allow copying the same creature', function () {
-            this.player1.play(this.mimicGel1);
+            this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.dustPixie);
-            this.player1.play(this.mimicGel2);
+            this.player1.clickPrompt('Left');
+
+            this.player1.clickCard(this.mimicGel2);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.dustPixie);
+            this.player1.clickPrompt('Left');
+
             expect(this.player1.amber).toBe(4);
             expect(this.player2.amber).toBe(0);
         });
 
         it('should allow copying another owned mimic gel', function () {
-            this.player1.play(this.mimicGel1);
-            this.player1.clickCard(this.dustPixie);
-            this.player1.play(this.mimicGel2);
             this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Play this creature');
+            this.player1.clickCard(this.dustPixie);
+            this.player1.clickPrompt('Left');
+
+            this.player1.clickCard(this.mimicGel2);
+            this.player1.clickPrompt('Play this creature');
+            this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Left');
+
             expect(this.player1.amber).toBe(4);
             expect(this.player2.amber).toBe(0);
         });
 
         it("should allow copying opponent's mimic gel", function () {
-            this.player1.play(this.mimicGel1);
+            this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.dustPixie);
+            this.player1.clickPrompt('Left');
+
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(0);
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel3);
+
+            this.player2.clickCard(this.mimicGel3);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.mimicGel1);
+            this.player2.clickPrompt('Left');
+
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(2);
         });
@@ -206,12 +254,20 @@ describe('Mimic Gel', function () {
         it('should cascade the effects', function () {
             this.player1.amber = 3;
             this.player2.amber = 3;
-            this.player1.play(this.mimicGel1);
+
+            this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.batdrone);
+            this.player1.clickPrompt('Left');
+
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel3);
+
+            this.player2.clickCard(this.mimicGel3);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.mimicGel1);
+            this.player2.clickPrompt('Left');
+
             this.player2.endTurn();
             this.player1.clickPrompt('logos');
             this.player1.fightWith(this.mimicGel1, this.dustPixie);
@@ -244,8 +300,12 @@ describe('Mimic Gel', function () {
             this.player1.clickPrompt('Done');
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel);
+
+            this.player2.clickCard(this.mimicGel);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.niffleKong);
+            this.player2.clickPrompt('Left');
+
             this.player2.clickPrompt('Done');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.power).toBe(12);
@@ -259,8 +319,10 @@ describe('Mimic Gel', function () {
             this.player1.clickPrompt('Done');
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel);
+            this.player2.clickCard(this.mimicGel);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.niffleKong2);
+            this.player2.clickPrompt('Left');
             this.player2.clickPrompt('Done');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.power).toBe(12);
@@ -274,8 +336,10 @@ describe('Mimic Gel', function () {
             this.player1.clickPrompt('Done');
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel);
+            this.player2.clickCard(this.mimicGel);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.niffleKong);
+            this.player2.clickPrompt('Left');
             this.player2.clickPrompt('Done');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.power).toBe(12);
@@ -302,8 +366,10 @@ describe('Mimic Gel', function () {
             this.player1.clickPrompt('Done');
             this.player1.endTurn();
             this.player2.clickPrompt('logos');
-            this.player2.play(this.mimicGel);
+            this.player2.clickCard(this.mimicGel);
+            this.player2.clickPrompt('Play this creature');
             this.player2.clickCard(this.niffleKong2);
+            this.player2.clickPrompt('Left');
             this.player2.clickPrompt('Done');
             expect(this.mimicGel.location).toBe('play area');
             expect(this.mimicGel.power).toBe(12);
@@ -341,8 +407,10 @@ describe('Mimic Gel', function () {
 
             this.daughter.tokens.amber = 5;
 
-            this.player1.play(this.mimicGel);
+            this.player1.clickCard(this.mimicGel);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.praefectusLudo);
+            this.player1.clickPrompt('Left');
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');
         });
@@ -391,11 +459,15 @@ describe('Mimic Gel', function () {
             this.mimicGel1 = this.player1.hand[0];
             this.mimicGel2 = this.player1.hand[1];
 
-            this.player1.play(this.mimicGel1);
-            this.player1.clickCard(this.johnnyLongfingers);
-
-            this.player1.play(this.mimicGel2);
             this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Play this creature');
+            this.player1.clickCard(this.johnnyLongfingers);
+            this.player1.clickPrompt('Left');
+
+            this.player1.clickCard(this.mimicGel2);
+            this.player1.clickPrompt('Play this creature');
+            this.player1.clickCard(this.mimicGel1);
+            this.player1.clickPrompt('Left');
 
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');
@@ -416,6 +488,42 @@ describe('Mimic Gel', function () {
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(5);
             expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+    });
+
+    describe("Ardent Hero's effect and Mimic Gel", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'logos',
+                    amber: 1,
+                    hand: ['mimic-gel']
+                },
+                player2: {
+                    amber: 4,
+                    inPlay: ['ardent-hero', 'champion-anaphiel', 'shooler', 'borr-nit']
+                }
+            });
+
+            this.player1.play(this.mimicGel);
+            this.player1.clickCard(this.ardentHero);
+        });
+
+        it('should not take damage from other cards when defending >5 power creature', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('sanctum');
+            this.player2.fightWith(this.championAnaphiel, this.mimicGel);
+            expect(this.mimicGel.location).toBe('play area');
+            expect(this.mimicGel.tokens.damage).toBeUndefined();
+            expect(this.championAnaphiel.tokens.damage).toBe(3);
+        });
+
+        it('should not take damage from other cards when attacking >5 power creature', function () {
+            this.mimicGel.exhausted = false;
+            this.player1.fightWith(this.mimicGel, this.championAnaphiel);
+            expect(this.mimicGel.location).toBe('play area');
+            expect(this.mimicGel.tokens.damage).toBeUndefined();
+            expect(this.championAnaphiel.tokens.damage).toBe(3);
         });
     });
 });

--- a/test/server/cards/04-MM/Chronus.spec.js
+++ b/test/server/cards/04-MM/Chronus.spec.js
@@ -85,9 +85,11 @@ describe('Chronus', function () {
 
         it('should work with Mimic Gel', function () {
             this.dextre.enhancements = ['draw'];
-
-            this.player1.play(this.mimicGel);
+            this.player1.clickCard(this.mimicGel);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.chronus);
+            this.player1.clickPrompt('Left');
+
             this.player1.play(this.dextre);
             expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toBeAbleToSelect(this.mimicGel);

--- a/test/server/cards/04-MM/CyberClone.spec.js
+++ b/test/server/cards/04-MM/CyberClone.spec.js
@@ -86,8 +86,10 @@ describe('Cyber-Clone', function () {
         });
 
         it('should purge and clone Mimic Gel', function () {
-            this.player1.play(this.mimicGel);
+            this.player1.clickCard(this.mimicGel);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.groupthinkTank);
+            this.player1.clickPrompt('Left');
             this.player1.play(this.cyberClone);
             this.player1.clickCard(this.mimicGel);
             expect(this.mimicGel.location).toBe('purged');

--- a/test/server/cards/04-MM/ThePaleStar.spec.js
+++ b/test/server/cards/04-MM/ThePaleStar.spec.js
@@ -85,8 +85,10 @@ describe('The Pale Star', function () {
         });
 
         it('should reduce power and armor of Mimic Gel and Cyber Clone', function () {
-            this.player1.play(this.mimicGel);
+            this.player1.clickCard(this.mimicGel);
+            this.player1.clickPrompt('Play this creature');
             this.player1.clickCard(this.wrath);
+            this.player1.clickPrompt('Right');
             this.player1.play(this.cyberClone);
             this.player1.clickCard(this.wrath);
             expect(this.wrath.location).toBe('purged');


### PR DESCRIPTION
Also fixes cards that did not go well with Mimic Gel due to $this: Lamindra and Ardent Hero
(Possibly fixes MG and Scowly Caper, but needs validation)
Fixes #2178