### PR TITLE
Woe friendship

### DIFF
--- a/server/game/cards/06-WoE/Friendship.js
+++ b/server/game/cards/06-WoE/Friendship.js
@@ -1,0 +1,53 @@
+const Card = require('../../Card.js');
+
+class Friendship extends Card {
+    setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onDamageApplied: (event, context) =>
+                    event.card === context.source.parent &&
+                    context.source.parent.neighbors.length > 0 &&
+                    event.amount > 0
+            },
+            gameAction: ability.actions.changeEvent((context) => ({
+                event: context.event,
+                cancel: true,
+                postHandler: (event) => {
+                    let neighbors = context.source.parent.neighbors;
+                    let damage = context.event.amount;
+                    let damagePerNeighbor = Math.floor(damage / neighbors.length);
+                    let remainder = damage % neighbors.length;
+
+                    ability.actions
+                        .applyDamage({
+                            amount: damagePerNeighbor,
+                            damageSource: event.damageSource
+                        })
+                        .resolve(neighbors, context);
+
+                    if (remainder > 0) {
+                        // Ask the player which neighbor should receive the extra damage
+                        context.game.promptForSelect(context.game.activePlayer, {
+                            activePromptTitle: 'Select a neighbor to receive extra damage',
+                            source: context.source,
+                            cardCondition: (card) => neighbors.includes(card),
+                            onSelect: (player, card) => {
+                                context.game.actions
+                                    .applyDamage({
+                                        amount: remainder,
+                                        damageSource: event.damageSource
+                                    })
+                                    .resolve(card, context);
+                                return true;
+                            }
+                        });
+                    }
+                }
+            }))
+        });
+    }
+}
+
+Friendship.id = 'friendship';
+
+module.exports = Friendship;

