### PR TITLE
WoE: implement Yxl the Iron Captain

### DIFF
--- a/server/game/GameActions/CaptureAction.js
+++ b/server/game/GameActions/CaptureAction.js
@@ -67,7 +67,7 @@ class CaptureAction extends CardAction {
             }
 
             let extra = 0;
-            if (event.amount > 0) {
+            if (amount > 0) {
                 extra = player.sumEffects('captureMoreFromPool');
             }
 

--- a/server/game/GameActions/CaptureAction.js
+++ b/server/game/GameActions/CaptureAction.js
@@ -58,8 +58,12 @@ class CaptureAction extends CardAction {
             amount: Math.min(this.amount, player.amber)
         };
         return super.createEvent('onCapture', params, (event) => {
+            let amount = event.amount;
             if (!player.anyEffect('captureFromPool')) {
-                player.modifyAmber(-event.amount);
+                if (amount > player.amber) {
+                    amount = player.amber;
+                }
+                player.modifyAmber(-amount);
             }
 
             let extra = 0;
@@ -67,7 +71,7 @@ class CaptureAction extends CardAction {
                 extra = player.sumEffects('captureMoreFromPool');
             }
 
-            event.card.addToken('amber', event.amount + extra);
+            event.card.addToken('amber', amount + extra);
         });
     }
 }

--- a/server/game/cards/06-WoE/YxlTheIronCaptain.js
+++ b/server/game/cards/06-WoE/YxlTheIronCaptain.js
@@ -1,0 +1,23 @@
+const Card = require('../../Card.js');
+
+class YxlTheIronCaptain extends Card {
+    // Play: Each friendly Ironyx creature captures 2Aember.
+    setupCardAbilities(ability) {
+        this.play({
+            effect: 'make each friendly Ironyx creature capture 2 amber',
+            gameAction: ability.actions.capture((context) => ({
+                target: context.game.creaturesInPlay.filter(
+                    (card) =>
+                        card.controller === context.source.controller &&
+                        card.type === 'creature' &&
+                        card.hasTrait('ironyx')
+                ),
+                amount: 2
+            }))
+        });
+    }
+}
+
+YxlTheIronCaptain.id = 'yxl-the-iron-captain';
+
+module.exports = YxlTheIronCaptain;

--- a/test/server/cards/06-WoE/YxlTheIronCaptain.spec.js
+++ b/test/server/cards/06-WoE/YxlTheIronCaptain.spec.js
@@ -1,0 +1,72 @@
+describe('Yxl the Iron Captain', function () {
+    describe("Yxl the Iron Captain's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 2,
+                    house: 'mars',
+                    inPlay: ['ironyx-rebel', 'ironyx-vatminder', 'pelf', 'blypyp'],
+                    hand: ['yxl-the-iron-captain']
+                },
+                player2: {
+                    amber: 10,
+                    inPlay: ['ironyx-rebel']
+                }
+            });
+        });
+
+        it('should capture 2 on each friendly Ironyx creature', function () {
+            this.ironyxRebel2 = this.player2.player.creaturesInPlay[0];
+            this.player1.play(this.yxlTheIronCaptain);
+            expect(this.player2.amber).toBe(4);
+            expect(this.ironyxRebel.amber).toBe(2);
+            expect(this.ironyxVatminder.amber).toBe(2);
+            expect(this.yxlTheIronCaptain.amber).toBe(2);
+            expect(this.pelf.amber).toBe(0);
+            expect(this.blypyp.amber).toBe(0);
+            expect(this.ironyxRebel2.amber).toBe(0);
+        });
+
+        it('should prompt if not enough to capture', function () {
+            this.ironyxRebel2 = this.player2.player.creaturesInPlay[0];
+            this.player2.amber = 3;
+            this.player1.play(this.yxlTheIronCaptain);
+            expect(this.player1).toBeAbleToSelect(this.ironyxRebel);
+            expect(this.player1).toBeAbleToSelect(this.ironyxVatminder);
+            expect(this.player1).toBeAbleToSelect(this.yxlTheIronCaptain);
+            expect(this.player1).not.toBeAbleToSelect(this.pelf);
+            expect(this.player1).not.toBeAbleToSelect(this.blypyp);
+            expect(this.player1).not.toBeAbleToSelect(this.ironyxRebel2);
+            this.player1.clickCard(this.ironyxVatminder);
+            this.player1.clickCard(this.yxlTheIronCaptain);
+            this.player1.clickPrompt('Done');
+            expect(this.player2.amber).toBe(0);
+            expect(this.ironyxRebel.amber).toBe(0);
+            expect(this.ironyxVatminder.amber).toBe(2);
+            expect(this.yxlTheIronCaptain.amber).toBe(1);
+            expect(this.pelf.amber).toBe(0);
+            expect(this.blypyp.amber).toBe(0);
+        });
+
+        it('should give leftover amber to last-clicked creature', function () {
+            this.ironyxRebel2 = this.player2.player.creaturesInPlay[0];
+            this.player2.amber = 3;
+            this.player1.play(this.yxlTheIronCaptain);
+            expect(this.player1).toBeAbleToSelect(this.ironyxRebel);
+            expect(this.player1).toBeAbleToSelect(this.ironyxVatminder);
+            expect(this.player1).toBeAbleToSelect(this.yxlTheIronCaptain);
+            expect(this.player1).not.toBeAbleToSelect(this.pelf);
+            expect(this.player1).not.toBeAbleToSelect(this.blypyp);
+            expect(this.player1).not.toBeAbleToSelect(this.ironyxRebel2);
+            this.player1.clickCard(this.yxlTheIronCaptain);
+            this.player1.clickCard(this.ironyxVatminder);
+            this.player1.clickPrompt('Done');
+            expect(this.player2.amber).toBe(0);
+            expect(this.ironyxRebel.amber).toBe(0);
+            expect(this.ironyxVatminder.amber).toBe(1);
+            expect(this.yxlTheIronCaptain.amber).toBe(2);
+            expect(this.pelf.amber).toBe(0);
+            expect(this.blypyp.amber).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
This is the first time multiple creatures are capturing an amount that is more than 1, so it required a change to make sure too much amber wasn't taken from the opponent.  For now the leftover just goes to the last-clicked creature, but maybe we want to improve that interface a bit in the future.

Issue: #2903