### PR TITLE
WoE: NFL shouldn't print card names before a shuffle

### DIFF
--- a/server/game/GameActions/ReturnToDeckAction.js
+++ b/server/game/GameActions/ReturnToDeckAction.js
@@ -25,7 +25,10 @@ class ReturnToDeckAction extends CardGameAction {
             eventName,
             { card: card, context: context, deckLength: deckLength },
             () => {
-                card.owner.moveCard(card, 'deck', { bottom: this.bottom });
+                card.owner.moveCard(card, 'deck', {
+                    bottom: this.bottom,
+                    aboutToShuffle: this.shuffle
+                });
                 let cardsByOwner = this.target.filter((c) => c.owner === card.owner);
                 if (
                     this.shuffle &&

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -183,7 +183,7 @@ class Player extends GameObject {
     deckRanOutOfCards() {
         this.game.addMessage("{0}'s deck has run out of cards, so they shuffle", this);
         for (let card of this.discard) {
-            this.moveCard(card, 'deck');
+            this.moveCard(card, 'deck', { aboutToShuffle: true });
         }
 
         this.shuffleDeck();
@@ -570,7 +570,7 @@ class Player extends GameObject {
             });
         }
 
-        if (this.isTopCardOfDeckVisible() && this.deck.length > 0) {
+        if (!options.aboutToShuffle && this.isTopCardOfDeckVisible() && this.deck.length > 0) {
             this.deck[0].facedown = false;
 
             // In case a new card was added on top of the deck.


### PR DESCRIPTION
If cards are being put on top of the deck just before a shuffle, there is no need to print them.

Fixes #3365