### PR TITLE
Change PlaceUnderAction location from purged to under

### DIFF
--- a/server/game/GameActions/PlaceUnderAction.js
+++ b/server/game/GameActions/PlaceUnderAction.js
@@ -34,7 +34,7 @@ class PlaceUnderAction extends CardGameAction {
                 card.controller.removeCardFromPile(card);
                 card.controller = card.owner;
                 card.parent = this.parent;
-                card.moveTo(this.isGraft ? 'grafted' : 'purged');
+                card.moveTo(this.isGraft ? 'grafted' : 'under');
                 card.facedown = this.facedown;
                 this.parent.childCards.push(card);
             }

--- a/test/server/cards/01-Core/Masterplan.spec.js
+++ b/test/server/cards/01-Core/Masterplan.spec.js
@@ -18,7 +18,7 @@ describe('Masterplan', function () {
             this.player1.play(this.masterplan);
             expect(this.player1).toHavePrompt('Masterplan');
             this.player1.clickCard(this.virtuousWorks);
-            expect(this.virtuousWorks.location).toBe('purged');
+            expect(this.virtuousWorks.location).toBe('under');
             expect(this.masterplan.childCards).toContain(this.virtuousWorks);
         });
 

--- a/test/server/cards/02-AoA/Jargogle.spec.js
+++ b/test/server/cards/02-AoA/Jargogle.spec.js
@@ -32,6 +32,7 @@ describe('Jargogle', function () {
             expect(this.player1).not.toBeAbleToSelect(this.shorty);
             this.player1.clickCard(this.bindingIrons);
             expect(this.jargogle.childCards).toContain(this.bindingIrons);
+            expect(this.bindingIrons.location).toBe('under');
         });
 
         it("should player after destroyed during player's turn", function () {


### PR DESCRIPTION
Fixes #2758
I've always asked myself why PlaceUnderAction marked the card in "purged", even though not put in purge pile. I changed it to under without a corresponding pile.