### PR TITLE
Adjustment in ForgeAction

### DIFF
--- a/server/game/GameActions/ForgeAction.js
+++ b/server/game/GameActions/ForgeAction.js
@@ -4,6 +4,8 @@ class ForgeAction extends PlayerAction {
     setDefaultProperties() {
         this.modifier = 0;
         this.atNoCost = false;
+        this.may = false;
+        this.cancelled = false;
     }
 
     setup() {
@@ -17,8 +19,28 @@ class ForgeAction extends PlayerAction {
         return this.atNoCost ? -player.getCurrentKeyCost() : this.modifier;
     }
 
-    canAffect(player, context) {
-        return player.canForgeKey(this.getModifier(player)) && super.canAffect(player, context);
+    preEventHandler(context) {
+        super.preEventHandler(context);
+
+        if (this.may) {
+            this.cancelled = !context.player.canForgeKey(this.getModifier(context.player));
+            if (!this.cancelled) {
+                context.game.promptWithHandlerMenu(context.player, {
+                    activePromptTitle: 'Do you wish to forge a key?',
+                    context: context,
+                    choices: ['Yes', 'No'],
+                    handlers: [() => (this.cancelled = false), () => (this.cancelled = true)]
+                });
+            }
+        }
+    }
+
+    checkEventCondition(event) {
+        return (
+            !this.cancelled &&
+            event.player.canForgeKey(this.getModifier(event.player)) &&
+            super.checkEventCondition(event)
+        );
     }
 
     defaultTargets(context) {

--- a/server/game/cards/01-Core/ChotaHazri.js
+++ b/server/game/cards/01-Core/ChotaHazri.js
@@ -5,8 +5,7 @@ class ChotaHazri extends Card {
         this.play({
             gameAction: ability.actions.loseAmber((context) => ({ target: context.player })),
             then: {
-                may: 'forge a key',
-                gameAction: ability.actions.forgeKey()
+                gameAction: ability.actions.forgeKey({ may: true })
             }
         });
     }

--- a/server/game/cards/01-Core/KeyAbduction.js
+++ b/server/game/cards/01-Core/KeyAbduction.js
@@ -8,9 +8,9 @@ class KeyAbduction extends Card {
                 target: context.game.creaturesInPlay.filter((card) => card.hasHouse('mars'))
             })),
             then: {
-                may: 'forge a key',
                 alwaysTriggers: true,
                 gameAction: ability.actions.forgeKey((context) => ({
+                    may: true,
                     modifier: 9 - context.player.hand.length
                 }))
             }

--- a/server/game/cards/01-Core/KeyCharge.js
+++ b/server/game/cards/01-Core/KeyCharge.js
@@ -5,8 +5,7 @@ class KeyCharge extends Card {
         this.play({
             gameAction: ability.actions.loseAmber((context) => ({ target: context.player })),
             then: {
-                may: 'forge a key',
-                gameAction: ability.actions.forgeKey()
+                gameAction: ability.actions.forgeKey({ may: true })
             }
         });
     }

--- a/server/game/cards/02-AoA/Nightforge.js
+++ b/server/game/cards/02-AoA/Nightforge.js
@@ -4,8 +4,8 @@ class Nightforge extends Card {
     setupCardAbilities(ability) {
         this.play({
             condition: (context) => context.player.keysForgedThisRound.length === 0,
-            may: 'forge a key',
             gameAction: ability.actions.forgeKey({
+                may: true,
                 modifier: 4
             })
         });

--- a/server/game/cards/03-WC/DataForge.js
+++ b/server/game/cards/03-WC/DataForge.js
@@ -3,9 +3,8 @@ const Card = require('../../Card.js');
 class DataForge extends Card {
     setupCardAbilities(ability) {
         this.play({
-            may: 'forge a key',
-            alwaysTriggers: true,
             gameAction: ability.actions.forgeKey((context) => ({
+                may: true,
                 modifier: 10 - context.player.hand.length
             }))
         });

--- a/server/game/cards/03-WC/ObsidianForge.js
+++ b/server/game/cards/03-WC/ObsidianForge.js
@@ -10,9 +10,9 @@ class ObsidianForge extends Card {
                 gameAction: ability.actions.sacrifice()
             },
             then: {
-                may: 'forge a key',
                 alwaysTriggers: true,
                 gameAction: ability.actions.forgeKey((context) => ({
+                    may: true,
                     modifier: 6 - context.preThenEvents.filter((event) => !event.cancelled).length
                 })),
                 then: {

--- a/test/server/cards/04-MM/Adaptoid.spec.js
+++ b/test/server/cards/04-MM/Adaptoid.spec.js
@@ -37,6 +37,7 @@ describe('Adaptoid', function () {
 
         it('after playing an action card with bonus icon, should be prompted for options', function () {
             this.player1.play(this.dataForge);
+            this.player1.clickPrompt('Data Forge');
             expect(this.player1).toHavePrompt('Select one');
             this.player1.clickPrompt('+2 armor');
             expect(this.adaptoid.getKeywordValue('assault')).toBe(0);
@@ -88,6 +89,7 @@ describe('Adaptoid', function () {
             this.player1.play(this.archimedes);
             this.player1.clickPrompt('Assault 2');
             this.player1.play(this.dataForge);
+            this.player1.clickPrompt('Data Forge');
             this.player1.clickPrompt('Assault 2');
             expect(this.adaptoid.getKeywordValue('assault')).toBe(4);
             expect(this.adaptoid.armor).toBe(0);
@@ -98,6 +100,7 @@ describe('Adaptoid', function () {
             this.player1.play(this.archimedes);
             this.player1.clickPrompt('Fight: Steal 1 amber');
             this.player1.play(this.dataForge);
+            this.player1.clickPrompt('Data Forge');
             this.player1.clickPrompt('Fight: Steal 1 amber');
             expect(this.adaptoid.getKeywordValue('assault')).toBe(0);
             expect(this.adaptoid.armor).toBe(0);
@@ -112,6 +115,7 @@ describe('Adaptoid', function () {
             this.player1.play(this.archimedes);
             this.player1.clickPrompt('Fight: Steal 1 amber');
             this.player1.play(this.dataForge);
+            this.player1.clickPrompt('Data Forge');
             this.player1.clickPrompt('+2 armor');
             this.player1.play(this.hologrammophone);
             this.player1.clickPrompt('+2 armor');
@@ -131,6 +135,7 @@ describe('Adaptoid', function () {
             this.player1.play(this.archimedes);
             this.player1.clickPrompt('Fight: Steal 1 amber');
             this.player1.play(this.dataForge);
+            this.player1.clickPrompt('Data Forge');
             this.player1.clickPrompt('+2 armor');
             this.player1.play(this.hologrammophone);
             this.player1.clickPrompt('+2 armor');

--- a/test/server/cards/04-MM/Keyfrog.spec.js
+++ b/test/server/cards/04-MM/Keyfrog.spec.js
@@ -163,4 +163,67 @@ describe('Keyfrog', function () {
             expect(this.player2.player.getForgedKeys()).toBe(0);
         });
     });
+
+    describe('Keyfrog', function () {
+        describe("Keyfrog's ability versus stealing", function () {
+            beforeEach(function () {
+                this.setupTest({
+                    player1: {
+                        amber: 4,
+                        house: 'untamed',
+                        hand: ['savage-clash'],
+                        inPlay: ['keyfrog', 'dæmo-bot', 'dæmo-knight', 'dæmo-beast', 'squire-alys']
+                    },
+                    player2: {
+                        amber: 4,
+                        inPlay: ['timetraveller']
+                    }
+                });
+
+                this.player1.play(this.savageClash);
+                this.player1.clickCard(this.timetraveller);
+                this.player1.clickCard(this.squireAlys);
+            });
+
+            it('should allow triggering its ability before stealing and not forge', function () {
+                expect(this.player1).toBeAbleToSelect(this.keyfrog);
+                expect(this.player1).toBeAbleToSelect(this.dæmoBot);
+                expect(this.player1).toBeAbleToSelect(this.dæmoKnight);
+                expect(this.player1).toBeAbleToSelect(this.dæmoBeast);
+                this.player1.clickCard(this.keyfrog);
+                this.player1.clickCard(this.dæmoBot);
+                this.player1.clickCard(this.dæmoKnight);
+                this.player1.clickCard(this.dæmoBeast);
+                expect(this.keyfrog.location).toBe('discard');
+                expect(this.dæmoBot.location).toBe('discard');
+                expect(this.dæmoKnight.location).toBe('discard');
+                expect(this.dæmoBeast.location).toBe('discard');
+                expect(this.player1.amber).toBe(7);
+                expect(this.player2.amber).toBe(1);
+                expect(this.player1).not.toHavePrompt('Which key would you like to forge?');
+                this.player1.endTurn();
+            });
+
+            it('should allow triggering its ability after stealing and forge', function () {
+                expect(this.player1).toBeAbleToSelect(this.keyfrog);
+                expect(this.player1).toBeAbleToSelect(this.dæmoBot);
+                expect(this.player1).toBeAbleToSelect(this.dæmoKnight);
+                expect(this.player1).toBeAbleToSelect(this.dæmoBeast);
+                this.player1.clickCard(this.dæmoBot);
+                this.player1.clickCard(this.dæmoKnight);
+                this.player1.clickCard(this.dæmoBeast);
+                this.player1.clickCard(this.keyfrog);
+                expect(this.player1).toHavePrompt('Which key would you like to forge?');
+                this.player1.clickPrompt('red');
+                expect(this.keyfrog.location).toBe('discard');
+                expect(this.dæmoBot.location).toBe('discard');
+                expect(this.dæmoKnight.location).toBe('discard');
+                expect(this.dæmoBeast.location).toBe('discard');
+                expect(this.player1.player.getForgedKeys()).toBe(1);
+                expect(this.player1.amber).toBe(1);
+                expect(this.player2.amber).toBe(1);
+                this.player1.endTurn();
+            });
+        });
+    });
 });

--- a/test/server/cards/04-MM/Krrrzzzaaap.spec.js
+++ b/test/server/cards/04-MM/Krrrzzzaaap.spec.js
@@ -5,7 +5,7 @@ describe('Krrrzzzaaap', function () {
                 player1: {
                     house: 'logos',
                     hand: ['krrrzzzaaap'],
-                    inPlay: ['keyfrog', 'dextre', 'professor-terato']
+                    inPlay: ['helper-bot', 'dextre', 'professor-terato']
                 },
                 player2: {
                     inPlay: ['troll']
@@ -16,6 +16,7 @@ describe('Krrrzzzaaap', function () {
         it('should destroy all non mutant creatures and gain 1 chain', function () {
             this.player1.play(this.krrrzzzaaap);
 
+            expect(this.helperBot.location).toBe('discard');
             expect(this.dextre.location).toBe('deck');
             expect(this.professorTerato.location).toBe('play area');
             expect(this.player1.chains).toBe(1);


### PR DESCRIPTION
Delays the ForgeAction canAffect decision to checkEventCondition and added a "may" check in a preEventHandler to avoid asking to forge if not enough amber.

Fixes #2279
Fixes #2807