### PR TITLE
Fix PangoCairo issues on setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 COPY package-lock.json /usr/src/app
+RUN apt-get update
+RUN apt-get install libcairo2-dev libpango1.0-dev -y
 RUN npm install --no-optional
 COPY . /usr/src/app


### PR DESCRIPTION
I couldn't get `npm install` and `docker-composer up` to finish successfully due to PangoCairo issues when installing the `canvas` library:

```
 > [keyteki_node 6/7] RUN npm install --no-optional:                                                                              
#17 19.71                                                                                                                         
#17 19.71 > canvas@2.6.1 install /usr/src/app/node_modules/canvas                                                                 
#17 19.71 > node-pre-gyp install --fallback-to-build                                                                              
#17 19.71                                                                                                                         
#17 19.88 node-pre-gyp WARN Using request for node-pre-gyp https download 
#17 20.30 node-pre-gyp WARN Tried to download(404): https://github.com/node-gfx/node-canvas-prebuilt/releases/download/v2.6.1/canvas-v2.6.1-node-v64-linux-glibc-arm64.tar.gz 
#17 20.30 node-pre-gyp WARN Pre-built binaries not found for canvas@2.6.1 and node@10.24.1 (node-v64 ABI, glibc) (falling back to source compile with node-gyp) 
#17 21.40 Package pangocairo was not found in the pkg-config search path.
#17 21.40 Perhaps you should add the directory containing `pangocairo.pc'
#17 21.40 to the PKG_CONFIG_PATH environment variable
#17 21.40 No package 'pangocairo' found
#17 21.40 gyp: Call to 'pkg-config pangocairo --libs' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
```

The changes on this PR fix the issue, but I'm not sure what's particular about my setup to require them.