### PR TITLE
Costs: paying w/ effects & effect selection prompt

### DIFF
--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -138,7 +138,7 @@ const Costs = {
                         !context.game.effectsUsed.includes(effect)
                 );
 
-                let effect = effects.find((effect) => {
+                let matchedEffects = effects.filter((effect) => {
                     let value = effect.getValue(context.player);
                     if (value.condition && !value.condition(context.source)) {
                         return false;
@@ -154,8 +154,22 @@ const Costs = {
                     );
                 });
 
-                if (effect) {
-                    context.game.effectUsed(effect);
+                if (matchedEffects.length === 1) {
+                    context.game.effectUsed(matchedEffects[0]);
+                    return true;
+                } else if (matchedEffects.length > 1) {
+                    const choices = matchedEffects.map(
+                        (effect) => effect.context.source.cardData.name
+                    );
+                    const handlers = matchedEffects.map((effect) => () => {
+                        context.game.effectUsed(effect);
+                    });
+                    context.game.promptWithHandlerMenu(context.player, {
+                        activePromptTitle: 'Choose an ability:',
+                        source: context.source,
+                        choices,
+                        handlers
+                    });
                     return true;
                 } else if (
                     context.player

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -154,7 +154,14 @@ const Costs = {
                     );
                 });
 
-                if (matchedEffects.length === 1) {
+                if (
+                    matchedEffects.length === 1 ||
+                    (matchedEffects.length > 0 &&
+                        matchedEffects.every(
+                            (effect) =>
+                                effect.context.source.id === matchedEffects[0].context.source.id
+                        ))
+                ) {
                     context.game.effectUsed(matchedEffects[0]);
                     return true;
                 } else if (matchedEffects.length > 1) {

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -85,11 +85,6 @@ const Costs = {
             ) {
                 return false;
             } else if (
-                context.source.hasHouse(context.player.activeHouse) &&
-                !context.player.anyEffect('noActiveHouseForPlay')
-            ) {
-                return true;
-            } else if (
                 context.ignoreHouse ||
                 context.player.getEffects('canPlay').some((match) => match(context.source, context))
             ) {
@@ -103,19 +98,34 @@ const Costs = {
                     !context.game.effectsUsed.includes(effect)
             );
 
-            return effects.some((effect) => {
-                let value = effect.getValue(context.player);
-                if (value.condition && !value.condition(context.source)) {
-                    return false;
-                } else if (value.house) {
-                    value = value.house;
-                }
+            if (
+                effects.some((effect) => {
+                    let value = effect.getValue(context.player);
+                    if (value.condition && !value.condition(context.source)) {
+                        return false;
+                    } else if (value.house) {
+                        value = value.house;
+                    }
 
-                return (
-                    (HousePlayEffects.includes(effect.type) && context.source.hasHouse(value)) ||
-                    (NonHousePlayEffects.includes(effect.type) && !context.source.hasHouse(value))
-                );
-            });
+                    return (
+                        (HousePlayEffects.includes(effect.type) &&
+                            context.source.hasHouse(value)) ||
+                        (NonHousePlayEffects.includes(effect.type) &&
+                            !context.source.hasHouse(value))
+                    );
+                })
+            ) {
+                return true;
+            }
+
+            if (
+                context.source.hasHouse(context.player.activeHouse) &&
+                !context.player.anyEffect('noActiveHouseForPlay')
+            ) {
+                return true;
+            }
+
+            return false;
         },
         payEvent: (context) =>
             context.game.getEvent('unnamedEvent', {}, () => {
@@ -125,8 +135,6 @@ const Costs = {
                         .getEffects('canPlay')
                         .some((match) => match(context.source, context))
                 ) {
-                    return true;
-                } else if (context.source.hasHouse(context.player.activeHouse)) {
                     return true;
                 }
 
@@ -155,6 +163,10 @@ const Costs = {
 
                 if (effect) {
                     context.game.effectUsed(effect);
+                    return true;
+                }
+
+                if (context.source.hasHouse(context.player.activeHouse)) {
                     return true;
                 }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -84,10 +84,7 @@ const Costs = {
                     .filter((card) => card.name === context.source.name).length >= 6
             ) {
                 return false;
-            } else if (
-                context.ignoreHouse ||
-                context.player.getEffects('canPlay').some((match) => match(context.source, context))
-            ) {
+            } else if (context.ignoreHouse) {
                 return true;
             }
 
@@ -116,11 +113,12 @@ const Costs = {
                 })
             ) {
                 return true;
-            }
-
-            if (
-                context.source.hasHouse(context.player.activeHouse) &&
-                !context.player.anyEffect('noActiveHouseForPlay')
+            } else if (
+                context.player
+                    .getEffects('canPlay')
+                    .some((match) => match(context.source, context)) ||
+                (context.source.hasHouse(context.player.activeHouse) &&
+                    !context.player.anyEffect('noActiveHouseForPlay'))
             ) {
                 return true;
             }
@@ -129,12 +127,7 @@ const Costs = {
         },
         payEvent: (context) =>
             context.game.getEvent('unnamedEvent', {}, () => {
-                if (
-                    context.ignoreHouse ||
-                    context.player
-                        .getEffects('canPlay')
-                        .some((match) => match(context.source, context))
-                ) {
+                if (context.ignoreHouse) {
                     return true;
                 }
 
@@ -164,9 +157,12 @@ const Costs = {
                 if (effect) {
                     context.game.effectUsed(effect);
                     return true;
-                }
-
-                if (context.source.hasHouse(context.player.activeHouse)) {
+                } else if (
+                    context.player
+                        .getEffects('canPlay')
+                        .some((match) => match(context.source, context)) ||
+                    context.source.hasHouse(context.player.activeHouse)
+                ) {
                     return true;
                 }
 

--- a/test/server/cards/01-Core/PhaseShift.spec.js
+++ b/test/server/cards/01-Core/PhaseShift.spec.js
@@ -27,6 +27,8 @@ describe('Phase Shift', function () {
             expect(this.player1.amber).toBe(0);
             expect(this.player1).toBeAbleToPlay(this.virtuousWorks);
             this.player1.play(this.virtuousWorks);
+            // Should not prompt to choose between duplicate play allowance effects.
+            expect(this.player1).not.toHavePrompt('Choose a play allowance ability:');
             expect(this.player1.amber).toBe(3);
             this.player1.play(this.punch);
             expect(this.player1).toHavePrompt('Punch');

--- a/test/server/cards/02-AoA/HelperBot.spec.js
+++ b/test/server/cards/02-AoA/HelperBot.spec.js
@@ -52,4 +52,22 @@ describe('Helper Bot', function () {
             expect(this.player1).toHavePrompt('Punch');
         });
     });
+    describe("Helper Bot's ability in a non-Logos turn", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['exhume', 'shooler', 'abond-the-armorsmith'],
+                    discard: ['helper-bot']
+                }
+            });
+        });
+
+        it('should be used up by playing a non-Logos card of the active house', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.helperBot);
+            this.player1.play(this.shooler);
+            expect(this.player1).not.toBeAbleToPlay(this.abondTheArmorsmith);
+        });
+    });
 });

