### PR TITLE
make Hecatomb sequential so destroyed effects trigger at the same time, and also does not award amber for creatures that were not destroyed

### DIFF
--- a/server/game/cards/01-Core/Hecatomb.js
+++ b/server/game/cards/01-Core/Hecatomb.js
@@ -4,24 +4,31 @@ class Hecatomb extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect:
-                'destroy all dis creatures and each player gains amber equal to the number of their creatures destroyed',
-            gameAction: [
-                ability.actions.destroy((context) => ({
-                    target: context.game.creaturesInPlay.filter((card) => card.hasHouse('dis'))
-                })),
-                ability.actions.gainAmber((context) => ({
-                    amount: context.player.creaturesInPlay.filter((card) => card.hasHouse('dis'))
-                        .length
-                })),
-                ability.actions.gainAmber((context) => ({
-                    target: context.player.opponent,
-                    amount: context.player.opponent
-                        ? context.player.opponent.creaturesInPlay.filter((card) =>
-                              card.hasHouse('dis')
-                          ).length
-                        : 0
-                }))
-            ]
+                'destroy {1} and make each player gain 1 amber for each controlled creature that was destroyed this way',
+            effectArgs: (context) => [
+                context.game.creaturesInPlay.filter((card) => card.hasHouse('dis'))
+            ],
+            gameAction: ability.actions.destroy((context) => ({
+                target: context.game.creaturesInPlay.filter((card) => card.hasHouse('dis'))
+            })),
+            then: {
+                alwaysTriggers: true,
+                gameAction: [
+                    ability.actions.gainAmber((context) => ({
+                        amount: context.preThenEvents.filter(
+                            (event) => !event.cancelled && event.clone.controller == context.player
+                        ).length
+                    })),
+                    ability.actions.gainAmber((context) => ({
+                        target: context.player.opponent,
+                        amount: context.preThenEvents.filter(
+                            (event) =>
+                                !event.cancelled &&
+                                event.clone.controller == context.player.opponent
+                        ).length
+                    }))
+                ]
+            }
         });
     }
 }

--- a/server/game/cards/02-AoA/MartyrsEnd.js
+++ b/server/game/cards/02-AoA/MartyrsEnd.js
@@ -4,20 +4,19 @@ class MartyrsEnd extends Card {
     setupCardAbilities(ability) {
         this.creaturesMartyrd = 0;
         this.play({
-            effect:
-                'destroy any number of friendly creatures. gain 1 amber for each creature destroyed this way.',
+            effect: 'destroy {0}, and gain 1 amber for each creature destroyed this way',
             target: {
                 mode: 'unlimited',
                 location: ['play area'],
                 cardCondition: (card) => card.type === 'creature',
                 controller: 'self',
-                gameAction: ability.actions.sequential([
-                    ability.actions.destroy(),
-                    ability.actions.gainAmber((context) => ({
-                        target: context.player,
-                        amount: context.target.length
-                    }))
-                ])
+                gameAction: ability.actions.destroy()
+            },
+            then: {
+                alwaysTriggers: true,
+                gameAction: ability.actions.gainAmber((context) => ({
+                    amount: context.preThenEvents.filter((event) => !event.cancelled).length
+                }))
             }
         });
     }

--- a/test/server/cards/01-Core/Hecatomb.spec.js
+++ b/test/server/cards/01-Core/Hecatomb.spec.js
@@ -14,6 +14,7 @@ describe('Hecatomb', function () {
                 }
             });
         });
+
         it('should award 1 amber for each dis creature destroyed to respective controllers', function () {
             this.player1.play(this.hecatomb);
             expect(this.player1.player.amber).toBe(3);
@@ -23,7 +24,37 @@ describe('Hecatomb', function () {
             expect(this.bloodshardImp.location).toBe('discard');
         });
     });
-    describe("Hecatomb's ability", function () {
+
+    describe('Hecatomb & warded creatures', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['hecatomb'],
+                    amber: 0,
+                    inPlay: ['rotgrub', 'ember-imp', 'streke']
+                },
+                player2: {
+                    amber: 0,
+                    inPlay: ['bloodshard-imp']
+                }
+            });
+        });
+
+        it('should not award amber for warded dis creatures', function () {
+            this.emberImp.ward();
+            this.rotgrub.ward();
+            this.player1.play(this.hecatomb); // gain 1 from aember bonus > gain 1 from Streke being destroyed
+            expect(this.player1.player.amber).toBe(2);
+            expect(this.player2.player.amber).toBe(1);
+            expect(this.emberImp.location).toBe('play area');
+            expect(this.rotgrub.location).toBe('play area');
+            expect(this.streke.location).toBe('discard');
+            expect(this.bloodshardImp.location).toBe('discard');
+        });
+    });
+
+    describe('Hecatomb & creatures destroyed in other ways', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -38,6 +69,7 @@ describe('Hecatomb', function () {
                 }
             });
         });
