### PR TITLE
always show the tide and let the active player raise the tide as many…

### DIFF
--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -203,36 +203,29 @@ export class GameBoard extends React.Component {
         return !this.props.currentGame.players[this.props.user.username];
     }
 
-    renderTide(thisPlayer, otherPlayer) {
-        if (thisPlayer.stats.tideRequired || (otherPlayer && otherPlayer.stats.tideRequired)) {
-            let locale = this.props.i18n.language;
-            let img = Constants.TideImages.card[locale]
-                ? Constants.TideImages.card[locale]
-                : Constants.TideImages.card['en'];
-            return (
-                <div className='tide-pane'>
-                    <img
-                        key='tide-card'
-                        onClick={this.onClickTide}
-                        className={`img-fluid normal tide-card tide-${thisPlayer.stats.tide}
-                            ${
-                                thisPlayer.activeHouse && thisPlayer.canRaiseTide
-                                    ? 'can-raise-tide'
-                                    : ''
-                            }`}
-                        src={img}
-                        onMouseOver={() => {
-                            this.onMouseOver({
-                                image: <img src={img} className='card-zoom normal' />,
-                                size: `tide-${thisPlayer.stats.tide}`
-                            });
-                        }}
-                        onMouseOut={this.onMouseOut}
-                        title={this.props.t(`${thisPlayer.stats.tide}-tide`)}
-                    />
-                </div>
-            );
-        }
+    renderTide(thisPlayer) {
+        let locale = this.props.i18n.language;
+        let img = Constants.TideImages.card[locale]
+            ? Constants.TideImages.card[locale]
+            : Constants.TideImages.card['en'];
+        return (
+            <div className='tide-pane'>
+                <img
+                    key='tide-card'
+                    onClick={this.onClickTide}
+                    className={`img-fluid normal tide-card tide-${thisPlayer.stats.tide}`}
+                    src={img}
+                    onMouseOver={() => {
+                        this.onMouseOver({
+                            image: <img src={img} className='card-zoom normal' />,
+                            size: `tide-${thisPlayer.stats.tide}`
+                        });
+                    }}
+                    onMouseOut={this.onMouseOut}
+                    title={this.props.t(`${thisPlayer.stats.tide}-tide`)}
+                />
+            </div>
+        );
     }
 
     renderBoard(thisPlayer, otherPlayer) {
@@ -371,9 +364,6 @@ export class GameBoard extends React.Component {
                         size={this.props.user.settings.cardSize}
                         spectating={this.isSpectating()}
                         stats={otherPlayer.stats}
-                        tideRequired={
-                            thisPlayer.stats.tideRequired || otherPlayer?.stats?.tideRequired
-                        }
                         user={otherPlayer.user}
                     />
                 </div>
@@ -383,7 +373,7 @@ export class GameBoard extends React.Component {
                     <div className='right-side'>
                         <div className='prompt-area'>
                             <div className='right-side-top'></div>
-                            {this.renderTide(thisPlayer, otherPlayer)}
+                            {this.renderTide(thisPlayer)}
                             <div className='inset-pane'>
                                 {this.isSpectating() ? (
                                     <div />
@@ -460,7 +450,6 @@ export class GameBoard extends React.Component {
                     size={this.props.user.settings.cardSize}
                     spectating={this.isSpectating()}
                     stats={thisPlayer.stats}
-                    tideRequired={thisPlayer.stats.tideRequired || otherPlayer?.stats?.tideRequired}
                     user={thisPlayer.user}
                 />
             </div>

--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -159,10 +159,6 @@
     &.tide-low {
         transform: rotate(180deg);
     }
-
-    &.can-raise-tide {
-        animation: glowing 2000ms infinite;
-    }
 }
 
 .right-side-top {

--- a/client/Components/GameBoard/PlayerStats.jsx
+++ b/client/Components/GameBoard/PlayerStats.jsx
@@ -61,7 +61,6 @@ const PlayerStats = ({
     size,
     spectating,
     stats,
-    tideRequired,
     user
 }) => {
     const { t } = useTranslation();
@@ -145,19 +144,17 @@ const PlayerStats = ({
     };
 
     const getTide = () => {
-        if (stats && stats.tide && tideRequired) {
-            return (
-                <div className='state'>
-                    <img
-                        key='tide'
-                        onClick={onClickTide}
-                        className='img-fluid tide'
-                        src={Constants.TideImages[stats.tide]}
-                        title={t(`${stats.tide}-tide`)}
-                    />
-                </div>
-            );
-        }
+        return (
+            <div className='state'>
+                <img
+                    key='tide'
+                    onClick={onClickTide}
+                    className='img-fluid tide'
+                    src={Constants.TideImages[stats.tide]}
+                    title={t(`${stats.tide}-tide`)}
+                />
+            </div>
+        );
     };
 
     const writeChatToClipboard = (event) => {

--- a/server/constants.js
+++ b/server/constants.js
@@ -25,11 +25,11 @@ Constants.HousesNames = [
     'Untamed'
 ];
 Constants.Expansions = [
-    { id: 341, label: 'CotA', tideRequired: false },
-    { id: 435, label: 'AoA', tideRequired: false },
-    { id: 452, label: 'WC', tideRequired: false },
-    { id: 479, label: 'MM', tideRequired: false },
-    { id: 496, label: 'DT', tideRequired: true }
+    { id: 341, label: 'CotA' },
+    { id: 435, label: 'AoA' },
+    { id: 452, label: 'WC' },
+    { id: 479, label: 'MM' },
+    { id: 496, label: 'DT' }
 ];
 Constants.Tide = Object.freeze({
     HIGH: 'high',

--- a/server/game/GameActions/RaiseTideAction.js
+++ b/server/game/GameActions/RaiseTideAction.js
@@ -18,11 +18,7 @@ class RaiseTideAction extends PlayerAction {
     }
 
     canAffect(player, context) {
-        return (
-            player.checkRestrictions('raiseTide', context) &&
-            !player.isTideHigh() &&
-            super.canAffect(player, context)
-        );
+        return player.checkRestrictions('raiseTide', context) && super.canAffect(player, context);
     }
 
     getEvent(player, context) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -869,13 +869,6 @@ class Player extends GameObject {
         this.wins = wins;
     }
 
-    isTideRequired() {
-        let expansion = Constants.Expansions.find(
-            (expansion) => expansion.id === this.deckData.expansion
-        );
-        return expansion && expansion.tideRequired;
-    }
-
     getStats() {
         return {
             amber: this.amber,
@@ -883,7 +876,6 @@ class Player extends GameObject {
             keys: this.keys,
             houses: this.houses,
             keyCost: this.getCurrentKeyCost(),
-            tideRequired: this.isTideRequired(),
             tide: this.isTideHigh()
                 ? Constants.Tide.HIGH
                 : this.isTideLow()
@@ -920,9 +912,6 @@ class Player extends GameObject {
             cardback: 'cardback',
             disconnected: !!this.disconnectedAt,
             activePlayer: this.game.activePlayer === this,
-            canRaiseTide:
-                !this.isTideHigh() &&
-                this.game.actions.raiseTide().canAffect(this, this.game.getFrameworkContext()),
             houses: this.houses,
             id: this.id,
             left: this.left,

--- a/test/server/tide.spec.js
+++ b/test/server/tide.spec.js
@@ -1,0 +1,14 @@
+describe('The Tide', function () {
+    beforeEach(function () {
+        this.setupTest({
+            player1: { house: 'untamed' },
+            player2: {}
+        });
+    });
+
+    it("can be raised even if it's high for the active player", function () {
+        this.player1.raiseTide();
+        this.player1.raiseTide();
+        expect(this.player1.chains).toBe(6);
+    });
+});


### PR DESCRIPTION
… times as they want

Maybe we want to have a setting for this: "show tide controls when not playing DT." If either player has this turned on, it will show the tide no matter which set is being played. If both players have this turned off, it will work as it does now.