--- a/server/game/cards/06-WoE/Friendship.js
+++ b/server/game/cards/06-WoE/Friendship.js
@@ -12,16 +12,17 @@ class Friendship extends Card {
             gameAction: ability.actions.changeEvent((context) => ({
                 event: context.event,
                 cancel: true,
-                postHandler: (event) => {
+                postHandler: () => {
                     let neighbors = context.source.parent.neighbors;
                     let damage = context.event.amount;
                     let damagePerNeighbor = Math.floor(damage / neighbors.length);
                     let remainder = damage % neighbors.length;
 
+                    // Add the evenly-split damage.
                     ability.actions
-                        .applyDamage({
-                            amount: damagePerNeighbor,
-                            damageSource: event.damageSource
+                        .addDamageToken({
+                            noGameStateCheck: true,
+                            amount: damagePerNeighbor
                         })
                         .resolve(neighbors, context);
 
@@ -32,10 +33,9 @@ class Friendship extends Card {
                             source: context.source,
                             cardCondition: (card) => neighbors.includes(card),
                             onSelect: (player, card) => {
-                                context.game.actions
-                                    .applyDamage({
-                                        amount: remainder,
-                                        damageSource: event.damageSource
+                                ability.actions
+                                    .addDamageToken({
+                                        amount: damagePerNeighbor
                                     })
                                     .resolve(card, context);
                                 return true;

--- a/test/server/cards/06-WoE/Friendship.spec.js
+++ b/test/server/cards/06-WoE/Friendship.spec.js
@@ -58,6 +58,17 @@ describe('Friendship', function () {
             });
         });
 
+        describe('five damage is distributed among two creatures', function () {
+            it('can destroy a creature, including warded creatures', function () {
+                this.player1.fightWith(this.reveredMonk, this.mother);
+                expect(this.player1).toHavePrompt('Friendship');
+                this.player1.clickCard(this.chancellorDexterus);
+                expect(this.reveredMonk.tokens.damage).toBe(undefined);
+                expect(this.paraguardian.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.location).toBe('discard');
+            });
+        });
+
         it('applies damage after armor', function () {
             this.player1.playCreature(this.challeTheSafeguard, true, true);
             this.player1.clickCard(this.chancellorDexterus);

--- a/test/server/cards/06-WoE/Friendship.spec.js
+++ b/test/server/cards/06-WoE/Friendship.spec.js
@@ -1,0 +1,89 @@
+describe('Friendship', function () {
+    describe("Friendship's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    amber: 4,
+                    token: 'defender',
+                    inPlay: ['paraguardian', 'revered-monk', 'chancellor-dexterus'],
+                    hand: ['friendship', 'challe-the-safeguard', 'friendship']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['batdrone', 'quixo-the-adventurer', 'dr-escotera', 'mother'],
+                    discard: []
+                }
+            });
+
+            this.friendship1 = this.player1.hand[0];
+            this.friendship2 = this.player1.hand[2];
+            this.player1.playUpgrade(this.friendship1, this.reveredMonk);
+            this.chancellorDexterus.tokens.ward = 1;
+        });
+
+        describe('two damage is distributed among two creatures', function () {
+            it('should split damage evenly without a prompt', function () {
+                this.player1.fightWith(this.reveredMonk, this.batdrone);
+                expect(this.reveredMonk.tokens.damage).toBe(undefined);
+                expect(this.paraguardian.tokens.damage).toBe(1);
+                expect(this.chancellorDexterus.tokens.damage).toBe(1);
+                expect(this.chancellorDexterus.tokens.ward).toBe(1);
+            });
+        });
+
+        describe('three damage is distributed among two creatures', function () {
+            it('should give an extra prompt to distribute the one extra damage', function () {
+                this.player1.fightWith(this.reveredMonk, this.quixoTheAdventurer);
+                expect(this.player1).toHavePrompt('Friendship');
+                expect(this.player1).not.toBeAbleToSelect(this.quixoTheAdventurer); // enemy creature
+                expect(this.player1).toBeAbleToSelect(this.paraguardian);
+                expect(this.player1).not.toBeAbleToSelect(this.reveredMonk); // friendly creature that was dealt damage
+                expect(this.player1).toBeAbleToSelect(this.chancellorDexterus);
+                this.player1.clickCard(this.paraguardian);
+                expect(this.reveredMonk.tokens.damage).toBe(undefined);
+                expect(this.paraguardian.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.tokens.damage).toBe(1);
+                expect(this.chancellorDexterus.tokens.ward).toBe(1);
+            });
+        });
+
+        describe('four damage is distributed among two creatures', function () {
+            it('should split damage evenly without a prompt', function () {
+                this.player1.fightWith(this.reveredMonk, this.drEscotera);
+                expect(this.reveredMonk.tokens.damage).toBe(undefined);
+                expect(this.paraguardian.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.tokens.ward).toBe(1);
+            });
+        });
+
+        it('applies damage after armor', function () {
+            this.player1.playCreature(this.challeTheSafeguard, true, true);
+            this.player1.clickCard(this.chancellorDexterus);
+            this.player1.fightWith(this.reveredMonk, this.mother);
+            expect(this.player1).toHavePrompt('Friendship');
+            expect(this.player1).not.toBeAbleToSelect(this.mother); // enemy creature
+            expect(this.player1).toBeAbleToSelect(this.paraguardian);
+            expect(this.player1).not.toBeAbleToSelect(this.reveredMonk); // friendly creature that was dealt damage
+            expect(this.player1).toBeAbleToSelect(this.challeTheSafeguard);
+            this.player1.clickCard(this.paraguardian);
+            expect(this.reveredMonk.tokens.damage).toBe(undefined);
+            expect(this.paraguardian.tokens.damage).toBe(2);
+            expect(this.challeTheSafeguard.tokens.damage).toBe(1);
+            expect(this.chancellorDexterus.tokens.damage).toBe(undefined);
+            expect(this.chancellorDexterus.tokens.ward).toBe(1);
+        });
+
+        describe('when damage is redirected onto a creature upgraded with Friendship', function () {
+            it('does not redirect a second time', function () {
+                this.player1.playUpgrade(this.friendship2, this.paraguardian);
+                this.player1.fightWith(this.reveredMonk, this.drEscotera);
+                expect(this.reveredMonk.tokens.damage).toBe(undefined);
+                expect(this.paraguardian.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.tokens.damage).toBe(2);
+                expect(this.chancellorDexterus.tokens.ward).toBe(1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
~~Not working yet. The result of the last `it` show that none of the creatures take damage. I think using applyDamage to redirect the divided damage is likely the problem.~~

EDIT: [this commit](https://github.com/keyteki/keyteki/pull/3178/commits/a5527ccd9d0822991d82c11adf27169f84f4f8da) add tokens instead of applying damage, and this allows the neighboring Friendship test to pass.