### PR TITLE
GR: implement 3LL-I0T

### DIFF
--- a/server/game/GameActions.js
+++ b/server/game/GameActions.js
@@ -63,6 +63,8 @@ const Actions = {
     placeAmber: (propertyFactory) => new GameActions.AddTokenAction(propertyFactory, 'amber'), // amount = 1
     placeUnder: (propertyFactory) => new GameActions.PlaceUnderAction(propertyFactory), // parent
     playCard: (propertyFactory) => new GameActions.PlayCardAction(propertyFactory), // resetOnCancel = false, postHandler
+    playUpgradeOnParent: (propertyFactory) =>
+        new GameActions.PlayUpgradeOnParentAction(propertyFactory),
     purge: (propertyFactory) => new GameActions.PurgeAction(propertyFactory),
     putIntoPlay: (propertyFactory) => new GameActions.PutIntoPlayAction(propertyFactory),
     ready: (propertyFactory) => new GameActions.ReadyAction(propertyFactory),

--- a/server/game/GameActions/PlayUpgradeOnParentAction.js
+++ b/server/game/GameActions/PlayUpgradeOnParentAction.js
@@ -1,0 +1,82 @@
+const CardGameAction = require('./CardGameAction');
+
+class PlayUpgradeOnParentAction extends CardGameAction {
+    setDefaultProperties() {
+        this.location = 'hand';
+        this.revealOnIllegalTarget = false;
+    }
+
+    setup() {
+        super.setup();
+        this.name = 'play';
+        this.effectMsg = 'play {0}';
+    }
+
+    canAffect(card, context) {
+        if (!super.canAffect(card, context)) {
+            return false;
+        }
+
+        if (this.revealOnIllegalTarget) {
+            return true;
+        }
+
+        if (
+            !this.parent ||
+            this.parent.type !== 'creature' ||
+            this.parent.location !== 'play area'
+        ) {
+            return false;
+        }
+
+        return card
+            .getActions(this.location)
+            .some(
+                (action) =>
+                    action.title.includes('Play this upgrade') &&
+                    this.actionMeetsRequirement(context, action)
+            );
+    }
+
+    actionMeetsRequirement(context, action) {
+        let actionContext = action.createContext(context.player);
+        actionContext.ignoreHouse = true;
+        return !action.meetsRequirements(actionContext, ['location']);
+    }
+
+    resolveAction(context, action) {
+        action.deploy = this.deploy;
+        let actionContext = action.createContext(context.player);
+        actionContext.ignoreHouse = true;
+        context.game.resolveAbility(actionContext);
+    }
+
+    getEvent(card, context) {
+        let playActions = card
+            .getActions(this.location)
+            .filter(
+                (action) =>
+                    action.title.includes('Play this upgrade') &&
+                    this.actionMeetsRequirement(context, action)
+            );
+
+        return super.createEvent(
+            'unnamedEvent',
+            { card: card, context: context, player: context.player },
+            () => {
+                if (playActions.length >= 1 && playActions[0].newWithParent) {
+                    this.resolveAction(context, playActions[0].newWithParent(this.parent));
+                } else {
+                    if (this.revealOnIllegalTarget) {
+                        context.game.addMessage(
+                            '{0} was unable to be played so is returned to its original location',
+                            card
+                        );
+                    }
+                }
+            }
+        );
+    }
+}
+
+module.exports = PlayUpgradeOnParentAction;

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -40,6 +40,7 @@ module.exports = {
     ResetTideAction: require('./ResetTideAction'),
     PlaceUnderAction: require('./PlaceUnderAction'),
     PlayCardAction: require('./PlayCardAction'),
+    PlayUpgradeOnParentAction: require('./PlayUpgradeOnParentAction'),
     MakeTokenCreatureAction: require('./MakeTokenCreatureAction'),
     PurgeAction: require('./PurgeAction'),
     PutIntoPlayAction: require('./PutIntoPlayAction'),

--- a/server/game/cards/07-GR/3LLI0T.js
+++ b/server/game/cards/07-GR/3LLI0T.js
@@ -1,0 +1,33 @@
+const Card = require('../../Card.js');
+
+class ThreeLLI0T extends Card {
+    // Play/After Fight/After Reap: You may play an upgrade from your
+    // discard pile on 3LL-I0T.
+    //
+    // Scrap: Shuffle all upgrades from play into their owners’ decks.
+    setupCardAbilities(ability) {
+        this.play({
+            reap: true,
+            fight: true,
+            target: {
+                controller: 'self',
+                location: 'discard',
+                cardType: 'upgrade',
+                gameAction: ability.actions.playUpgradeOnParent((context) => ({
+                    parent: context.source
+                }))
+            }
+        });
+
+        this.scrap({
+            gameAction: ability.actions.returnToDeck((context) => ({
+                target: context.game.creaturesInPlay.flatMap((card) => card.upgrades || []),
+                shuffle: true
+            }))
+        });
+    }
+}
+
+ThreeLLI0T.id = '3ll-i0t';
+
+module.exports = ThreeLLI0T;

--- a/test/server/cards/07-GR/3LLI0T.spec.js
+++ b/test/server/cards/07-GR/3LLI0T.spec.js
@@ -1,0 +1,64 @@
+describe('3LL-I0T', function () {
+    describe("3LL-I0T's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 1,
+                    house: 'staralliance',
+                    hand: ['3ll-i0t', 'officer-s-blaster', 'quadracorder'],
+                    inPlay: ['charette'],
+                    discard: ['gub', 'light-of-the-archons', 'insurance-policy']
+                },
+                player2: {
+                    hand: ['wild-spirit'],
+                    inPlay: ['flaxia']
+                }
+            });
+        });
+
+        it('can play an upgrade from discard onto itself', function () {
+            this.player1.playCreature(this['3llI0t']);
+            expect(this.player1).toBeAbleToSelect(this.lightOfTheArchons);
+            expect(this.player1).toBeAbleToSelect(this.insurancePolicy);
+            this.player1.clickCard(this.lightOfTheArchons);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.player1.amber).toBe(2);
+            expect(this.lightOfTheArchons.location).toBe('play area');
+            expect(this.lightOfTheArchons.parent).toBe(this['3llI0t']);
+        });
+
+        it('gets the Play: ability of the played upgrade', function () {
+            this.player1.playCreature(this['3llI0t']);
+            this.player1.clickCard(this.insurancePolicy);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.player1.amber).toBe(0);
+            expect(this.insurancePolicy.location).toBe('play area');
+            expect(this.insurancePolicy.parent).toBe(this['3llI0t']);
+        });
+
+        it('can discard a card and resolve its play ability on scrap', function () {
+            this.player1.playUpgrade(this.officerSBlaster, this.charette);
+            this.player1.playUpgrade(this.quadracorder, this.flaxia);
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.playUpgrade(this.wildSpirit, this.flaxia);
+            this.player2.endTurn();
+            this.player1.clickPrompt('staralliance');
+            this.player1.clickCard(this['3llI0t']);
+            this.player1.clickPrompt('Discard this card');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            expect(this.officerSBlaster.location).toBe('deck');
+            expect(this.officerSBlaster.parent).toBe(null);
+            expect(this.player1.player.deck).toContain(this.officerSBlaster);
+            expect(this.quadracorder.location).toBe('deck');
+            expect(this.quadracorder.parent).toBe(null);
+            expect(this.player1.player.deck).toContain(this.quadracorder);
+            expect(this.wildSpirit.location).toBe('deck');
+            expect(this.wildSpirit.parent).toBe(null);
+            expect(this.player2.player.deck).toContain(this.wildSpirit);
+            expect(this.charette.upgrades.length).toBe(0);
+            expect(this.flaxia.upgrades.length).toBe(0);
+            expect(this['3llI0t'].location).toBe('discard');
+        });
+    });
+});


### PR DESCRIPTION
This card is the first card that forces a specific parent for an upgrade on
play (as opposed to re-attaching an existing upgrade).  I was able
to make this work by allowing a parent to be passed into
`PlayUpgradeAction` from a new `GameAction` but it's not my
favorite code in the world and I'm happy to change it however
anyone else suggests.