### PR TITLE
update MoveToBottomAction to determine player using card.owner

### DIFF
--- a/server/game/GameActions/MoveToBottomAction.js
+++ b/server/game/GameActions/MoveToBottomAction.js
@@ -3,7 +3,6 @@ const CardGameAction = require('./CardGameAction');
 class MoveToBottomAction extends CardGameAction {
     constructor(propertyFactory) {
         super(propertyFactory);
-        this.targetPlayer = 'current';
     }
 
     setDefaultProperties() {}
@@ -15,13 +14,9 @@ class MoveToBottomAction extends CardGameAction {
     }
 
     getEvent(card, context) {
-        const targetPlayerForEffect = this.targetPlayer;
-
         return super.createEvent('unnamedEvent', { card: card, context: context }, () => {
-            let targetPlayer =
-                targetPlayerForEffect === 'current' ? context.player : context.player.opponent;
-            targetPlayer.deck = targetPlayer.deck.filter((c) => c !== card);
-            targetPlayer.deck.push(card);
+            card.owner.deck = card.owner.deck.filter((c) => c !== card);
+            card.owner.deck.push(card);
         });
     }
 }

--- a/server/game/cards/05-DT/DrawnByTheDepths.js
+++ b/server/game/cards/05-DT/DrawnByTheDepths.js
@@ -13,7 +13,6 @@ class DrawnByTheDepths extends Card {
                     }
                 })),
                 ability.actions.moveToBottom((context) => ({
-                    targetPlayer: (context) => context.player.opponent,
                     promptWithHandlerMenu: {
                         activePromptTitle: 'Choose a card to move to bottom of deck',
                         cards: context.player.opponent.deck.slice(0, 2),


### PR DESCRIPTION
In this PR I've updated MoveToBottomAction to determine which players deck to update based on the owner of the card being moved. This makes sense since moving a card to bottom of a deck implies the card should stay in the same deck. 

From feedback in this PR;
https://github.com/keyteki/keyteki/pull/2370

(Great idea Romano)