### PR TITLE
Update RaiseTideAction.js

### DIFF
--- a/server/game/GameActions/RaiseTideAction.js
+++ b/server/game/GameActions/RaiseTideAction.js
@@ -25,7 +25,7 @@ class RaiseTideAction extends PlayerAction {
         let raiseTideEvent = super.createEvent(
             'onRaiseTide',
             { player: player, context: context },
-            event => {
+            (event) => {
                 if(event.player.isTideHigh()) {
                    event.name = 'unnamedEvent';
                 }

--- a/server/game/GameActions/RaiseTideAction.js
+++ b/server/game/GameActions/RaiseTideAction.js
@@ -25,8 +25,11 @@ class RaiseTideAction extends PlayerAction {
         let raiseTideEvent = super.createEvent(
             'onRaiseTide',
             { player: player, context: context },
-            () => {
-                context.game.changeTide(player, Constants.Tide.HIGH, this.showMessage);
+            event => {
+                if(event.player.isTideHigh()) {
+                   event.name = 'unnamedEvent';
+                }
+                context.game.changeTide(event.player, Constants.Tide.HIGH, this.showMessage);
             }
         );
 

--- a/server/game/GameActions/RaiseTideAction.js
+++ b/server/game/GameActions/RaiseTideAction.js
@@ -26,8 +26,8 @@ class RaiseTideAction extends PlayerAction {
             'onRaiseTide',
             { player: player, context: context },
             (event) => {
-                if(event.player.isTideHigh()) {
-                   event.name = 'unnamedEvent';
+                if (event.player.isTideHigh()) {
+                    event.name = 'unnamedEvent';
                 }
                 context.game.changeTide(event.player, Constants.Tide.HIGH, this.showMessage);
             }


### PR DESCRIPTION
Changes the event name of the event generated by the raise tide action to stop other effects from responding to it in the case where raising the tide doesn't actually generate a gamestate change due to the tide already being high for that player.