### PR TITLE
feat: fix ctm errata

### DIFF
--- a/server/game/cards/04-MM/AutoEncoder.js
+++ b/server/game/cards/04-MM/AutoEncoder.js
@@ -8,6 +8,7 @@ class AutoEncoder extends Card {
                 onCardDiscarded: (event, context) =>
                     event.location === 'hand' && event.card.controller === context.player
             },
+            effect: 'archive the top card of their deck',
             gameAction: ability.actions.archive((context) => ({
                 target: context.player.deck.length > 0 ? context.player.deck[0] : []
             }))

--- a/server/game/cards/06-WoE/CornerTheMarket.js
+++ b/server/game/cards/06-WoE/CornerTheMarket.js
@@ -1,14 +1,15 @@
 const Card = require('../../Card.js');
 
 class CornerTheMarket extends Card {
-    // Play: During your opponent's next turn, they cannot play cards,
-    // and each time they discard a card from their hand, they may
-    // instead archive that card.
+    // Play: During your opponent's next turn, they cannot
+    // play cards, and each time they discard a card from
+    // their hand, they may archive that card from their
+    // discard pile.
     setupCardAbilities(ability) {
         this.play({
             condition: (context) => !!context.player.opponent,
             effect:
-                'stop {1} from playing cards next turn; when they discard a card, they may archive it instead',
+                'stop {1} from playing cards next turn; when they discard a card, they may archive it from their discard pile',
             effectArgs: (context) => context.player.opponent,
             effectAlert: true,
             gameAction: [
@@ -17,41 +18,27 @@ class CornerTheMarket extends Card {
                     effect: ability.effects.cardCannot('play')
                 }),
                 ability.actions.nextRoundEffect({
+                    preferActionPromptMessage: true,
                     targetController: 'opponent',
-                    when: {
-                        onCardDiscarded: (event) => event.location === 'hand'
-                    },
-                    triggeredAbilityType: 'interrupt',
+                    when: { onCardDiscarded: (event) => event.location === 'hand' },
                     gameAction: ability.actions.sequential([
+                        ability.actions.changeEvent((context) => ({
+                            event: context.event,
+                            cancel: false
+                        })),
                         ability.actions.archive((context) => ({
                             reveal: true,
                             target: context.event.card,
                             promptWithHandlerMenu: {
-                                optional: true,
-                                activePromptTitle: 'Archive instead?',
+                                activePromptTitle: 'Archive card?',
                                 cards: [context.event.card],
                                 choices: ['Discard'],
-                                handlers: [
-                                    () => {
-                                        context.event.doNotCancelDiscard = true;
-                                    }
-                                ]
+                                handlers: [() => {}],
+                                message: '{0} uses {1} to archive {2}',
+                                optional: true
                             }
-                        })),
-                        ability.actions.conditional({
-                            condition: (context) => !context.event.doNotCancelDiscard,
-                            trueGameAction: ability.actions.changeEvent((context) => ({
-                                event: context.event,
-                                cancel: true
-                            }))
-                        })
-                    ]),
-                    message: '{0} uses {1} to allow archival of {2} instead of discard',
-                    messageArgs: (context) => [
-                        context.player.opponent,
-                        context.source,
-                        context.event.card
-                    ]
+                        }))
+                    ])
                 })
             ]
         });

--- a/test/server/cards/06-WoE/CornerTheMarket.spec.js
+++ b/test/server/cards/06-WoE/CornerTheMarket.spec.js
@@ -48,13 +48,13 @@ describe('Corner the Market', function () {
             expect(this.gauntletOfCommand.location).toBe('play area');
         });
 
