### PR TITLE
GR: fix Paradox Shield to discard even with not enough cards

### DIFF
--- a/server/game/cards/07-GR/ParadoxShield.js
+++ b/server/game/cards/07-GR/ParadoxShield.js
@@ -8,8 +8,6 @@ class ParadoxShield extends Card {
         this.whileAttached({
             effect: [
                 ability.effects.gainAbility('destroyed', {
-                    condition: (context) =>
-                        context.source.controller.deck.length >= context.source.power,
                     effect:
                         'discard {2} cards from their deck to heal all damage from {0} and destroy {1} instead',
                     effectArgs: (context) => [this, context.source.power],
@@ -17,6 +15,9 @@ class ParadoxShield extends Card {
                         target: context.source.controller.deck.slice(0, context.source.power)
                     })),
                     then: (preThenContext) => ({
+                        alwaysTriggers: true,
+                        condition: (context) =>
+                            context.preThenEvents.length === preThenContext.source.power,
                         gameAction: [
                             ability.actions.heal({ fully: true }),
                             ability.actions.changeEvent({

--- a/test/server/cards/07-GR/ParadoxShield.spec.js
+++ b/test/server/cards/07-GR/ParadoxShield.spec.js
@@ -55,13 +55,13 @@ describe('Paradox Shield', function () {
         });
 
         it('does nothing if not enough cards in deck', function () {
-            this.player1.player.deck = [];
+            this.player1.player.deck = this.player1.player.deck.slice(0, 3);
             this.player1.fightWith(this.cpoZytar, this.troll);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
             expect(this.cpoZytar.location).toBe('discard');
             expect(this.paradoxShield.location).toBe('discard');
             expect(this.troll.tokens.damage).toBe(4);
-            expect(this.player1.player.discard.length).toBe(2);
+            expect(this.player1.player.discard.length).toBe(3 + 2);
         });
     });
 });


### PR DESCRIPTION
Because of "do as much as you can", Paradox Shield should still discard cards even if there are fewer cards left in deck than the creature's power.

Also, move it to the right directory, oops.