+
         it('should not award amber for non dis creatures as an aftereffect', function () {
             this.player1.play(this.hecatomb);
             expect(this.player1.player.amber).toBe(4);
@@ -48,6 +80,80 @@ describe('Hecatomb', function () {
             expect(this.harbingerOfDoom.location).toBe('discard');
             expect(this.bumpsy.location).toBe('discard');
             expect(this.krump.location).toBe('discard');
+        });
+
+        it('should not award amber for warded dis creatures as an aftereffect', function () {
+            this.rotgrub.ward();
+            this.emberImp.ward();
+            this.player1.play(this.hecatomb); // gain 1 from aember bonus > gain 1 from Harbinger Of Doom being destroyed
+            expect(this.player1.player.amber).toBe(2);
+            expect(this.player2.player.amber).toBe(1);
+            expect(this.emberImp.location).toBe('discard');
+            expect(this.rotgrub.location).toBe('discard');
+            expect(this.bloodshardImp.location).toBe('discard');
+            expect(this.harbingerOfDoom.location).toBe('discard');
+            expect(this.bumpsy.location).toBe('discard');
+            expect(this.krump.location).toBe('discard');
+        });
+    });
+
+    describe('Hecatomb & destroyed abilities', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['hecatomb'],
+                    amber: 1,
+                    inPlay: ['rotgrub', 'ember-imp', 'pit-demon', 'streke', 'sinder']
+                },
+                player2: {
+                    amber: 0,
+                    inPlay: ['brabble']
+                }
+            });
+        });
+
+        it('destroyed abilities should trigger before the aember gain', function () {
+            this.player1.play(this.hecatomb); // gain 1 from aember bonus > lose 3 from Brabble > gain 5 from friendly destroyed Dis creatures
+            expect(this.player1.player.amber).toBe(5);
+            expect(this.player2.player.amber).toBe(1);
+            expect(this.emberImp.location).toBe('discard');
+            expect(this.rotgrub.location).toBe('discard');
+            expect(this.brabble.location).toBe('discard');
+        });
+    });
+
+    describe('Hecatomb & creatures that changed controllers', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    hand: ['hecatomb'],
+                    amber: 0,
+                    inPlay: ['rotgrub', 'ember-imp']
+                },
+                player2: {
+                    amber: 0,
+                    hand: ['collar-of-subordination'],
+                    inPlay: ['pit-demon']
+                }
+            });
+        });
+
+        it('destroyed abilities should trigger before the aember gain', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('dis');
+            this.player2.playUpgrade(this.collarOfSubordination, this.rotgrub);
+            this.player2.clickPrompt('Left');
+            expect(this.rotgrub.controller).toBe(this.player2.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('dis');
+            this.player1.play(this.hecatomb); // gain 1 from aember bonus > gain 1 from ember imp
+            expect(this.player1.player.amber).toBe(2);
+            expect(this.player2.player.amber).toBe(2); // 1 from pit demon, 1 from stolen rotgrub
+            expect(this.emberImp.location).toBe('discard');
+            expect(this.rotgrub.location).toBe('discard');
+            expect(this.pitDemon.location).toBe('discard');
         });
     });
 });

--- a/test/server/cards/02-AoA/MartyrsEnd.spec.js
+++ b/test/server/cards/02-AoA/MartyrsEnd.spec.js
@@ -29,4 +29,52 @@ describe("Martyr's End", function () {
             expect(this.player2.amber).toBe(0);
         });
     });
+
+    describe("Martyr's End and warded creatures", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    inPlay: ['bulwark', 'dextre', 'barrister-joya'],
+                    hand: ['martyr-s-end']
+                },
+                player2: {
+                    inPlay: ['troll', 'chuff-ape', 'grommid']
+                }
+            });
+        });
+
+        it('should not give aember for warded creatures', function () {
+            this.bulwark.ward();
+            this.player1.play(this.martyrSEnd);
+            this.player1.clickCard(this.bulwark);
+            this.player1.clickCard(this.dextre);
+            this.player1.clickPrompt('Done');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(0);
+        });
+    });
+
+    describe("Martyr's End and Harbinger of Doom", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    inPlay: ['bulwark', 'dextre', 'barrister-joya', 'harbinger-of-doom'],
+                    hand: ['martyr-s-end']
+                },
+                player2: {
+                    inPlay: ['troll', 'chuff-ape', 'grommid']
+                }
+            });
+        });
+
+        it('should not give aember for creatures destroyed by Harbinger of Doom', function () {
+            this.player1.play(this.martyrSEnd);
+            this.player1.clickCard(this.harbingerOfDoom);
+            this.player1.clickPrompt('Done');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
Fixes #2832