### PR TITLE
WoE: don't let The Promised Blade target any artifact

### DIFF
--- a/server/game/cards/06-WoE/ThePromisedBlade.js
+++ b/server/game/cards/06-WoE/ThePromisedBlade.js
@@ -30,18 +30,20 @@ class ThePromisedBlade extends Card {
                         Me: () => true,
                         Opponent: () => true
                     }
-                },
-                then: {
-                    gameAction: ability.actions.cardLastingEffect((context) => ({
-                        duration: 'lastingEffect',
-                        effect: ability.effects.takeControl(
-                            context.selects.select.choice === 'Me'
-                                ? context.game.activePlayer
-                                : context.game.activePlayer.opponent
-                        )
-                    }))
                 }
-            }
+            },
+            then: (preThenContext) => ({
+                alwaysTriggers: true,
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'lastingEffect',
+                    target: context.source,
+                    effect: ability.effects.takeControl(
+                        preThenContext.selects.select.choice === 'Me'
+                            ? context.game.activePlayer
+                            : context.game.activePlayer.opponent
+                    )
+                }))
+            })
         });
 
         // Uneven creature count, automatic
@@ -54,6 +56,7 @@ class ThePromisedBlade extends Card {
             },
             gameAction: ability.actions.cardLastingEffect((context) => ({
                 duration: 'lastingEffect',
+                target: context.source,
                 effect: ability.effects.takeControl(context.source.controller.opponent)
             }))
         });

--- a/server/game/cards/06-WoE/ThePromisedBlade.js
+++ b/server/game/cards/06-WoE/ThePromisedBlade.js
@@ -32,6 +32,12 @@ class ThePromisedBlade extends Card {
                     }
                 }
             },
+            effect: 'give control of {0} to {1}',
+            effectArgs: (context) => [
+                !!context.selects.select && context.selects.select.choice === 'Me'
+                    ? context.game.activePlayer
+                    : context.game.activePlayer.opponent
+            ],
             then: (preThenContext) => ({
                 alwaysTriggers: true,
                 gameAction: ability.actions.cardLastingEffect((context) => ({

--- a/test/server/cards/06-WoE/ThePromisedBlade.spec.js
+++ b/test/server/cards/06-WoE/ThePromisedBlade.spec.js
@@ -47,7 +47,12 @@ describe('The Promised Blade', function () {
                         ]
                     },
                     player2: {
-                        inPlay: ['tyxl-beambuckler', 'myx-the-tallminded', 'xanthyx-harvester'],
+                        inPlay: [
+                            'tyxl-beambuckler',
+                            'myx-the-tallminded',
+                            'xanthyx-harvester',
+                            'sv3-lander'
+                        ],
                         hand: []
                     }
                 });
@@ -58,8 +63,10 @@ describe('The Promised Blade', function () {
                 expect(this.thePromisedBlade.controller).toBe(this.player1.player);
                 expect(this.player2).toHavePrompt('The Promised Blade');
                 this.player2.clickPrompt('Me');
-                this.player2.clickCard(this.thePromisedBlade);
                 expect(this.thePromisedBlade.controller).toBe(this.player2.player);
+                expect(this.player2).toHavePrompt(
+                    'Choose which house you want to activate this turn'
+                );
             });
         });
     });


### PR DESCRIPTION
It was treating `then:` as another target.

Fixes #3383