### PR TITLE
server: actually fix the adaptive token-swap issue

### DIFF
--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -40,6 +40,7 @@ class Deck {
             }
 
             result.card.isNonDeck = card.isNonDeck;
+            result.isNonDeck = card.isNonDeck;
 
             return result;
         });

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -830,13 +830,10 @@ class Game extends EventEmitter {
             if (player2) {
                 const deckData = players[player1].deckData;
                 const houses = players[player1].houses;
-                const tokenCard = players[player1].tokenCard;
                 players[player1].deckData = players[player2].deckData;
                 players[player1].houses = players[player2].houses;
-                players[player1].tokenCard = players[player2].tokenCard;
                 players[player2].houses = houses;
                 players[player2].deckData = deckData;
-                players[player2].tokenCard = tokenCard;
             }
         }
 

--- a/server/game/gamesteps/setup/AdaptiveDeckSelectionPrompt.js
+++ b/server/game/gamesteps/setup/AdaptiveDeckSelectionPrompt.js
@@ -80,7 +80,7 @@ class AdaptiveDeckSelectionPrompt extends AllPlayerPrompt {
                     argType: 'link',
                     label: deck.name
                 };
-                this.game.addMessage('{0} has selected  {1} as their Archon', player.name, link);
+                this.game.addMessage('{0} has selected {1} as their Archon', player.name, link);
             });
             if (player1.owner !== player1.player) {
                 this.game.reInitialisePlayers(true);

--- a/test/helpers/deckbuilder.js
+++ b/test/helpers/deckbuilder.js
@@ -80,10 +80,10 @@ class DeckBuilder {
             deck = deck.concat(defaultFiller[houses[0]]);
         }
 
-        return this.buildDeck(houses, player.token, deck);
+        return this.buildDeck(houses, player.token, deck, player.name + "'s deck");
     }
 
-    buildDeck(houses, token, cardLabels) {
+    buildDeck(houses, token, cardLabels, name) {
         let cardCounts = {};
         _.each(cardLabels, (label) => {
             let cardData = this.getCard(label);
@@ -114,7 +114,8 @@ class DeckBuilder {
 
         return {
             houses: houses,
-            cards: Object.values(cardCounts)
+            cards: Object.values(cardCounts),
+            name: name
         };
     }
 

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -54,6 +54,16 @@ class GameFlowWrapper {
 
     startGame() {
         this.game.initialise();
+        if (this.game.gameFormat === 'adaptive-bo1') {
+            // For now just always swap decks after bidding two chains.
+            // TODO: make this more customizable.
+            this.player1.clickPrompt(this.player2.name + "'s deck");
+            this.player2.clickPrompt(this.player2.name + "'s deck");
+
+            this.player1.clickPrompt('2');
+            this.player2.clickPrompt('Pass');
+        }
+
         this.game.activePlayer = this.player1.player;
         this.player1.clickPrompt('Start the Game');
         this.player2.clickPrompt('Start the Game');

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -243,6 +243,10 @@ beforeEach(function () {
             options.player2 = {};
         }
 
+        if (options.gameFormat) {
+            this.game.gameFormat = options.gameFormat;
+        }
+
         //Build decks
         this.player1.selectDeck(deckBuilder.customDeck(options.player1));
         this.player2.selectDeck(deckBuilder.customDeck(options.player2));

--- a/test/server/tokens.spec.js
+++ b/test/server/tokens.spec.js
@@ -57,3 +57,28 @@ describe('Token', function () {
         });
     });
 });
+
+describe('Token', function () {
+    describe("'s ability for adaptive", function () {
+        beforeEach(function () {
+            this.setupTest({
+                gameFormat: 'adaptive-bo1',
+                player1: {
+                    name: 'player1',
+                    house: 'untamed',
+                    token: 'prospector'
+                },
+                player2: {
+                    name: 'player2',
+                    hand: []
+                }
+            });
+        });
+
+        it('should swap the token during adaptive', function () {
+            expect(this.player1.player.chains).toBe(1);
+            expect(this.player1.player.tokenCard).toBe(undefined);
+            expect(this.player2.player.tokenCard.name).toBe('Prospector');
+        });
+    });
+});


### PR DESCRIPTION
The deckdata was dropping the `isNonDeck` trait for the token card.