### PR TITLE
WoE: using placeUnder from the play area should return amber

### DIFF
--- a/server/game/GameActions/PlaceUnderAction.js
+++ b/server/game/GameActions/PlaceUnderAction.js
@@ -31,6 +31,9 @@ class PlaceUnderAction extends CardGameAction {
             this.isGraft ? 'onCardGrafted' : 'onPlaceUnder',
             { card, context },
             () => {
+                if (card.location === 'play area') {
+                    card.onLeavesPlay();
+                }
                 card.controller.removeCardFromPile(card);
                 card.controller = card.owner;
                 card.parent = this.parent;

--- a/test/server/cards/06-WoE/ReplayPod.spec.js
+++ b/test/server/cards/06-WoE/ReplayPod.spec.js
@@ -4,11 +4,13 @@ describe('Replay Pod', function () {
             this.setupTest({
                 player1: {
                     house: 'mars',
-                    hand: ['ammonia-clouds'],
+                    hand: ['ammonia-clouds', 'ether-spider'],
                     inPlay: ['replay-pod', 'yxilo-bolter', 'john-smyth', 'blypyp', 'pelf']
                 },
                 player2: {
-                    inPlay: ['yxili-marauder']
+                    amber: 1,
+                    hand: ['rant-and-rive'],
+                    inPlay: ['yxili-marauder', 'earthshaker']
                 }
             });
         });
@@ -36,6 +38,19 @@ describe('Replay Pod', function () {
             expect(this.pelf.location).toBe('discard');
             expect(this.yxiliMarauder.location).toBe('discard');
             expect(this.replayPod.location).toBe('purged');
+        });
+
+        it('should return amber on ether spider to opponent', function () {
+            this.player1.play(this.etherSpider);
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.play(this.rantAndRive);
+            expect(this.player2.amber).toBe(1);
+            expect(this.etherSpider.tokens.amber).toBe(1);
+            this.player2.fightWith(this.earthshaker, this.etherSpider);
+            expect(this.replayPod.childCards).toContain(this.etherSpider);
+            expect(this.player2.amber).toBe(2);
+            expect(this.etherSpider.tokens.amber).toBe(undefined);
         });
     });
 });


### PR DESCRIPTION
Until Replay Pod, it was never used on cards in the play area.

Fixes #3309
Fixes #3311