### PR TITLE
Update node to 12 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app


### PR DESCRIPTION
Some javascript functions used are not available in node 10, such as [Array.prototype.flatMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap) and [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat).

These functions are used in the following cards:
https://github.com/keyteki/keyteki/blob/eca831ec8ba43ebb231c098275f131e06c445bdb/server/game/cards/05-DT/ExploratoryCraft.js#L17
https://github.com/keyteki/keyteki/blob/eca831ec8ba43ebb231c098275f131e06c445bdb/server/game/cards/05-DT/WipeClear.js#L12

Upgrade to node 12 addresses this.

Fixes #2833

Testing done:
- [x] Played games with impacted cards