--- a/test/server/cards/02-AoA/HelperBot.spec.js
+++ b/test/server/cards/02-AoA/HelperBot.spec.js
@@ -57,7 +57,14 @@ describe('Helper Bot', function () {
             this.setupTest({
                 player1: {
                     house: 'dis',
-                    hand: ['exhume', 'shooler', 'abond-the-armorsmith'],
+                    inPlay: ['matter-maker'],
+                    hand: [
+                        'exhume',
+                        'shooler',
+                        'armsmaster-molina',
+                        'soulkeeper',
+                        'light-of-the-archons'
+                    ],
                     discard: ['helper-bot']
                 }
             });
@@ -67,7 +74,21 @@ describe('Helper Bot', function () {
             this.player1.play(this.exhume);
             this.player1.clickCard(this.helperBot);
             this.player1.play(this.shooler);
-            expect(this.player1).not.toBeAbleToPlay(this.abondTheArmorsmith);
+            expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
+        });
+
+        it('should be used up even if the card played is permitted by another effect and of the active house', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.helperBot);
+            this.player1.playUpgrade(this.soulkeeper, this.helperBot);
+            expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
+        });
+
+        it('should be used up even if the card played is permitted by another effect', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.helperBot);
+            this.player1.playUpgrade(this.lightOfTheArchons, this.helperBot);
+            expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
         });
     });
 });

--- a/test/server/cards/02-AoA/HelperBot.spec.js
+++ b/test/server/cards/02-AoA/HelperBot.spec.js
@@ -52,12 +52,12 @@ describe('Helper Bot', function () {
             expect(this.player1).toHavePrompt('Punch');
         });
     });
