### PR TITLE
WoE: Implement Batariel of the Grey

### DIFF
--- a/server/game/cards/06-WoE/BatarielOfTheGrey.js
+++ b/server/game/cards/06-WoE/BatarielOfTheGrey.js
@@ -1,0 +1,16 @@
+const Card = require('../../Card.js');
+
+class BatarielOfTheGrey extends Card {
+    // After Reap: Ready each Disciple.
+    setupCardAbilities(ability) {
+        this.reap({
+            gameAction: ability.actions.ready((context) => ({
+                target: context.game.creaturesInPlay.filter((card) => card.name === 'Disciple')
+            }))
+        });
+    }
+}
+
+BatarielOfTheGrey.id = 'batariel-of-the-grey';
+
+module.exports = BatarielOfTheGrey;

--- a/test/server/cards/06-WoE/BatarielOfTheGrey.spec.js
+++ b/test/server/cards/06-WoE/BatarielOfTheGrey.spec.js
@@ -1,0 +1,33 @@
+describe('Batariel of the Grey', function () {
+    describe("Batariel of the Grey's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    token: 'disciple',
+                    inPlay: ['disciple:troll', 'disciple:holdfast', 'batariel-of-the-grey', 'troll']
+                },
+                player2: {
+                    token: 'disciple',
+                    inPlay: ['disciple:quixxle-stone']
+                }
+            });
+
+            this.disciple1 = this.player1.player.cardsInPlay[0];
+            this.disciple2 = this.player1.player.cardsInPlay[1];
+            this.disciple3 = this.player2.player.cardsInPlay[0];
+        });
+
+        it('should ready Disciples after reap', function () {
+            this.disciple1.exhausted = true;
+            this.disciple2.exhausted = true;
+            this.disciple3.exhausted = true;
+            this.troll.exhausted = true;
+            this.player1.reap(this.batarielOfTheGrey);
+            expect(this.disciple1.exhausted).toBe(false);
+            expect(this.disciple2.exhausted).toBe(false);
+            expect(this.disciple3.exhausted).toBe(false);
+            expect(this.troll.exhausted).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Marking as a draft - wasn't seeing opposing disciples show up as cards in play for player 2, i.e. `this.player2.player.cardsInPlay.length === 0` in the test below. I'll revisit but figured I'd toss up the draft in case it was related to something not fully implemented with tokens (non-token cards seemed to show up as I expected).

See: #2904