### PR TITLE
Add effect messages

### DIFF
--- a/server/game/cards/01-Core/EtherSpider.js
+++ b/server/game/cards/01-Core/EtherSpider.js
@@ -18,7 +18,8 @@ class EtherSpider extends Card {
                     event: context.event,
                     amount: 0
                 }))
-            ])
+            ]),
+            effect: "capture amber instead of adding it to opponent's pool"
         });
 
         this.persistentEffect({

--- a/server/game/cards/06-WoE/Braindart.js
+++ b/server/game/cards/06-WoE/Braindart.js
@@ -14,7 +14,8 @@ class Braindart extends Card {
                         player: context.player.opponent
                     }))
                 ])
-            }
+            },
+            effect: 'enrage {0} and make it capture 1 amber from its own side'
         });
     }
 }

--- a/server/game/cards/06-WoE/CelestialGorm.js
+++ b/server/game/cards/06-WoE/CelestialGorm.js
@@ -13,7 +13,8 @@ class CelestialGorm extends Card {
                         (card) => card.type === 'artifact' && card !== context.source
                     )
                 }))
-            ])
+            ]),
+            effect: "destroy {0} and return each other artifact to its owner's hand"
         });
     }
 }

--- a/server/game/cards/06-WoE/CornerTheMarket.js
+++ b/server/game/cards/06-WoE/CornerTheMarket.js
@@ -45,7 +45,13 @@ class CornerTheMarket extends Card {
                                 cancel: true
                             }))
                         })
-                    ])
+                    ]),
+                    message: '{0} uses {1} to allow archival of {2} instead of discard',
+                    messageArgs: (context) => [
+                        context.player.opponent,
+                        context.source,
+                        context.event.card
+                    ]
                 })
             ]
         });

--- a/server/game/cards/06-WoE/EndlessHordes.js
+++ b/server/game/cards/06-WoE/EndlessHordes.js
@@ -48,7 +48,8 @@ class EndlessHordes extends Card {
                             }
                         })
                     }))
-                }
+                },
+                message: '{0} uses {1} to ready and fight with all tokens'
             }
         });
     }

--- a/server/game/cards/06-WoE/EpicPoem.js
+++ b/server/game/cards/06-WoE/EpicPoem.js
@@ -13,7 +13,9 @@ class EpicPoem extends Card {
                         target: context.player
                     }))
                 ])
-            }
+            },
+            effect: 'exalt {0} and gain {1} amber',
+            effectArgs: (context) => [context.target.amber + 1]
         });
     }
 }

--- a/server/game/cards/06-WoE/EpicPoem.js
+++ b/server/game/cards/06-WoE/EpicPoem.js
@@ -1,5 +1,6 @@
 const Card = require('../../Card.js');
 class EpicPoem extends Card {
+    // Play: Exalt a friendly creature. Gain 1Aember icon for each Aember icon on that creature.
     setupCardAbilities(ability) {
         this.play({
             target: {

--- a/server/game/cards/06-WoE/FleaMarket.js
+++ b/server/game/cards/06-WoE/FleaMarket.js
@@ -5,7 +5,7 @@ class FleaMarket extends Card {
     // Action: Look at a random card in your opponent's hand. You may give your opponent 1 Aember icon. If you do, play that card as if it were yours.
     setupCardAbilities(ability) {
         this.action({
-            effect: "reveal a random card from {1}'s hand",
+            effect: "reveal a random card from {1}'s hand and optionally lose 1 amber to play it",
             effectArgs: (context) => context.player.opponent,
             gameAction: ability.actions.reveal((context) => ({
                 location: 'hand',

--- a/server/game/cards/06-WoE/FleaMarket.js
+++ b/server/game/cards/06-WoE/FleaMarket.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 const Card = require('../../Card.js');
 
 class FleaMarket extends Card {
+    // Action: Look at a random card in your opponent's hand. You may give your opponent 1 Aember icon. If you do, play that card as if it were yours.
     setupCardAbilities(ability) {
         this.action({
             effect: "reveal a random card from {1}'s hand",

--- a/server/game/cards/06-WoE/GedHammer.js
+++ b/server/game/cards/06-WoE/GedHammer.js
@@ -23,7 +23,8 @@ class GedHammer extends Card {
                             card.type === 'creature'
                     )
                 }))
-            ])
+            ]),
+            effect: 'ready and enrage each other friendly Brobnar creature'
         });
     }
 }

--- a/server/game/cards/06-WoE/GemcoatVendor.js
+++ b/server/game/cards/06-WoE/GemcoatVendor.js
@@ -9,7 +9,8 @@ class GemcoatVendor extends Card {
                 ability.actions.dealDamage((context) => ({
                     target: context.source
                 }))
-            ])
+            ]),
+            effect: 'Steal 1 amber and deal 1 damage to {0}'
         });
     }
 }