-        it('allows opponent to archive instead of discard', function () {
+        it('allows opponent to archive from discard', function () {
             this.player1.play(this.cornerTheMarket);
             this.player1.endTurn();
             this.player2.clickPrompt('brobnar');
             this.player2.clickCard(this.gauntletOfCommand);
             this.player2.clickPrompt('Discard this card');
-            expect(this.player2).toHavePrompt('Archive instead?');
+            expect(this.player2).toHavePrompt('Archive card?');
             expect(this.player2).toHavePromptCardButton(this.gauntletOfCommand);
             expect(this.player2).toHavePromptButton('Discard');
             this.player2.clickPrompt('gauntlet of command');
@@ -67,11 +67,81 @@ describe('Corner the Market', function () {
             this.player2.clickPrompt('brobnar');
             this.player2.clickCard(this.gauntletOfCommand);
             this.player2.clickPrompt('Discard this card');
-            expect(this.player2).toHavePrompt('Archive instead?');
+            expect(this.player2).toHavePrompt('Archive card?');
             expect(this.player2).toHavePromptCardButton(this.gauntletOfCommand);
             expect(this.player2).toHavePromptButton('Discard');
             this.player2.clickPrompt('Discard');
             expect(this.gauntletOfCommand.location).toBe('discard');
+        });
+    });
+
+    describe('is not a replacement effect', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 1,
+                    house: 'ekwidon',
+                    hand: ['corner-the-market', 'antiquities-dealer']
+                },
+                player2: {
+                    inPlay: ['auto-encoder'],
+                    hand: ['gauntlet-of-command', 'bumpsy']
+                }
+            });
+        });
+
+        it('auto-encodes before ctm archive', function () {
+            this.player1.play(this.cornerTheMarket);
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.moveCard(this.bumpsy, 'deck');
+            this.player2.clickCard(this.gauntletOfCommand);
+            this.player2.clickPrompt('Discard this card');
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.autoEncoder);
+            expect(this.player2).toHavePromptCardButton(this.cornerTheMarket);
+            this.player2.clickPrompt('Corner the Market');
+            expect(this.player2).toHavePrompt('Archive card?');
+            expect(this.player2).toHavePromptCardButton(this.gauntletOfCommand);
+            expect(this.player2).toHavePromptButton('Discard');
+            this.player2.clickPrompt('gauntlet of command');
+            expect(this.gauntletOfCommand.location).toBe('archives');
+            expect(this.bumpsy.location).toBe('archives');
+        });
+
+        it('auto-encodes after ctm archive', function () {
+            this.player1.play(this.cornerTheMarket);
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.moveCard(this.bumpsy, 'deck');
+            this.player2.clickCard(this.gauntletOfCommand);
+            this.player2.clickPrompt('Discard this card');
+            expect(this.player2).toHavePrompt('Triggered Abilities');
+            expect(this.player2).toBeAbleToSelect(this.autoEncoder);
+            expect(this.player2).toHavePromptCardButton(this.cornerTheMarket);
+            this.player2.clickCard('Auto-Encoder');
+            expect(this.player2).toHavePrompt('Archive card?');
+            expect(this.player2).toHavePromptCardButton(this.gauntletOfCommand);
+            expect(this.player2).toHavePromptButton('Discard');
+            this.player2.clickPrompt('gauntlet of command');
+            expect(this.gauntletOfCommand.location).toBe('archives');
+            expect(this.bumpsy.location).toBe('archives');
+        });
+
+        it('auto-encodes after ctm discard', function () {
+            this.player1.play(this.cornerTheMarket);
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.moveCard(this.bumpsy, 'deck');
+            this.player2.clickCard(this.gauntletOfCommand);
+            this.player2.clickPrompt('Discard this card');
+            this.player2.clickPrompt('Corner the Market');
+            expect(this.player2).toHavePrompt('Archive card?');
+            expect(this.player2).toHavePromptCardButton(this.gauntletOfCommand);
+            expect(this.player2).toHavePromptButton('Discard');
+            this.player2.clickPrompt('Discard');
+            expect(this.gauntletOfCommand.location).toBe('discard');
+            expect(this.bumpsy.location).toBe('archives');
         });
     });
 });


### PR DESCRIPTION
Fixes #3558 

- Changed corner the market errata from replacement effect to archiving from discard
- Added auto-encoder test case
- Updated auto-encoder message

I wasn't sure if after discard, the player should be prompted to order CTM and AE effects, or if AE should always happen, and then CTM chance to archive. AFAIK there's no "when you archive interactions" that would make this matter either. I left it prompting the order bc I wasn't sure how to implement auto-encoder automatically archiving.

Screenshot of the 3 possible flows:
- discard, ctm archive, ae
- discard, ae, ctm archive
- discard, ae, no ctm archive

![image](https://github.com/keyteki/keyteki/assets/324548/91526ae0-e273-499f-a720-a36738c15cce)
