### PR TITLE
fixed hand cannon

### DIFF
--- a/server/game/cards/05-DT/HandCannon.js
+++ b/server/game/cards/05-DT/HandCannon.js
@@ -7,13 +7,13 @@ class HandCannon extends Card {
             effect: [
                 ability.effects.addKeyword({ skirmish: 1 }),
                 ability.effects.gainAbility('fight', {
-                    condition: (context) => context.source.amber > 0,
-                    gameAction: ability.actions.placeAmber((context) => ({
-                        target: context.event.card
-                    })),
-                    then: {
-                        gameAction: ability.actions.removeAmber()
-                    },
+                    condition: (context) => context.event.card.amber > 0,
+                    gameAction: ability.actions.gainAmber(),
+                    then: (context) => ({
+                        gameAction: ability.actions.removeAmber({
+                            target: context.event.card
+                        })
+                    }),
                     effect: 'move 1 amber from {0} to {1}',
                     effectArgs: (context) => context.event.card
                 })

--- a/test/server/cards/05-DT/HandCannon.spec.js
+++ b/test/server/cards/05-DT/HandCannon.spec.js
@@ -3,39 +3,58 @@ describe('Hand Cannon', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
-                    amber: 3,
+                    amber: 2,
                     house: 'shadows',
-                    inPlay: ['lamindra'],
+                    inPlay: ['lamindra', 'gas-pipes-malone'],
                     hand: ['hand-cannon']
                 },
                 player2: {
-                    inPlay: ['dust-imp', 'dew-faerie', 'toad']
+                    inPlay: ['dust-imp', 'dew-faerie', 'toad', 'mother']
                 }
             });
-
-            this.lamindra.tokens.amber = 2;
-            this.player1.playUpgrade(this.handCannon, this.lamindra);
         });
 
         it('should gain skirmish while attached', function () {
+            this.player1.playUpgrade(this.handCannon, this.lamindra);
             expect(this.lamindra.getKeywordValue('skirmish')).toBe(1);
         });
 
-        it('should move 1A to opponent after fight', function () {
-            this.player1.fightWith(this.lamindra, this.dustImp);
-            expect(this.lamindra.amber).toBe(1);
-            expect(this.dustImp.amber).toBe(1);
-            expect(this.player1.amber).toBe(4);
-            expect(this.player2.amber).toBe(0);
+        it('should move 1A from target of fight to the player pool', function () {
+            this.player1.playUpgrade(this.handCannon, this.lamindra);
+
+            this.player1.amber = 2;
+            this.player2.amber = 2;
+            this.mother.tokens.amber = 2;
+
+            expect(this.mother.amber).toBe(2);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+
+            this.player1.fightWith(this.lamindra, this.mother);
+
+            expect(this.mother.amber).toBe(1);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(2);
+
             this.player1.endTurn();
         });
 
-        it('should not move 1A the defender creature, if it is destroyed', function () {
-            this.player1.fightWith(this.lamindra, this.toad);
-            expect(this.lamindra.amber).toBe(2);
-            expect(this.toad.location).toBe('discard');
-            expect(this.player1.amber).toBe(4);
-            expect(this.player2.amber).toBe(0);
+        it('should take amber away that is placed there on a creature before the fight', function () {
+            this.player1.playUpgrade(this.handCannon, this.gasPipesMalone);
+
+            this.player1.amber = 2;
+            this.player2.amber = 2;
+
+            expect(this.mother.amber).toBe(0);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+
+            this.player1.fightWith(this.gasPipesMalone, this.mother);
+
+            expect(this.mother.amber).toBe(0);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(1);
+
             this.player1.endTurn();
         });
     });


### PR DESCRIPTION
fixed hand cannon per issue here:
https://github.com/keyteki/keyteki/issues/2489

The old impl was moving amber off of the creature being used to fight - the text says to move the amber off of the target.

`This creature gains skirmish and, "Fight: Move 1AE from the creature this creature fights to your pool."`
https://decksofkeyforge.com/cards/hand-cannon