### PR TITLE
WoE: fix and clean up the "make a token" cards in each house

### DIFF
--- a/server/game/cards/06-WoE/CloneHome.js
+++ b/server/game/cards/06-WoE/CloneHome.js
@@ -5,21 +5,23 @@ class CloneHome extends Card {
     // creatures than enemy creatures, archive Clone Home.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: [
+            gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
+                        !!context.player.opponent &&
                         context.player.creaturesInPlay.length >
-                        context.player.opponent.creaturesInPlay.length,
+                            context.player.opponent.creaturesInPlay.length,
                     trueGameAction: ability.actions.archive((context) => ({
                         target: context.source
                     }))
                 })
-            ],
+            ]),
             effect: 'make a token creature{1}{2}',
             effectArgs: (context) =>
+                !!context.player.opponent &&
                 context.player.creaturesInPlay.length >
-                context.player.opponent.creaturesInPlay.length
+                    context.player.opponent.creaturesInPlay.length
                     ? [' and archive ', context.source]
                     : ['', '']
         });

--- a/server/game/cards/06-WoE/HireOn.js
+++ b/server/game/cards/06-WoE/HireOn.js
@@ -5,7 +5,7 @@ class HireOn extends Card {
     // Aember or more between both players' pools, archive Hire On.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: [
+            gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
@@ -17,7 +17,7 @@ class HireOn extends Card {
                         target: context.source
                     }))
                 })
-            ],
+            ]),
             effect: 'make a token creature{1}{2}',
             effectArgs: (context) =>
                 context.player.amber +

--- a/server/game/cards/06-WoE/Muster.js
+++ b/server/game/cards/06-WoE/Muster.js
@@ -8,14 +8,14 @@ class Muster extends Card {
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
-                        !!context.player.opponent &&
+                        context.player.opponent &&
                         context.player.opponent.amber > context.player.amber,
                     trueGameAction: ability.actions.archive()
                 })
             ]),
             effect: 'make a token creature{1}',
             effectArgs: (context) =>
-                !!context.player.opponent && context.player.opponent.amber > context.player.amber
+                context.player.opponent && context.player.opponent.amber > context.player.amber
                     ? ' and archive Muster'
                     : ''
         });

--- a/server/game/cards/06-WoE/Muster.js
+++ b/server/game/cards/06-WoE/Muster.js
@@ -8,14 +8,14 @@ class Muster extends Card {
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
-                        context.player.opponent &&
+                        !!context.player.opponent &&
                         context.player.opponent.amber > context.player.amber,
                     trueGameAction: ability.actions.archive()
                 })
             ]),
             effect: 'make a token creature{1}',
             effectArgs: (context) =>
-                context.player.opponent && context.player.opponent.amber > context.player.amber
+                !!context.player.opponent && context.player.opponent.amber > context.player.amber
                     ? ' and archive Muster'
                     : ''
         });

--- a/server/game/cards/06-WoE/PressGang.js
+++ b/server/game/cards/06-WoE/PressGang.js
@@ -15,20 +15,20 @@ class PressGang extends Card {
         this.tracker.register(['onCardDestroyed', 'onPhaseStarted']);
 
         this.play({
-            gameAction: [
+            gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
-                        context.player.opponent &&
+                        !!context.player.opponent &&
                         this.creaturesDestroyed[context.player.opponent.uuid] >= 1,
                     trueGameAction: ability.actions.archive((context) => ({
                         target: context.source
                     }))
                 })
-            ],
+            ]),
             effect: 'make a token creature{1}{2}',
             effectArgs: (context) =>
-                context.player.opponent &&
+                !!context.player.opponent &&
                 this.creaturesDestroyed[context.player.opponent.uuid] >= 1
                     ? [' and archive ', context.source]
                     : ['', '']