+
     describe("Helper Bot's ability in a non-Logos turn", function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
                     house: 'dis',
-                    inPlay: ['matter-maker'],
                     hand: [
                         'exhume',
                         'shooler',
@@ -74,20 +74,6 @@ describe('Helper Bot', function () {
             this.player1.play(this.exhume);
             this.player1.clickCard(this.helperBot);
             this.player1.play(this.shooler);
-            expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
-        });
-
-        it('should be used up even if the card played is permitted by another effect and of the active house', function () {
-            this.player1.play(this.exhume);
-            this.player1.clickCard(this.helperBot);
-            this.player1.playUpgrade(this.soulkeeper, this.helperBot);
-            expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
-        });
-
-        it('should be used up even if the card played is permitted by another effect', function () {
-            this.player1.play(this.exhume);
-            this.player1.clickCard(this.helperBot);
-            this.player1.playUpgrade(this.lightOfTheArchons, this.helperBot);
             expect(this.player1).not.toBeAbleToPlay(this.armsmasterMolina);
         });
     });

--- a/test/server/cards/03-WC/CaptainValJericho.spec.js
+++ b/test/server/cards/03-WC/CaptainValJericho.spec.js
@@ -72,4 +72,26 @@ describe('Captain Val Jericho', function () {
             expect(this.player1).toBeAbleToPlay(this.alakaSBrew);
         });
     });
+
+    describe("Captain Val Jericho's and Com. Officer Kirby's abilities stacking", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'staralliance',
+                    inPlay: ['chief-engineer-walls', 'captain-val-jericho', 'com-officer-kirby'],
+                    hand: ['alaka', 'alaka-s-brew']
+                }
+            });
+        });
+
+        it('should be prompted to choose between abilities when both apply', function () {
+            this.player1.reap(this.comOfficerKirby);
+            this.player1.clickCard(this.alakaSBrew);
+            expect(this.player1).toHavePrompt('Play Alaka’s Brew:');
+            this.player1.clickPrompt('Play this action');
+            expect(this.player1).toHavePrompt('Choose an ability:');
+            this.player1.clickPrompt('Com. Officer Kirby');
+            expect(this.player1).toBeAbleToPlay(this.alaka);
+        });
+    });
 });

--- a/test/server/cards/03-WC/CaptainValJericho.spec.js
+++ b/test/server/cards/03-WC/CaptainValJericho.spec.js
@@ -65,7 +65,7 @@ describe('Captain Val Jericho', function () {
             });
         });
 
-        it('should not be used up by playing non-Star Alliance card of the active house', function () {
+        it('should not be used up by playing a card of the active house', function () {
             this.player1.play(this.exhume);
             this.player1.clickCard(this.captainValJericho);
             this.player1.playUpgrade(this.soulkeeper, this.captainValJericho);

--- a/test/server/cards/03-WC/CaptainValJericho.spec.js
+++ b/test/server/cards/03-WC/CaptainValJericho.spec.js
@@ -89,7 +89,7 @@ describe('Captain Val Jericho', function () {
             this.player1.clickCard(this.alakaSBrew);
             expect(this.player1).toHavePrompt('Play Alaka’s Brew:');
             this.player1.clickPrompt('Play this action');
-            expect(this.player1).toHavePrompt('Choose an ability:');
+            expect(this.player1).toHavePrompt('Choose a play allowance ability:');
             this.player1.clickPrompt('Com. Officer Kirby');
             expect(this.player1).toBeAbleToPlay(this.alaka);
         });

--- a/test/server/cards/03-WC/CaptainValJericho.spec.js
+++ b/test/server/cards/03-WC/CaptainValJericho.spec.js
@@ -53,4 +53,23 @@ describe('Captain Val Jericho', function () {
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });
+
+    describe("Captain Val Jericho's ability on a non-Star Alliance turn", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['exhume', 'soulkeeper', 'alaka-s-brew'],
+                    discard: ['captain-val-jericho']
+                }
+            });
+        });
+
+        it('should not be used up by playing non-Star Alliance card of the active house', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.captainValJericho);
+            this.player1.playUpgrade(this.soulkeeper, this.captainValJericho);
+            expect(this.player1).toBeAbleToPlay(this.alakaSBrew);
+        });
+    });
 });

