### PR TITLE
Fix: rogue operation and gargantodon messaging

### DIFF
--- a/server/game/cards/03-WC/Gargantodon.js
+++ b/server/game/cards/03-WC/Gargantodon.js
@@ -18,6 +18,7 @@ class Gargantodon extends Card {
             when: {
                 onStealAmber: () => true
             },
+            effect: 'capture amber instead of stealing it',
             gameAction: ability.actions.changeEvent((context) => ({
                 event: context.event,
                 cancel: true

--- a/server/game/cards/06-WoE/RogueOperation.js
+++ b/server/game/cards/06-WoE/RogueOperation.js
@@ -2,6 +2,7 @@ const Card = require('../../Card.js');
 
 class RogueOperation extends Card {
     // Play: Discard the top 2 cards of your deck. Steal 1 Aember for each house represented among the discarded cards.
+
     setupCardAbilities(ability) {
         this.play({
             gameAction: ability.actions.discard((context) => ({
@@ -20,7 +21,16 @@ class RogueOperation extends Card {
                             .map((event) => event.card)
                             .filter((card) => card.location === 'discard')
                     ).length
-                }))
+                })),
+                message: '{0} uses {1} to steal {3} amber from {4}',
+                messageArgs: (context) => [
+                    context.game.getHousesInPlay(
+                        context.preThenEvents
+                            .map((event) => event.card)
+                            .filter((card) => card.location === 'discard')
+                    ).length,
+                    context.player.opponent
+                ]
             }
         });
     }

--- a/server/game/cards/06-WoE/RogueOperation.js
+++ b/server/game/cards/06-WoE/RogueOperation.js
@@ -2,7 +2,6 @@ const Card = require('../../Card.js');
 
 class RogueOperation extends Card {
     // Play: Discard the top 2 cards of your deck. Steal 1 Aember for each house represented among the discarded cards.
-
     setupCardAbilities(ability) {
         this.play({
             gameAction: ability.actions.discard((context) => ({


### PR DESCRIPTION
Fixes #3498

- Updated rogue operation message with amount of aember being stolen
- Update gargantodon message with replacement effect

It did not seem easy to have gargantodon replace the steal message, but the double message seems like an improvement.

![image](https://github.com/keyteki/keyteki/assets/324548/3b6ccd70-f7f2-4db9-956d-5434f15da7d8)