--- a/server/game/cards/06-WoE/PressGang.js
+++ b/server/game/cards/06-WoE/PressGang.js
@@ -19,7 +19,7 @@ class PressGang extends Card {
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
-                        !!context.player.opponent &&
+                        context.player.opponent &&
                         this.creaturesDestroyed[context.player.opponent.uuid] >= 1,
                     trueGameAction: ability.actions.archive((context) => ({
                         target: context.source
@@ -28,7 +28,7 @@ class PressGang extends Card {
             ]),
             effect: 'make a token creature{1}{2}',
             effectArgs: (context) =>
-                !!context.player.opponent &&
+                context.player.opponent &&
                 this.creaturesDestroyed[context.player.opponent.uuid] >= 1
                     ? [' and archive ', context.source]
                     : ['', '']

--- a/server/game/cards/06-WoE/Recruit.js
+++ b/server/game/cards/06-WoE/Recruit.js
@@ -15,16 +15,15 @@ class Recruit extends Card {
         this.tracker.register(['onExalt', 'onPhaseStarted']);
 
         this.play({
-            gameAction: [
+            gameAction: ability.actions.sequential([
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
-                    condition: (context) =>
-                        context.player.opponent && this.creaturesExalted[context.player.uuid] >= 1,
+                    condition: (context) => this.creaturesExalted[context.player.uuid] >= 1,
                     trueGameAction: ability.actions.archive((context) => ({
                         target: context.source
                     }))
                 })
-            ],
+            ]),
             effect: 'make a token creature{1}{2}',
             effectArgs: (context) =>
                 this.creaturesExalted[context.player.uuid] >= 1

--- a/server/game/cards/06-WoE/Teamwork.js
+++ b/server/game/cards/06-WoE/Teamwork.js
@@ -6,7 +6,7 @@ class Teamwork extends Card {
         this.play({
             effect: 'make a token creature{1}',
             effectArgs: (context) =>
-                context.player.opponent &&
+                !!context.player.opponent &&
                 context.player.opponent.creaturesInPlay.length >
                     context.player.creaturesInPlay.length
                     ? ' and archive this card'
@@ -15,7 +15,7 @@ class Teamwork extends Card {
                 ability.actions.makeTokenCreature(),
                 ability.actions.conditional({
                     condition: (context) =>
-                        context.player.opponent &&
+                        !!context.player.opponent &&
                         context.player.opponent.creaturesInPlay.length >
                             context.player.creaturesInPlay.length,
                     trueGameAction: ability.actions.archive()

--- a/test/server/cards/06-WoE/CloneHome.spec.js
+++ b/test/server/cards/06-WoE/CloneHome.spec.js
@@ -5,8 +5,27 @@ describe('Clone Home', function () {
                 player1: {
                     house: 'mars',
                     token: 'grumpus',
-                    hand: ['clone-home', 'blypyp', 'zizok'],
-                    deck: ['pelf', 'pelf', 'pelf', 'pelf', 'pelf']
+                    hand: ['clone-home', 'blypyp', 'zizok']
+                },
+                player2: {
+                    inPlay: ['troll', 'groke']
+                }
+            });
+        });
+
+        it('should not archive if there are fewer friendly creatures', function () {
+            this.player1.play(this.cloneHome);
+            expect(this.cloneHome.location).toBe('discard');
+        });
+    });
+
+    describe("Clone Home's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    token: 'grumpus',
+                    hand: ['clone-home', 'blypyp', 'zizok']
                 },
                 player2: {
                     inPlay: ['troll']
@@ -14,16 +33,16 @@ describe('Clone Home', function () {
             });
         });
 
-        it('should not archive if there are not more friendly creatures', function () {
+        it('should not archive if there are equal friendly creatures', function () {
             this.player1.play(this.cloneHome);
             expect(this.cloneHome.location).toBe('discard');
         });
 
-        it('should not archive if there are equal creatures', function () {
+        it('should archive if the token makes more creatures', function () {
             this.player1.playCreature(this.blypyp, true);
             this.player1.play(this.cloneHome);
             this.player1.clickPrompt('Right');
-            expect(this.cloneHome.location).toBe('discard');
+            expect(this.cloneHome.location).toBe('archives');
         });
 
         it('should archive if there are more friendly creatures', function () {


### PR DESCRIPTION
These all need to be sequential actions, in case making a token effects the archive condition.  Clone Home (and its test) was broken.

Fixes #3274