--- a/test/server/cards/03-WC/ComOfficerKirby.spec.js
+++ b/test/server/cards/03-WC/ComOfficerKirby.spec.js
@@ -93,14 +93,14 @@ describe('Com. Officer Kirby', function () {
             });
         });
 
-        it('should be used up by playing non-Star Alliance upgrade of the active house', function () {
+        it('should be used up by playing a non-Star Alliance upgrade of the active house', function () {
             this.player1.play(this.exhume);
             this.player1.clickCard(this.comOfficerKirby);
             this.player1.playUpgrade(this.soulkeeper, this.comOfficerKirby);
             expect(this.player1).not.toBeAbleToPlay(this.alakaSBrew);
         });
 
-        it('should not be used up by playing non-Star Alliance creature of the active house', function () {
+        it('should not be used up by playing a non-Star Alliance creature of the active house', function () {
             this.player1.play(this.exhume);
             this.player1.clickCard(this.comOfficerKirby);
             this.player1.play(this.shooler);

--- a/test/server/cards/03-WC/ComOfficerKirby.spec.js
+++ b/test/server/cards/03-WC/ComOfficerKirby.spec.js
@@ -81,4 +81,30 @@ describe('Com. Officer Kirby', function () {
             expect(this.player1).toBeAbleToPlay(this.safePlace);
         });
     });
+
+    describe("Com. Officer Kirby's ability on a non-Star Alliance turn", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['exhume', 'shooler', 'soulkeeper', 'alaka-s-brew'],
+                    discard: ['com-officer-kirby']
+                }
+            });
+        });
+
+        it('should be used up by playing non-Star Alliance upgrade of the active house', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.comOfficerKirby);
+            this.player1.playUpgrade(this.soulkeeper, this.comOfficerKirby);
+            expect(this.player1).not.toBeAbleToPlay(this.alakaSBrew);
+        });
+
+        it('should not be used up by playing non-Star Alliance creature of the active house', function () {
+            this.player1.play(this.exhume);
+            this.player1.clickCard(this.comOfficerKirby);
+            this.player1.play(this.shooler);
+            expect(this.player1).toBeAbleToPlay(this.alakaSBrew);
+        });
+    });
 });

--- a/test/server/cards/04-MM/MatterMaker.spec.js
+++ b/test/server/cards/04-MM/MatterMaker.spec.js
@@ -66,4 +66,29 @@ describe('matter-maker', function () {
             expect(this.troll.upgrades).toContain(this.securiDroid);
         });
     });
+
+    describe("Matter Makers's and Captain Val Jericho's abilities stacking", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'brobnar',
+                    inPlay: ['matter-maker', 'captain-val-jericho'],
+                    hand: ['camouflage', 'stunner', 'alaka', 'ballcano', 'securi-droid']
+                }
+            });
+        });
+
+        it("should not use up Matter Maker's ability", function () {
+            this.player1.clickCard('camouflage');
+            this.player1.clickPrompt('Play this upgrade');
+            expect(this.player1).toHavePrompt('Choose a play allowance ability:');
+            this.player1.clickPrompt('Matter Maker');
+            this.player1.clickCard(this.captainValJericho);
+            this.player1.clickCard('stunner');
+            this.player1.clickPrompt('Play this upgrade');
+            expect(this.player1).toHavePrompt('Choose a play allowance ability:');
+            this.player1.clickPrompt('Matter Maker');
+            this.player1.clickCard(this.captainValJericho);
+        });
+    });
 });


### PR DESCRIPTION
This PR is made to fix the Helper Bot task in [this list](https://github.com/keyteki/keyteki/issues/2153). I added tests to Helper Bot's, Com. Officer Kirby's, and Jericho's specs to cover this interaction. It should also apply to CXO Taber, but I didn't add tests for that. Should I?

What is `noActiveHouseForPlay`? Does there need to be a case before the effects part to cover the positive case of this effect?

In this PR, I could see:
- adding comments in costs.js to justify why effects go above active house (i.e. a rules reference)
- moving the "beforeEach" in Helper Bot and Jericho specs into the `it` because there's only one test
- deleting the Jericho test because it's redundant (because I think they all count as a `StaticEffect`?)

What do you think?

EDIT (2021/10/16):
I added a prompt when there are multiple house-cheating effects coming from different cards. This was done to fix https://github.com/keyteki/keyteki/issues/947.

![image](https://user-images.githubusercontent.com/7118380/137609250-3442f3a9-6871-45d3-8eb3-e37e21936400.png)
