### PR TITLE
remove unneeded "click card"

### DIFF
--- a/test/server/cards/04-MM/SenatorQuintina.spec.js
+++ b/test/server/cards/04-MM/SenatorQuintina.spec.js
@@ -21,7 +21,6 @@ describe('Senator Quintina', function () {
             expect(this.citizenShrix.tokens.amber).toBe(2);
 
             this.player1.reap(this.senatorQuintina);
-            this.player1.clickCard(this.senatorQuintina);
             expect(this.senatorQuintina.tokens.amber).toBe(1);
         });
 


### PR DESCRIPTION
this is only needed when there are multiple reap effects (e.g. for troll and citizen shrix)