### PR TITLE
Add option to choose first player

### DIFF
--- a/client/Components/Games/GameOptions.jsx
+++ b/client/Components/Games/GameOptions.jsx
@@ -12,7 +12,8 @@ const GameOptions = ({ formProps }) => {
         { name: 'muteSpectators', label: t('Mute spectators') },
         { name: 'useGameTimeLimit', label: t('Use a time limit (in minutes)') },
         { name: 'gamePrivate', label: t('Private (requires game link)') },
-        { name: 'hideDeckLists', label: t('Hide deck lists') }
+        { name: 'hideDeckLists', label: t('Hide deck lists') },
+        { name: 'chooseFirst', label: t('Opponent chooses first player') }
     ];
 
     return (

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -70,6 +70,7 @@ class Game extends EventEmitter {
         this.swap = details.swap;
         this.timeLimit = new TimeLimit(this);
         this.useGameTimeLimit = details.useGameTimeLimit;
+        this.chooseFirst = details.chooseFirst;
 
         this.cardsUsed = [];
         this.omegaCard = null;

--- a/server/game/gamesteps/setup/FirstPlayerSelection.js
+++ b/server/game/gamesteps/setup/FirstPlayerSelection.js
@@ -5,12 +5,19 @@ class FirstPlayerSelection extends AllPlayerPrompt {
     constructor(game) {
         super(game);
         this.previousWinner = game.previousWinner;
+        this.chooseFirst = game.chooseFirst;
+        this.owner = game.owner;
         this.clickedButton = false;
         this.players = game.getPlayers();
     }
 
     completionCondition(player) {
-        return this.previousWinner === player.name || !this.previousWinner || this.clickedButton;
+        return (
+            this.previousWinner === player.name ||
+            (!this.previousWinner && !this.chooseFirst) ||
+            this.clickedButton ||
+            (this.chooseFirst && this.owner === player.name)
+        );
     }
 
     activePrompt() {

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -32,6 +32,7 @@ class PendingGame {
         this.useGameTimeLimit = details.useGameTimeLimit;
         this.rematch = false;
         this.tournament = details.tournament;
+        this.chooseFirst = details.chooseFirst;
     }
 
     // Getters
@@ -370,7 +371,8 @@ class PendingGame {
                     avatar: spectator.user.avatar
                 };
             }),
-            useGameTimeLimit: this.useGameTimeLimit
+            useGameTimeLimit: this.useGameTimeLimit,
+            chooseFirst: this.chooseFirst
         };
     }
 
@@ -417,7 +419,8 @@ class PendingGame {
             spectators,
             started: this.started,
             swap: this.swap,
-            useGameTimeLimit: this.useGameTimeLimit
+            useGameTimeLimit: this.useGameTimeLimit,
+            chooseFirst: this.chooseFirst
         };
     }
 }


### PR DESCRIPTION
Reason: during BO3 tournament games this option needed to choose first player for 2nd and 3rd game, because rematch don't allow spectators and even if rematch works, sometimes games are interrupted. need way to choose first player. 

Idea: make checkbox that allow your opponent to choose first player. This way we exclude abuse from game creator because if they mark this checkbox in random game, they give advantage to opponent, not to them. in tournament game, opponent just will choose correct player or winner will create game 2