### PR TITLE
Fix Grand Melee logic to work with Badge of Unity

### DIFF
--- a/server/game/cards/05-DT/GrandMelee.js
+++ b/server/game/cards/05-DT/GrandMelee.js
@@ -9,10 +9,10 @@ class GrandMelee extends Card {
                 target: context.game.creaturesInPlay.filter(
                     (card) =>
                         card.neighbors.length === 0 ||
-                        Constants.Houses.some(
+                        !Constants.Houses.some(
                             (house) =>
                                 card.hasHouse(house) &&
-                                !card.neighbors.some((neighbor) => neighbor.hasHouse(house))
+                                card.neighbors.some((neighbor) => neighbor.hasHouse(house))
                         )
                 )
             }))

--- a/test/server/cards/05-DT/GrandMelee.spec.js
+++ b/test/server/cards/05-DT/GrandMelee.spec.js
@@ -56,4 +56,37 @@ describe('GrandMelee', function () {
             });
         });
     });
+
+    describe('Action test with Badge of Unity', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'staralliance',
+                    inPlay: ['bulwark', 'the-grey-rider'],
+                    hand: ['grand-melee', 'badge-of-unity']
+                },
+                player2: {
+                    inPlay: ['bumpsy'],
+                    amber: 2
+                }
+            });
+        });
+
+        describe('plays card with Badge of Unity in play', function () {
+            beforeEach(function () {
+                this.player1.playUpgrade(this.badgeOfUnity, this.bulwark);
+                this.player1.endTurn();
+                this.player2.clickPrompt('brobnar');
+                this.player2.endTurn();
+                this.player1.clickPrompt('sanctum');
+                this.player1.play(this.grandMelee);
+            });
+
+            it('destroys card that dont have neighbors', function () {
+                expect(this.bulwark.location).toBe('play area');
+                expect(this.theGreyRider.location).toBe('play area');
+                expect(this.bumpsy.location).toBe('discard');
+            });
+        });
+    });
 });


### PR DESCRIPTION
It just requires one house fulfills the condition, not that some house does not fulfill the condition.  Previously, if the creature had 2 houses (like with Badge of Unity), the logic required it to have neighbors of both houses, but the card doesn't require that.