### PR TITLE
WoE: implement Near-Future Lens

### DIFF
--- a/server/game/CardVisibility.js
+++ b/server/game/CardVisibility.js
@@ -28,7 +28,7 @@ class CardVisibility {
     }
 
     isEffectRule(card) {
-        if (card.getEffects('visbileIn').some((effect) => effect === card.location)) {
+        if (card.getEffects('visibleIn').some((effect) => effect === card.location)) {
             return true;
         }
 

--- a/server/game/CardVisibility.js
+++ b/server/game/CardVisibility.js
@@ -28,7 +28,15 @@ class CardVisibility {
     }
 
     isEffectRule(card) {
-        return card.getEffects('visbileIn').some((effect) => effect === card.location);
+        if (card.getEffects('visbileIn').some((effect) => effect === card.location)) {
+            return true;
+        }
+
+        return (
+            card.location === 'deck' &&
+            card.controller.deck[0] === card &&
+            card.controller.isTopCardOfDeckVisible()
+        );
     }
 
     isControllerRule(card, player) {

--- a/server/game/GameActions/RevealAction.js
+++ b/server/game/GameActions/RevealAction.js
@@ -4,6 +4,7 @@ class RevealAction extends CardGameAction {
     setDefaultProperties() {
         this.chatMessage = false;
         this.location = ['hand'];
+        this.facedown = true;
     }
 
     setup() {
@@ -25,6 +26,7 @@ class RevealAction extends CardGameAction {
             if (this.chatMessage) {
                 context.game.addMessage('{0} reveals {1}', context.source, card);
             }
+            card.facedown = this.facedown;
         });
     }
 }

--- a/server/game/cards/04-MM/TheArchivist.js
+++ b/server/game/cards/04-MM/TheArchivist.js
@@ -4,7 +4,7 @@ class TheArchivist extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            effect: ability.effects.visbileIn('archives')
+            effect: ability.effects.visibleIn('archives')
         });
         this.persistentEffect({
             condition: (context) =>

--- a/server/game/cards/06-WoE/NearFutureLens.js
+++ b/server/game/cards/06-WoE/NearFutureLens.js
@@ -1,0 +1,30 @@
+const Card = require('../../Card.js');
+
+class NearFutureLens extends Card {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: (context) => context.player === context.source.controller,
+            location: 'play area',
+            effect: ability.effects.topCardOfDeckVisible(this)
+        });
+
+        this.play({
+            gameAction: ability.actions.reveal((context) => ({
+                target: context.player.deck[0],
+                location: 'deck',
+                facedown: false
+            }))
+        });
+
+        this.omni({
+            gameAction: ability.actions.playCard((context) => ({
+                revealOnIllegalTarget: true,
+                target: context.player.deck[0]
+            }))
+        });
+    }
+}
+
+NearFutureLens.id = 'near-future-lens';
+
+module.exports = NearFutureLens;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -131,7 +131,8 @@ const Effects = {
     stopHouseChoice: (house) => EffectBuilder.player.flexible('stopHouseChoice', house),
     skipStep: (step) => EffectBuilder.player.static('skipStep', step),
     opponentCardsCannotLeaveArchives: (card) =>
-        EffectBuilder.player.static('opponentCardsCannotLeaveArchives', card)
+        EffectBuilder.player.static('opponentCardsCannotLeaveArchives', card),
+    topCardOfDeckVisible: (card) => EffectBuilder.player.static('topCardOfDeckVisible', card)
 };
 
 module.exports = Effects;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -39,7 +39,7 @@ const Effects = {
     entersPlayStunned: (condition) =>
         EffectBuilder.card.static('entersPlayStunned', new ConditionValue(condition)),
     flipToken: () => EffectBuilder.card.static('flipToken'),
-    visbileIn: (location) => EffectBuilder.card.static('visbileIn', location),
+    visibleIn: (location) => EffectBuilder.card.static('visibleIn', location),
     gainAbility: (type, properties) =>
         EffectBuilder.card.static('gainAbility', new GainAbility(type, properties)),
     fightAbilitiesAddReap: () => EffectBuilder.card.static('fightAbilitiesAddReap'),

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -195,6 +195,13 @@ class Player extends GameObject {
     shuffleDeck() {
         this.game.emitEvent('onDeckShuffled', { player: this });
         this.deck = _.shuffle(this.deck);
+        if (this.isTopCardOfDeckVisible() && this.deck.length > 0) {
+            this.deck[0].facedown = false;
+            this.deck.slice(1).forEach((card) => {
+                card.facedown = true;
+            });
+            this.game.addMessage('{0} reveals {1} on top of their deck', this, this.deck[0]);
+        }
     }
 
     /**
@@ -476,6 +483,7 @@ class Player extends GameObject {
             return;
         }
 
+        let oldTopOfDeck = this.deck[0];
         this.removeCardFromPile(card);
         let location = card.location;
 
@@ -560,6 +568,19 @@ class Player extends GameObject {
                 from: location,
                 to: targetLocation
             });
+        }
+
+        if (this.isTopCardOfDeckVisible() && this.deck.length > 0) {
+            this.deck[0].facedown = false;
+
+            // In case a new card was added on top of the deck.
+            if (this.deck.length > 1) {
+                this.deck[1].facedown = true;
+            }
+
+            if (oldTopOfDeck != this.deck[0]) {
+                this.game.addMessage('{0} reveals {1} on top of their deck', this, this.deck[0]);
+            }
         }
     }
 
@@ -943,6 +964,10 @@ class Player extends GameObject {
         return this.getEffects('additionalCost')
             .reduce((array, costFactory) => array.concat(costFactory(context)), [])
             .filter((cost) => !!cost);
+    }
+
+    isTopCardOfDeckVisible() {
+        return this.getEffects('topCardOfDeckVisible').length > 0;
     }
 
     setWins(wins) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -200,7 +200,7 @@ class Player extends GameObject {
             this.deck.slice(1).forEach((card) => {
                 card.facedown = true;
             });
-            this.game.addMessage('{0} reveals {1} on top of their deck', this, this.deck[0]);
+            this.addTopCardOfDeckVisibleMessage();
         }
     }
 
@@ -579,7 +579,7 @@ class Player extends GameObject {
             }
 
             if (oldTopOfDeck != this.deck[0]) {
-                this.game.addMessage('{0} reveals {1} on top of their deck', this, this.deck[0]);
+                this.addTopCardOfDeckVisibleMessage();
             }
         }
     }
@@ -968,6 +968,15 @@ class Player extends GameObject {
 
     isTopCardOfDeckVisible() {
         return this.getEffects('topCardOfDeckVisible').length > 0;
+    }
+
+    addTopCardOfDeckVisibleMessage() {
+        this.game.addMessage(
+            '{0} uses {1} to reveal {2} on top of their deck',
+            this,
+            this.mostRecentEffect('topCardOfDeckVisible'),
+            this.deck[0]
+        );
     }
 
     setWins(wins) {

--- a/test/server/cards/06-WoE/NearFutureLens.spec.js
+++ b/test/server/cards/06-WoE/NearFutureLens.spec.js
@@ -1,0 +1,68 @@
+describe('Near-Future Lens', function () {
+    describe("Near-Future Len's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 1,
+                    house: 'brobnar',
+                    hand: ['pelf', 'near-future-lens', 'help-from-future-self'],
+                    discard: ['timetraveller']
+                },
+                player2: {
+                    amber: 1,
+                    inPlay: ['shooler']
+                }
+            });
+        });
+
+        it('should make the top card of your deck visible', function () {
+            this.topCard = this.player1.player.deck[0];
+            expect(this.topCard.getSummary(this.player1.player).facedown).toBe(false);
+            expect(this.topCard.getSummary(this.player2.player).facedown).toBe(true);
+
+            this.player1.play(this.nearFutureLens);
+
+            expect(this.topCard.getSummary(this.player1.player).facedown).toBe(false);
+            expect(this.topCard.getSummary(this.player2.player).facedown).toBe(false);
+
+            this.player1.endTurn();
+        });
+
+        it('should make the top card of your deck playable', function () {
+            this.player1.play(this.nearFutureLens);
+            this.player1.play(this.pelf);
+            this.player1.endTurn();
+            this.player2.clickPrompt('dis');
+            this.player2.endTurn();
+            this.player1.clickPrompt('untamed');
+
+            // All cards in the deck are Anger.
+            this.player1.useAction(this.nearFutureLens, true);
+            this.player1.clickCard(this.pelf);
+            this.player1.clickCard(this.shooler);
+            expect(this.player2.amber).toBe(0);
+
+            // New top card is faceup to both players.
+            expect(this.player1.deck[0].getSummary(this.player1.player).facedown).toBe(false);
+            expect(this.player1.deck[0].getSummary(this.player2.player).facedown).toBe(false);
+        });
+
+        it('should work after a shuffle', function () {
+            this.player1.play(this.nearFutureLens);
+            this.player1.play(this.pelf);
+            this.player1.endTurn();
+            this.player2.clickPrompt('dis');
+            this.player2.endTurn();
+            this.player1.clickPrompt('logos');
+
+            this.player1.play(this.helpFromFutureSelf);
+            this.player1.clickCard(this.timetraveller);
+            this.player1.clickPrompt('Done');
+
+            // New top card after shuffle is faceup to both players.
+            expect(this.player1.deck[0].getSummary(this.player1.player).facedown).toBe(false);
+            expect(this.player1.deck[0].getSummary(this.player2.player).facedown).toBe(false);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+    });
+});


### PR DESCRIPTION
Basic idea here is to print a message for the new top card every time
the top card of the deck changes, and to always have that top card
marked as not "facedown".  Currently unable to test it in the actual
UI but hopefully it works???

Fixes #3170