### PR TITLE
disallow moving blasters once attached to their associated officer

### DIFF
--- a/server/game/cards/03-WC/BlasterCard.js
+++ b/server/game/cards/03-WC/BlasterCard.js
@@ -27,7 +27,10 @@ class BlasterCard extends Card {
         result.targets[moveChoice] = {
             dependsOn: 'action',
             cardType: 'creature',
-            cardCondition: (card) => card.name === creatureName && !card.upgrades.includes(this),
+            cardCondition: (card) =>
+                this.parent.name != creatureName &&
+                card.name === creatureName &&
+                !card.upgrades.includes(this),
             gameAction: ability.actions.attach({ upgrade: this })
         };
 

--- a/test/server/cards/03-WC/ChansBlaster.spec.js
+++ b/test/server/cards/03-WC/ChansBlaster.spec.js
@@ -219,7 +219,7 @@ describe('Chan’s Blaster', function () {
             this.commanderChan2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.chanSBlaster, this.commanderChan1);
             this.player1.clickCard(this.gub);
             this.player1.clickPrompt('Reap with this creature');
@@ -228,15 +228,12 @@ describe('Chan’s Blaster', function () {
 
             this.player1.clickPrompt('Chan’s Blaster');
             this.player1.clickPrompt('Move Chan’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.commanderChan1);
-            expect(this.player1).toBeAbleToSelect(this.commanderChan2);
-            this.player1.clickCard(this.commanderChan2);
+            // There are no valid targets. Move to resolving Chan's ability.
             this.player1.clickCard(this.shooler);
             this.player1.clickPrompt('Reap with this creature');
             expect(this.player1.amber).toBe(4);
 
-            expect(this.commanderChan1.upgrades).not.toContain(this.chanSBlaster);
-            expect(this.commanderChan2.upgrades).toContain(this.chanSBlaster);
+            expect(this.commanderChan1.upgrades).toContain(this.chanSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/FranesBlaster.spec.js
+++ b/test/server/cards/03-WC/FranesBlaster.spec.js
@@ -200,7 +200,6 @@ describe('Frane’s Blaster', function () {
                     inPlay: ['techivore-pulpate', 'first-officer-frane', 'first-officer-frane']
                 },
                 player2: {
-                    amber: 2,
                     inPlay: ['lamindra', 'krump']
                 }
             });
@@ -209,26 +208,15 @@ describe('Frane’s Blaster', function () {
             this.firstOfficerFrane2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
-            this.firstOfficerFrane1.tokens.amber = 3;
-            this.firstOfficerFrane2.tokens.amber = 5;
-
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.franeSBlaster, this.firstOfficerFrane1);
             this.player1.reap(this.firstOfficerFrane1);
             this.player1.clickCard(this.firstOfficerFrane1);
 
-            this.player1.clickPrompt('Frane’s Blaster');
             this.player1.clickPrompt('Move Frane’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.firstOfficerFrane1);
-            expect(this.player1).toBeAbleToSelect(this.firstOfficerFrane2);
-            this.player1.clickCard(this.firstOfficerFrane2);
-
-            expect(this.firstOfficerFrane1.upgrades).not.toContain(this.franeSBlaster);
-            expect(this.firstOfficerFrane2.upgrades).toContain(this.franeSBlaster);
-
-            expect(this.firstOfficerFrane1.hasToken('amber')).toBe(false);
-            expect(this.firstOfficerFrane2.hasToken('amber')).toBe(false);
-            expect(this.player1.amber).toBe(10);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.firstOfficerFrane1.upgrades).toContain(this.franeSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/GarciasBlaster.spec.js
+++ b/test/server/cards/03-WC/GarciasBlaster.spec.js
@@ -204,22 +204,19 @@ describe('Garcia’s Blaster', function () {
             this.sensorChiefGarcia2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.garciaSBlaster, this.sensorChiefGarcia1);
             this.player1.reap(this.sensorChiefGarcia1);
             this.player1.clickCard(this.sensorChiefGarcia1);
 
             this.player1.clickPrompt('Garcia’s Blaster');
             this.player1.clickPrompt('Move Garcia’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.sensorChiefGarcia1);
-            expect(this.player1).toBeAbleToSelect(this.sensorChiefGarcia2);
-            this.player1.clickCard(this.sensorChiefGarcia2);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.sensorChiefGarcia1.upgrades).toContain(this.garciaSBlaster);
 
-            expect(this.sensorChiefGarcia1.upgrades).not.toContain(this.garciaSBlaster);
-            expect(this.sensorChiefGarcia2.upgrades).toContain(this.garciaSBlaster);
-
-            expect(this.player1.amber).toBe(4);
-            expect(this.player2.amber).toBe(0);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(1);
         });
     });
 });

--- a/test/server/cards/03-WC/IngramsBlaster.spec.js
+++ b/test/server/cards/03-WC/IngramsBlaster.spec.js
@@ -226,7 +226,7 @@ describe('Ingram’s Blaster', function () {
             this.medicIngram2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.ingramSBlaster, this.medicIngram1);
             this.player1.clickCard(this.techivorePulpate);
             this.player1.reap(this.medicIngram1);
@@ -234,15 +234,12 @@ describe('Ingram’s Blaster', function () {
 
             this.player1.clickPrompt('Ingram’s Blaster');
             this.player1.clickPrompt('Move Ingram’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.medicIngram1);
-            expect(this.player1).toBeAbleToSelect(this.medicIngram2);
-            this.player1.clickCard(this.medicIngram2);
-            expect(this.player1).toHavePrompt('Choose a creature');
+            // There are no valid targets. Move to healing.
+            expect(this.player1).toHavePrompt('Choose a creature to heal');
             this.player1.clickCard(this.techivorePulpate);
             expect(this.techivorePulpate.hasToken('damage')).toBe(false);
 
-            expect(this.medicIngram1.upgrades).not.toContain(this.ingramSBlaster);
-            expect(this.medicIngram2.upgrades).toContain(this.ingramSBlaster);
+            expect(this.medicIngram1.upgrades).toContain(this.ingramSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/KhrkharsBlaster.spec.js
+++ b/test/server/cards/03-WC/KhrkharsBlaster.spec.js
@@ -204,22 +204,16 @@ describe('Khrkhar’s Blaster', function () {
             this.lieutenantKhrkhar2 = this.player1.findCardByName('lieutenant-khrkhar', 'hand');
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.khrkharSBlaster, this.lieutenantKhrkhar1);
             this.player1.playCreature(this.lieutenantKhrkhar2);
             this.player1.reap(this.lieutenantKhrkhar1);
             this.player1.clickCard(this.lieutenantKhrkhar1);
 
             this.player1.clickPrompt('Move Khrkhar’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.lieutenantKhrkhar1);
-            expect(this.player1).toBeAbleToSelect(this.lieutenantKhrkhar2);
-            this.player1.clickCard(this.lieutenantKhrkhar2);
-
-            expect(this.lieutenantKhrkhar1.upgrades).not.toContain(this.khrkharSBlaster);
-            expect(this.lieutenantKhrkhar2.upgrades).toContain(this.khrkharSBlaster);
-
-            expect(this.lieutenantKhrkhar1.warded).toBe(true);
-            expect(this.lieutenantKhrkhar2.warded).toBe(true);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.lieutenantKhrkhar1.upgrades).toContain(this.khrkharSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/KirbysBlaster.spec.js
+++ b/test/server/cards/03-WC/KirbysBlaster.spec.js
@@ -199,21 +199,16 @@ describe('Kirby’s Blaster', function () {
             this.comOfficerKirby2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.kirbySBlaster, this.comOfficerKirby1);
             this.player1.reap(this.comOfficerKirby1);
             this.player1.clickCard(this.comOfficerKirby1);
 
             this.player1.clickPrompt('Kirby’s Blaster');
             this.player1.clickPrompt('Move Kirby’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.comOfficerKirby1);
-            expect(this.player1).toBeAbleToSelect(this.comOfficerKirby2);
-            this.player1.clickCard(this.comOfficerKirby2);
-
-            expect(this.comOfficerKirby1.upgrades).not.toContain(this.kirbySBlaster);
-            expect(this.comOfficerKirby2.upgrades).toContain(this.kirbySBlaster);
-
-            expect(this.player1.hand.length).toBe(4);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.comOfficerKirby1.upgrades).toContain(this.kirbySBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/MolinasBlaster.spec.js
+++ b/test/server/cards/03-WC/MolinasBlaster.spec.js
@@ -214,7 +214,7 @@ describe('Molina’s Blaster', function () {
             this.armsmasterMolina2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.molinaSBlaster, this.armsmasterMolina1);
             this.player1.clickCard(this.krump);
             expect(this.krump.tokens.damage).toBe(3);
@@ -222,14 +222,9 @@ describe('Molina’s Blaster', function () {
             this.player1.clickCard(this.armsmasterMolina1);
 
             this.player1.clickPrompt('Move Molina’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.armsmasterMolina1);
-            expect(this.player1).toBeAbleToSelect(this.armsmasterMolina2);
-            this.player1.clickCard(this.armsmasterMolina2);
-            this.player1.clickCard(this.krump);
-            expect(this.krump.location).toBe('discard');
-
-            expect(this.armsmasterMolina1.upgrades).not.toContain(this.molinaSBlaster);
-            expect(this.armsmasterMolina2.upgrades).toContain(this.molinaSBlaster);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.armsmasterMolina1.upgrades).toContain(this.molinaSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/QincasBlaster.spec.js
+++ b/test/server/cards/03-WC/QincasBlaster.spec.js
@@ -227,7 +227,7 @@ describe('Qincan’s Blaster', function () {
             this.sciOfficerQincan2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.qincanSBlaster, this.sciOfficerQincan1);
             this.player1.clickCard(this.techivorePulpate);
             expect(this.techivorePulpate.location).toBe('archives');
@@ -235,14 +235,9 @@ describe('Qincan’s Blaster', function () {
             this.player1.clickCard(this.sciOfficerQincan1);
 
             this.player1.clickPrompt('Move Qincan’s Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.sciOfficerQincan1);
-            expect(this.player1).toBeAbleToSelect(this.sciOfficerQincan2);
-            this.player1.clickCard(this.sciOfficerQincan2);
-            this.player1.clickCard(this.gub);
-            expect(this.gub.location).toBe('archives');
-
-            expect(this.sciOfficerQincan1.upgrades).not.toContain(this.qincanSBlaster);
-            expect(this.sciOfficerQincan2.upgrades).toContain(this.qincanSBlaster);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.sciOfficerQincan1.upgrades).toContain(this.qincanSBlaster);
         });
     });
 });

--- a/test/server/cards/03-WC/WallsBlaster.spec.js
+++ b/test/server/cards/03-WC/WallsBlaster.spec.js
@@ -233,22 +233,16 @@ describe('Walls’ Blaster', function () {
             this.chiefEngineerWalls2 = this.player1.player.creaturesInPlay[2];
         });
 
-        it('should allow moving upgrade between officers of same name', function () {
+        it('should not allow moving upgrade between officers of same name', function () {
             this.player1.playUpgrade(this.wallsBlaster, this.chiefEngineerWalls1);
             this.player1.clickCard(this.techivorePulpate);
             this.player1.reap(this.chiefEngineerWalls1);
             this.player1.clickCard(this.chiefEngineerWalls1);
 
             this.player1.clickPrompt('Move Walls’ Blaster');
-            expect(this.player1).not.toBeAbleToSelect(this.chiefEngineerWalls1);
-            expect(this.player1).toBeAbleToSelect(this.chiefEngineerWalls2);
-            this.player1.clickCard(this.chiefEngineerWalls2);
-            expect(this.player1).toHavePrompt('Choose a creature');
-            this.player1.clickCard(this.lamindra);
-            expect(this.lamindra.stunned).toBe(true);
-
-            expect(this.chiefEngineerWalls1.upgrades).not.toContain(this.wallsBlaster);
-            expect(this.chiefEngineerWalls2.upgrades).toContain(this.wallsBlaster);
+            // There are no valid targets.
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.chiefEngineerWalls1.upgrades).toContain(this.wallsBlaster);
         });
     });
 });


### PR DESCRIPTION
You can still choose the option, but all targets are invalidated.

I did not expect to have to change the text in Ingram's Blaster's spec line 238. "Choose a creature" -> "Choose a creature to heal"