--- a/server/game/cards/06-WoE/GezdrutyoTheArcane.js
+++ b/server/game/cards/06-WoE/GezdrutyoTheArcane.js
@@ -7,7 +7,8 @@ class GezdrutyoTheArcane extends Card {
             gameAction: ability.actions.sequential([
                 ability.actions.steal({ amount: 2 }),
                 ability.actions.flip()
-            ])
+            ]),
+            effect: 'Steal 2 amber and flip {0} facedown'
         });
     }
 }

--- a/server/game/cards/06-WoE/Initiation.js
+++ b/server/game/cards/06-WoE/Initiation.js
@@ -5,8 +5,7 @@ class Initiation extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'make a token creature{1}',
-            effectArgs: (context) =>
-                context.player.hand.length < 4 ? ' and archive this card' : '',
+            effectArgs: (context) => (context.player.hand.length < 4 ? ' and archive itself' : ''),
             gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({

--- a/server/game/cards/06-WoE/Kaboom.js
+++ b/server/game/cards/06-WoE/Kaboom.js
@@ -12,7 +12,9 @@ class Kaboom extends Card {
                     target: context.game.creaturesInPlay
                 })),
                 ability.actions.gainChains({ amount: 3 })
-            ])
+            ]),
+            effect:
+                "Put each Mars creature into its owner's archives, destroy each creature, and gain 3 chains."
         });
     }
 }

--- a/server/game/cards/06-WoE/KelpingHands.js
+++ b/server/game/cards/06-WoE/KelpingHands.js
@@ -14,7 +14,10 @@ class KelpingHands extends Card {
                         poison: 1
                     })
                 })
-            ])
+            ]),
+            effect:
+                'destroy {0}. For the remainder of the turn, each friendly creature gains poison',
+            effectAlert: true
         });
     }
 }

--- a/server/game/cards/06-WoE/MagistrateCrispus.js
+++ b/server/game/cards/06-WoE/MagistrateCrispus.js
@@ -22,7 +22,8 @@ class MagistrateCrispus extends Card {
                             card.controller !== card.owner
                     )
                     .map((card) => ability.effects.takeControl(card.owner))
-            }))
+            })),
+            effect: 'return control of each creature and artifact to their owners'
         });
     }
 }

--- a/server/game/cards/06-WoE/MembershipDrive.js
+++ b/server/game/cards/06-WoE/MembershipDrive.js
@@ -9,7 +9,8 @@ class MembershipDrive extends Card {
                 ability.actions.gainAmber((context) => ({
                     amount: context.player.creaturesInPlay.filter((c) => c.isToken()).length
                 }))
-            ])
+            ]),
+            effect: 'make a token creature and gain 1 amber for each friendly token creature'
         });
     }
 }

--- a/server/game/cards/06-WoE/MightClub.js
+++ b/server/game/cards/06-WoE/MightClub.js
@@ -10,7 +10,8 @@ class MightClub extends Card {
                     ability.actions.ready(),
                     ability.actions.enrage()
                 ])
-            }
+            },
+            effect: 'ready and enrage {0}'
         });
     }
 }

--- a/server/game/cards/06-WoE/Muster.js
+++ b/server/game/cards/06-WoE/Muster.js
@@ -12,7 +12,12 @@ class Muster extends Card {
                         context.player.opponent.amber > context.player.amber,
                     trueGameAction: ability.actions.archive()
                 })
-            ])
+            ]),
+            effect: 'make a token creature{1}',
+            effectArgs: (context) =>
+                context.player.opponent && context.player.opponent.amber > context.player.amber
+                    ? ' and archive Muster'
+                    : ''
         });
     }
 }

--- a/server/game/cards/06-WoE/StrongerTogether.js
+++ b/server/game/cards/06-WoE/StrongerTogether.js
@@ -17,7 +17,9 @@ class StrongerTogether extends Card {
                             .some((house) => !card.neighbors[1].hasHouse(house))
                 ),
                 action: ability.actions.ready()
