### PR TITLE
WoE: The Visible Hand should always reveal your hand

### DIFF
--- a/server/game/GameActions/MakeTokenCreatureAction.js
+++ b/server/game/GameActions/MakeTokenCreatureAction.js
@@ -6,6 +6,7 @@ class MakeTokenCreatureAction extends PlayerAction {
         this.deployIndex = undefined;
         this.cards = null;
         this.cardLocation = 'deck';
+        this.alwaysSucceed = false;
     }
 
     setup() {
@@ -20,7 +21,9 @@ class MakeTokenCreatureAction extends PlayerAction {
     }
 
     canAffect(player, context) {
-        return this.amount === 0 || !player.tokenCard || player.deck.length === 0
+        return this.amount === 0 ||
+            !player.tokenCard ||
+            (player.deck.length === 0 && !this.alwaysSucceed)
             ? false
             : super.canAffect(player, context);
     }

--- a/server/game/cards/06-WoE/TheVisibleHand.js
+++ b/server/game/cards/06-WoE/TheVisibleHand.js
@@ -6,7 +6,10 @@ class TheVisibleHand extends Card {
         this.play({
             effect: 'make 2 token creatures and reveal their hand: {1}',
             effectArgs: (context) => [context.player.hand.map((card) => card).sort()],
-            gameAction: ability.actions.makeTokenCreature({ amount: 2 })
+            gameAction: ability.actions.makeTokenCreature({
+                amount: 2,
+                alwaysSucceed: true
+            })
         });
     }
 }

--- a/test/server/cards/06-WoE/TheVisibleHand.spec.js
+++ b/test/server/cards/06-WoE/TheVisibleHand.spec.js
@@ -17,5 +17,12 @@ describe('The Visible Hand', function () {
             expect(this.player1.player.creaturesInPlay.length).toBe(2);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
+
+        it('works with no deck', function () {
+            this.player1.player.deck = [];
+            this.player1.play(this.theVisibleHand);
+            expect(this.player1.player.creaturesInPlay.length).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
     });
 });


### PR DESCRIPTION
If you have no deck, the make token action should still fire so that we can print the cards to the chat.

Fixes #3330