### PR TITLE
WoE: use card names to apply the rule of 6, not cards themselves

### DIFF
--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -14,9 +14,8 @@ const Costs = {
     use: () => ({
         canPay: (context) => {
             if (
-                context.game.cardsUsed
-                    .concat(context.game.cardsPlayed)
-                    .filter((card) => card.name === context.source.name).length >= 6
+                context.game.cardNamesPlayedOrUsed.filter((name) => name === context.source.name)
+                    .length >= 6
             ) {
                 return false;
             } else if (

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -74,6 +74,7 @@ class Game extends EventEmitter {
         this.useGameTimeLimit = details.useGameTimeLimit;
         this.startingHandsDrawn = false;
 
+        this.cardNamesPlayedOrUsed = [];
         this.cardsUsed = [];
         this.omegaCard = null;
         this.cardsPlayed = [];
@@ -1299,6 +1300,7 @@ class Game extends EventEmitter {
         }
 
         this.activePlayer.endRound();
+        this.cardNamesPlayedOrUsed = [];
         this.cardsUsed = [];
         this.omegaCard = null;
         this.cardsPlayed = [];
@@ -1397,11 +1399,13 @@ class Game extends EventEmitter {
     cardPlayed(card) {
         this.cardsPlayed.push(card);
         this.cardsPlayedThisPhase.push(card);
+        this.cardNamesPlayedOrUsed.push(card.name);
     }
 
     cardUsed(card) {
         this.cardsUsed.push(card);
         this.cardsUsedThisPhase.push(card);
+        this.cardNamesPlayedOrUsed.push(card.name);
     }
 
     continue() {

--- a/test/server/cards/06-WoE/EndlessHordes.spec.js
+++ b/test/server/cards/06-WoE/EndlessHordes.spec.js
@@ -61,4 +61,48 @@ describe('Endless Hordes', function () {
             expect(this.player1).toBeAbleToSelect(this.championAnaphiel);
         });
     });
+
+    describe("Endless Hordes's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'brobnar',
+                    token: 'grunt',
+                    hand: ['endless-hordes', 'anger']
+                },
+                player2: {
+                    inPlay: [
+                        'bumpsy',
+                        'dust-pixie',
+                        'urchin',
+                        'hunting-witch',
+                        'dodger',
+                        'groke',
+                        'witch-of-the-eye'
+                    ]
+                }
+            });
+        });
+
+        it('should obey the rule of 6', function () {
+            this.player1.play(this.endlessHordes);
+            this.player1.clickPrompt('Right');
+            this.player1.clickPrompt('Right');
+            this.player1.clickPrompt('Right');
+            this.player1.clickPrompt('Right');
+            this.player1.clickPrompt('Right');
+            this.player1.clickPrompt('Right');
+            this.player1.clickCard(this.bumpsy);
+            this.player1.clickCard(this.dustPixie);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.huntingWitch);
+            this.player1.clickCard(this.dodger);
+            this.player1.clickCard(this.groke);
+            expect(
+                this.player1.player.creaturesInPlay[this.player1.player.creaturesInPlay.length - 1]
+                    .exhausted
+            ).toBe(false);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+    });
 });


### PR DESCRIPTION
Because tokens that die end up changing their name back to their printed name, and then would no longer count.

Fixes #3328