### PR TITLE
updated Selective Preservation to prompt for each power

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -583,5 +583,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Selecione uma criatura para expurgar",
     "Exalt, ready and use": "Exaltar, preparar e usar",
-    "Move 1 amber": "Mover 1 amber"
+    "Move 1 amber": "Mover 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/th.json
+++ b/public/locales/th.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/zhhans.json
+++ b/public/locales/zhhans.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/public/locales/zhhant.json
+++ b/public/locales/zhhant.json
@@ -592,5 +592,6 @@
     "Choose a creature of each power value to not destroy": "Choose a creature of each power value to not destroy",
     "Choose a creature to purge": "Choose a creature to purge",
     "Exalt, ready and use": "Exalt, ready and use",
-    "Move 1 amber": "Move 1 amber"
+    "Move 1 amber": "Move 1 amber",
+    "Select creatures for each power to not destroy.": "Select creatures for each power to not destroy."
 }

--- a/server/game/cards/05-DT/SelectivePreservation.js
+++ b/server/game/cards/05-DT/SelectivePreservation.js
@@ -3,20 +3,44 @@ const Card = require('../../Card.js');
 class SelectivePreservation extends Card {
     setupCardAbilities(ability) {
         this.play({
-            target: {
-                activePromptTitle: 'Choose a creature of each power value to not destroy',
-                cardType: 'creature',
-                mode: 'exactly',
-                numCards: (context) =>
-                    new Set(context.game.creaturesInPlay.map((card) => card.power)).size,
-                selectorCondition: (selectedCards, context) =>
-                    new Set(context.game.creaturesInPlay.map((card) => card.power)).size ===
-                    new Set(selectedCards.map((card) => card.power)).size,
-                gameAction: ability.actions.destroy((context) => ({
-                    target: context.game.creaturesInPlay.filter(
-                        (card) => context.target && !context.target.includes(card)
+            effect: 'Select creatures for each power to not destroy.',
+
+            then: (preThenContext) => {
+                let unqiuePowers = Array.from(
+                    new Set(
+                        preThenContext.game.creaturesInPlay.map((creature) =>
+                            creature.getPower(false)
+                        )
                     )
-                }))
+                );
+                unqiuePowers.sort((a, b) => (a > b ? 1 : -1));
+
+                let targets = [];
+                for (let i = 0; i < unqiuePowers.length; i++) {
+                    let power = unqiuePowers[i];
+                    let targetKey = 'power' + power;
+                    targets[targetKey] = {
+                        activePromptTitle: {
+                            text: 'Choose a {{power}} creature to not destroy',
+                            values: { power: power }
+                        },
+                        cardType: 'creature',
+                        numCards: 1,
+                        cardCondition: (card) => card.getPower(false) === power,
+                        gameAction: ability.actions.destroy((context) => ({
+                            target: context.game.creaturesInPlay.filter(
+                                (card) =>
+                                    context.targets[targetKey] !== card &&
+                                    card.getPower(false) === power
+                            )
+                        }))
+                    };
+                }
+
+                return {
+                    alwaysTriggers: true,
+                    targets: targets
+                };
             }
         });
     }

--- a/test/server/cards/05-DT/SelectivePreservation.spec.js
+++ b/test/server/cards/05-DT/SelectivePreservation.spec.js
@@ -25,6 +25,7 @@ describe('Selective Preservation', function () {
             this.player1.moveCard(this.scoutPete, 'play area');
             expect(this.scoutPete.location).toBe('play area');
             this.player1.play(this.selectivePreservation);
+
             this.player1.endTurn();
             expect(this.scoutPete.location).toBe('play area');
         });
@@ -59,13 +60,13 @@ describe('Selective Preservation', function () {
 
             this.player1.play(this.selectivePreservation);
 
-            expect(this.player1).toBeAbleToSelect(this.scoutPete);
-            expect(this.player1).toBeAbleToSelect(this.flamewakeShaman);
             expect(this.player1).toBeAbleToSelect(this.chiefEngineerWalls);
             expect(this.player1).toBeAbleToSelect(this.bingleBangbang);
-            this.player1.clickCard(this.scoutPete);
             this.player1.clickCard(this.bingleBangbang);
-            this.player1.clickPrompt('Done');
+
+            expect(this.player1).toBeAbleToSelect(this.scoutPete);
+            expect(this.player1).toBeAbleToSelect(this.flamewakeShaman);
+            this.player1.clickCard(this.scoutPete);
 
             this.player1.endTurn();
             expect(this.scoutPete.location).toBe('play area');


### PR DESCRIPTION
This pr updates Selective Preservation to prompt for each unique power level, instead of all creatures at once.

Note, I added the ```effect: 'Select creatures for each power to not destroy.',``` so that I could have a no-op for the pre-then block.