-            }))
+            })),
+            effect:
+                'ready each Star Alliance creature that has 2 non-Star Alliance neighbors of different houses'
         });
     }
 }

--- a/server/game/cards/06-WoE/Symposium.js
+++ b/server/game/cards/06-WoE/Symposium.js
@@ -16,6 +16,7 @@ class Symposium extends Card {
                     ability.actions.use()
                 ])
             },
+            effect: 'exalt, ready, and use {0}',
             then: (preThenContext) => ({
                 condition: () => preThenContext.target.isToken(),
                 target: {
@@ -28,7 +29,8 @@ class Symposium extends Card {
                         ability.actions.ready(),
                         ability.actions.use()
                     ])
-                }
+                },
+                message: 'exalt, ready, and use {2}'
             })
         });
     }

--- a/server/game/cards/06-WoE/TalentScout.js
+++ b/server/game/cards/06-WoE/TalentScout.js
@@ -1,6 +1,8 @@
 const Card = require('../../Card.js');
 
 class TalentScout extends Card {
+    // Talent Scout may be used as if it belonged to the active house.
+    // Play: Look at your opponent's hand and play a creature from it as if it were yours. Your opponent takes control of Talent Scout.
     setupCardAbilities(ability) {
         this.play({
             target: {

--- a/server/game/cards/06-WoE/TalentScout.js
+++ b/server/game/cards/06-WoE/TalentScout.js
@@ -16,7 +16,10 @@ class TalentScout extends Card {
                         effect: ability.effects.takeControl(context.player.opponent)
                     }))
                 ])
-            }
+            },
+            effect:
+                "look at opponent's hand and play a creature, and give control of {1} to opponent",
+            effectArgs: (context) => context.source
         });
     }
 }

--- a/server/game/cards/06-WoE/TheAmberRoad.js
+++ b/server/game/cards/06-WoE/TheAmberRoad.js
@@ -1,6 +1,7 @@
 const Card = require('../../Card.js');
 
 class TheAmberRoad extends Card {
+    // Omni: Put 1 trade counter on The Æmber Road, then gain 1 Aember icon for each trade counter on it. Give control of The Æmber Road to your opponent.
     setupCardAbilities(ability) {
         this.omni({
             effect: 'to put a trade counter on {0}, gain {1} amber, and give control to {2}',

--- a/server/game/cards/06-WoE/TokenOfAppreciation.js
+++ b/server/game/cards/06-WoE/TokenOfAppreciation.js
@@ -7,9 +7,8 @@ class TokenOfAppreciation extends Card {
     // each friendly token creature.
     setupCardAbilities(ability) {
         this.play({
-            message:
-                '{0} uses {1} to make a token creature and forge a key for +7 current cost, minus 1 amber for each friendly token creature',
-            messageArgs: (context) => [context.player, context.source],
+            effect:
+                'make a token creature and forge a key for +7 current cost, minus 1 amber for each friendly token creature',
             gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.forgeKey((context) => ({

--- a/server/game/cards/06-WoE/Trader.js
+++ b/server/game/cards/06-WoE/Trader.js
@@ -7,7 +7,8 @@ class Trader extends Card {
             gameAction: ability.actions.sequential([
                 ability.actions.steal(),
                 ability.actions.destroy()
-            ])
+            ]),
+            effect: 'steal 1 amber and destroy {0}'
         });
     }
 }

--- a/test/server/cards/06-WoE/EpicPoem.spec.js
+++ b/test/server/cards/06-WoE/EpicPoem.spec.js
@@ -15,7 +15,7 @@ describe('Epic Poem', function () {
             });
         });
 
-        it('should exalt and gain ameber', function () {
+        it('should exalt and gain amber', function () {
             expect(this.player1.amber).toBe(1);
 
             this.flaxia.addToken('amber', 2);


### PR DESCRIPTION
closes #3233

Add `effect` messages to cards which use `gameActions.sequential`. Tested using the environemnt variable `DEBUG_TEST=1` to show messages.

Before:

`"[player] uses [card] to do several things"`

After:

Card-specific text

n.b., for Corner the Market, I could not figure out how to show specific messages based on discard vs archive

https://github.com/keyteki/keyteki/blob/9b522d7e14f6114cab5f9c7bffd4bc40bcf8d7ed/server/game/cards/06-WoE/CornerTheMarket.js#L49-L54