### PR TITLE
fix for issue 2427

### DIFF
--- a/server/game/cards/05-DT/GrandAllianceCouncil.js
+++ b/server/game/cards/05-DT/GrandAllianceCouncil.js
@@ -14,22 +14,17 @@ class GrandAllianceCouncil extends Card {
                 },
                 cardType: 'creature',
                 numCards: 1,
-                cardCondition: (card) => card.hasHouse(house),
-                gameAction: ability.actions.destroy((context) => ({
-                    target: context.game.creaturesInPlay.filter(
-                        // don't kill the creature that was targeted, and don't kill a creature who only had 1 creature from that house
-                        (card) =>
-                            context.targets[house] !== card &&
-                            card.hasHouse(house) &&
-                            context.game.creaturesInPlay.filter((card) => card.hasHouse(house))
-                                .length > 1
-                    )
-                }))
+                cardCondition: (card) => card.hasHouse(house)
             };
         }
 
         this.play({
-            targets: targets
+            targets: targets,
+            gameAction: ability.actions.destroy((context) => ({
+                target: context.game.creaturesInPlay.filter(
+                    (creatureToKill) => !Object.values(context.targets).includes(creatureToKill)
+                )
+            }))
         });
     }
 }

--- a/server/game/cards/05-DT/GrandAllianceCouncil.js
+++ b/server/game/cards/05-DT/GrandAllianceCouncil.js
@@ -17,7 +17,12 @@ class GrandAllianceCouncil extends Card {
                 cardCondition: (card) => card.hasHouse(house),
                 gameAction: ability.actions.destroy((context) => ({
                     target: context.game.creaturesInPlay.filter(
-                        (card) => context.targets[house] !== card && card.hasHouse(house)
+                        // don't kill the creature that was targeted, and don't kill a creature who only had 1 creature from that house
+                        (card) =>
+                            context.targets[house] !== card &&
+                            card.hasHouse(house) &&
+                            context.game.creaturesInPlay.filter((card) => card.hasHouse(house))
+                                .length > 1
                     )
                 }))
             };

--- a/test/server/cards/05-DT/GrandAllianceCouncil.spec.js
+++ b/test/server/cards/05-DT/GrandAllianceCouncil.spec.js
@@ -5,7 +5,13 @@ describe('Grand Alliance Council', function () {
                 player1: {
                     house: 'staralliance',
                     amber: 1,
-                    hand: ['grand-alliance-council', 'stealthster', 'dust-pixie', 'dharna'],
+                    hand: [
+                        'grand-alliance-council',
+                        'stealthster',
+                        'dust-pixie',
+                        'dharna',
+                        'dextre'
+                    ],
                     inPlay: []
                 },
                 player2: {
@@ -82,22 +88,33 @@ describe('Grand Alliance Council', function () {
             this.player1.moveCard(this.dharna, 'play area');
             this.player1.moveCard(this.stealthster, 'play area');
             this.player2.moveCard(this.scoutPete, 'play area');
+            this.player1.moveCard(this.dextre, 'play area');
 
             expect(this.dharna.location).toBe('play area');
             expect(this.stealthster.location).toBe('play area');
             expect(this.scoutPete.location).toBe('play area');
+            expect(this.dextre.location).toBe('play area');
 
             this.player1.play(this.grandAllianceCouncil);
 
+            expect(this.player1).toHavePrompt('Choose a Logos creature to not destroy');
+            expect(this.player1).toBeAbleToSelect(this.dextre);
+            this.player1.clickCard(this.dextre);
+
+            expect(this.player1).toHavePrompt('Choose a Star Alliance creature to not destroy');
             expect(this.player1).toBeAbleToSelect(this.stealthster);
             expect(this.player1).toBeAbleToSelect(this.scoutPete);
-            expect(this.player1).toHavePrompt('Choose a Star Alliance creature to not destroy');
             this.player1.clickCard(this.scoutPete);
+
+            expect(this.player1).toHavePrompt('Choose a Untamed creature to not destroy');
+            expect(this.player1).toBeAbleToSelect(this.dharna);
+            this.player1.clickCard(this.dharna);
 
             this.player1.endTurn();
             expect(this.dharna.location).toBe('play area');
             expect(this.stealthster.location).toBe('discard');
             expect(this.scoutPete.location).toBe('play area');
+            expect(this.dextre.location).toBe('play area');
         });
     });
 });

--- a/test/server/cards/05-DT/GrandAllianceCouncil.spec.js
+++ b/test/server/cards/05-DT/GrandAllianceCouncil.spec.js
@@ -21,16 +21,6 @@ describe('Grand Alliance Council', function () {
             this.player1.endTurn();
         });
 
-        xit('should prompt to not kill a single creature to not kill and leave them alive', function () {
-            this.player1.moveCard(this.stealthster, 'play area');
-            this.player1.play(this.grandAllianceCouncil);
-            expect(this.player1).toHavePrompt('Choose a Star Alliance creature to not destroy');
-            this.player1.clickCard(this.stealthster);
-
-            this.player1.endTurn();
-            expect(this.stealthster.location).toBe('play area');
-        });
-
         it('should prompt to not kill a single creature and kill the rest', function () {
             this.player1.moveCard(this.stealthster, 'play area');
             this.player2.moveCard(this.scoutPete, 'play area');
@@ -86,6 +76,28 @@ describe('Grand Alliance Council', function () {
             expect(this.stealthster.location).toBe('discard');
             expect(this.scoutPete.location).toBe('play area');
             expect(this.subjectKirby.location).toBe('discard');
+        });
+
+        it('should should not kill creatures who are the only ones from their house', function () {
+            this.player1.moveCard(this.dharna, 'play area');
+            this.player1.moveCard(this.stealthster, 'play area');
+            this.player2.moveCard(this.scoutPete, 'play area');
+
+            expect(this.dharna.location).toBe('play area');
+            expect(this.stealthster.location).toBe('play area');
+            expect(this.scoutPete.location).toBe('play area');
+
+            this.player1.play(this.grandAllianceCouncil);
+
+            expect(this.player1).toBeAbleToSelect(this.stealthster);
+            expect(this.player1).toBeAbleToSelect(this.scoutPete);
+            expect(this.player1).toHavePrompt('Choose a Star Alliance creature to not destroy');
+            this.player1.clickCard(this.scoutPete);
+
+            this.player1.endTurn();
+            expect(this.dharna.location).toBe('play area');
+            expect(this.stealthster.location).toBe('discard');
+            expect(this.scoutPete.location).toBe('play area');
         });
     });
 });


### PR DESCRIPTION
fixes the issue reported here: https://github.com/keyteki/keyteki/issues/2427

I fixed this by making it so that creatures can't be targeted for destruction if there is only 1 creature of that house in play, with this in the filter:

`context.game.creaturesInPlay.filter((card) => card.hasHouse(house)).length > 1`