### PR TITLE
only show the tide card when a dark tidings deck is being played

### DIFF
--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -203,29 +203,36 @@ export class GameBoard extends React.Component {
         return !this.props.currentGame.players[this.props.user.username];
     }
 
-    renderTide(thisPlayer) {
-        let locale = this.props.i18n.language;
-        let img = Constants.TideImages.card[locale]
-            ? Constants.TideImages.card[locale]
-            : Constants.TideImages.card['en'];
-        return (
-            <div className='tide-pane'>
-                <img
-                    key='tide-card'
-                    onClick={this.onClickTide}
-                    className={`img-fluid normal tide-card tide-${thisPlayer.stats.tide}`}
-                    src={img}
-                    onMouseOver={() => {
-                        this.onMouseOver({
-                            image: <img src={img} className='card-zoom normal' />,
-                            size: `tide-${thisPlayer.stats.tide}`
-                        });
-                    }}
-                    onMouseOut={this.onMouseOut}
-                    title={this.props.t(`${thisPlayer.stats.tide}-tide`)}
-                />
-            </div>
-        );
+    renderTide(thisPlayer, otherPlayer) {
+        if (thisPlayer.stats.tideRequired || (otherPlayer && otherPlayer.stats.tideRequired)) {
+            let locale = this.props.i18n.language;
+            let img = Constants.TideImages.card[locale]
+                ? Constants.TideImages.card[locale]
+                : Constants.TideImages.card['en'];
+            return (
+                <div className='tide-pane'>
+                    <img
+                        key='tide-card'
+                        onClick={this.onClickTide}
+                        className={`img-fluid normal tide-card tide-${thisPlayer.stats.tide}
+                            ${
+                                thisPlayer.activeHouse && thisPlayer.canRaiseTide
+                                    ? 'can-raise-tide'
+                                    : ''
+                            }`}
+                        src={img}
+                        onMouseOver={() => {
+                            this.onMouseOver({
+                                image: <img src={img} className='card-zoom normal' />,
+                                size: `tide-${thisPlayer.stats.tide}`
+                            });
+                        }}
+                        onMouseOut={this.onMouseOut}
+                        title={this.props.t(`${thisPlayer.stats.tide}-tide`)}
+                    />
+                </div>
+            );
+        }
     }
 
     renderBoard(thisPlayer, otherPlayer) {
@@ -364,6 +371,9 @@ export class GameBoard extends React.Component {
                         size={this.props.user.settings.cardSize}
                         spectating={this.isSpectating()}
                         stats={otherPlayer.stats}
+                        tideRequired={
+                            thisPlayer.stats.tideRequired || otherPlayer?.stats?.tideRequired
+                        }
                         user={otherPlayer.user}
                     />
                 </div>
@@ -373,7 +383,7 @@ export class GameBoard extends React.Component {
                     <div className='right-side'>
                         <div className='prompt-area'>
                             <div className='right-side-top'></div>
-                            {this.renderTide(thisPlayer)}
+                            {this.renderTide(thisPlayer, otherPlayer)}
                             <div className='inset-pane'>
                                 {this.isSpectating() ? (
                                     <div />
@@ -450,6 +460,7 @@ export class GameBoard extends React.Component {
                     size={this.props.user.settings.cardSize}
                     spectating={this.isSpectating()}
                     stats={thisPlayer.stats}
+                    tideRequired={thisPlayer.stats.tideRequired || otherPlayer?.stats?.tideRequired}
                     user={thisPlayer.user}
                 />
             </div>

--- a/client/Components/GameBoard/GameBoard.scss
+++ b/client/Components/GameBoard/GameBoard.scss
@@ -159,6 +159,10 @@
     &.tide-low {
         transform: rotate(180deg);
     }
+    
+    &.can-raise-tide {
+        animation: glowing 2000ms infinite;
+    }
 }
 
 .right-side-top {

--- a/client/Components/GameBoard/PlayerStats.jsx
+++ b/client/Components/GameBoard/PlayerStats.jsx
@@ -61,6 +61,7 @@ const PlayerStats = ({
     size,
     spectating,
     stats,
+    tideRequired,
     user
 }) => {
     const { t } = useTranslation();
@@ -144,17 +145,19 @@ const PlayerStats = ({
     };
 
     const getTide = () => {
-        return (
-            <div className='state'>
-                <img
-                    key='tide'
-                    onClick={onClickTide}
-                    className='img-fluid tide'
-                    src={Constants.TideImages[stats.tide]}
-                    title={t(`${stats.tide}-tide`)}
-                />
-            </div>
-        );
+        if (tideRequired) {
+            return (
+                <div className='state'>
+                    <img
+                        key='tide'
+                        onClick={onClickTide}
+                        className='img-fluid tide'
+                        src={Constants.TideImages[stats.tide]}
+                        title={t(`${stats.tide}-tide`)}
+                    />
+                </div>
+            );
+        }
     };
 
     const writeChatToClipboard = (event) => {

--- a/client/constants.js
+++ b/client/constants.js
@@ -30,11 +30,11 @@ export const Constants = {
     ],
     Locales: ['de', 'en', 'es', 'fr', 'it', 'ko', 'pt', 'pl', 'th', 'zhhans', 'zhhant'],
     Expansions: [
-        { value: '341', label: 'CotA' },
-        { value: '435', label: 'AoA' },
-        { value: '452', label: 'WC' },
-        { value: '479', label: 'MM' },
-        { value: '496', label: 'DT' }
+        { value: '341', label: 'CotA', tideRequired: false },
+        { value: '435', label: 'AoA', tideRequired: false },
+        { value: '452', label: 'WC', tideRequired: false },
+        { value: '479', label: 'MM', tideRequired: false },
+        { value: '496', label: 'DT', tideRequired: true }
     ],
     CardTypes: ['action', 'artifact', 'creature', 'upgrade'],
     SetIconPaths: {},

--- a/server/constants.js
+++ b/server/constants.js
@@ -25,11 +25,11 @@ Constants.HousesNames = [
     'Untamed'
 ];
 Constants.Expansions = [
-    { id: 341, label: 'CotA' },
-    { id: 435, label: 'AoA' },
-    { id: 452, label: 'WC' },
-    { id: 479, label: 'MM' },
-    { id: 496, label: 'DT' }
+    { id: 341, label: 'CotA', tideRequired: false },
+    { id: 435, label: 'AoA', tideRequired: false },
+    { id: 452, label: 'WC', tideRequired: false },
+    { id: 479, label: 'MM', tideRequired: false },
+    { id: 496, label: 'DT', tideRequired: true }
 ];
 Constants.Tide = Object.freeze({
     HIGH: 'high',

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -869,6 +869,13 @@ class Player extends GameObject {
         this.wins = wins;
     }
 
+    isTideRequired() {
+        let expansion = Constants.Expansions.find(
+            (expansion) => expansion.id === this.deckData.expansion
+        );
+        return expansion && expansion.tideRequired;
+    }
+
     getStats() {
         return {
             amber: this.amber,
@@ -876,6 +883,7 @@ class Player extends GameObject {
             keys: this.keys,
             houses: this.houses,
             keyCost: this.getCurrentKeyCost(),
+            tideRequired: this.isTideRequired(),
             tide: this.isTideHigh()
                 ? Constants.Tide.HIGH
                 : this.isTideLow()
@@ -912,6 +920,9 @@ class Player extends GameObject {
             cardback: 'cardback',
             disconnected: !!this.disconnectedAt,
             activePlayer: this.game.activePlayer === this,
+            canRaiseTide:
+                !this.isTideHigh() &&
+                this.game.actions.raiseTide().canAffect(this, this.game.getFrameworkContext()),
             houses: this.houses,
             id: this.id,
             left: this.left,

--- a/test/server/tide.spec.js
+++ b/test/server/tide.spec.js
@@ -1,14 +1,30 @@
 describe('The Tide', function () {
-    beforeEach(function () {
-        this.setupTest({
-            player1: { house: 'untamed' },
-            player2: {}
+    describe('when a player has a Dark Tidings deck', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: { house: 'untamed' },
+                player2: {}
+            });
+        });
+
+        it("can be raised even if it's high for the active player", function () {
+            this.player1.raiseTide();
+            this.player1.raiseTide();
+            expect(this.player1.chains).toBe(6);
         });
     });
 
-    it("can be raised even if it's high for the active player", function () {
-        this.player1.raiseTide();
-        this.player1.raiseTide();
-        expect(this.player1.chains).toBe(6);
+    describe('when neither player has a Dark Tidings deck', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: { house: 'untamed' },
+                player2: {}
+            });
+        });
+
+        xit('the tide cannot be raised', function () {
+            this.player1.raiseTide();
+            expect(this.player1.isTideHigh()).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
Mostly reverts https://github.com/keyteki/keyteki/pull/2813/files.

The `raiseTide` game action still raises the tide even if neither player requires the tide. I added a disabled test for this because I think we should consider changing the game action to prevent that.

Why is the id for the expansions a string on the client and an integer on the server? I think if we were to write a test for this I need to include the expansion id in the game setup.

Demo:
![no-dt-no-tide](https://user-images.githubusercontent.com/7118380/229242239-a084b23e-be86-4619-9864-febc09a7e15e.png)

![dt-yes-tide](https://user-images.githubusercontent.com/7118380/229242247-15e33840-f224-4d98-9a2f-6c51bc76c0a7.png)
