### PR TITLE
update deck selection modal to refresh after deck is selected.

### DIFF
--- a/client/Components/Decks/DeckList.jsx
+++ b/client/Components/Decks/DeckList.jsx
@@ -140,6 +140,14 @@ const DeckList = ({ onDeckSelected, standaloneDecks = false }) => {
     const rowEvents = {
         onClick: (event, deck) => {
             onDeckSelected && onDeckSelected(deck);
+
+            // reset the form, so the next time it is
+            // loaded it is in the starting postiion
+            nameFilter.current('');
+            expansionFilter.current([]);
+            let newPageData = Object.assign({}, pagingDetails);
+            newPageData.page = 1;
+            setPagingDetails(newPageData);
         }
     };
 


### PR DESCRIPTION
With this PR I'm trying to fix an annoying issue that happens on deck selection.

What happens is this:
1) Select a deck for a game.
2) Play game.
3) Start a new game.
4) Press button to select deck
5) On the screen, see the deck you want to play (the one you selected last time).
6) Try to click on the deck - but just as you click, the deck selection screen refreshes.
7) The deck you ended up clicking on was some random deck from your collection.
8) Opponent eager to start the game, presses start game, and you end up playing some random deck from your collection.

With this PR, I'm trying to reset the deck selection component after the deck is selected:
* resetting the name filter
* resetting the expansion filter
* resetting the pagination

This way, the next time the deck selection button is pressed there is no step 5 above (you never see the deck you wanted to play pop up quickly).
