### PR TITLE
Fix issue #2586

### DIFF
--- a/server/game/cards/03-WC/BlasterCard.js
+++ b/server/game/cards/03-WC/BlasterCard.js
@@ -34,11 +34,42 @@ class BlasterCard extends Card {
         return result;
     }
 
+    getDefaultAbility(ability) {
+        let choices = {
+            'Deal 2 damage': () => true
+        };
+
+        let result = {
+            optional: true,
+            targets: {
+                action: {
+                    mode: 'select',
+                    choices: choices
+                },
+                'Deal 2 damage': {
+                    dependsOn: 'action',
+                    cardType: 'creature',
+                    gameAction: ability.actions.dealDamage({ amount: 2 })
+                }
+            }
+        };
+
+        return result;
+    }
+
     setupBlasterCardAbilities(ability, creatureName) {
         this.whileAttached({
+            match: (card) => card.name !== creatureName,
             effect: [
                 ability.effects.gainAbility('reap', this.getAttachedAbility(ability, creatureName)),
                 ability.effects.gainAbility('fight', this.getAttachedAbility(ability, creatureName))
+            ]
+        });
+        this.whileAttached({
+            match: (card) => card.name === creatureName,
+            effect: [
+                ability.effects.gainAbility('reap', this.getDefaultAbility(ability)),
+                ability.effects.gainAbility('fight', this.getDefaultAbility(ability))
             ]
         });
     }


### PR DESCRIPTION
This is to fix https://github.com/keyteki/keyteki/issues/2586

I tried just doing it with one function, but figured this was better because you can see that you are about to do 2 damage in the logs, so less likely to accidentally damage your own creature.

This failed the tests because I didn't want to update the tests for the blasters without approval/confirmation.