### PR TITLE
GR: fix Curse of Disappearances archiving to owner's archive

### DIFF
--- a/server/game/GameActions/ArchiveAction.js
+++ b/server/game/GameActions/ArchiveAction.js
@@ -3,6 +3,7 @@ const CardGameAction = require('./CardGameAction');
 class ArchiveAction extends CardGameAction {
     setDefaultProperties() {
         this.owner = true;
+        this.opponent = false;
         this.reveal = false;
     }
 
@@ -23,7 +24,11 @@ class ArchiveAction extends CardGameAction {
 
     getEvent(card, context) {
         return super.createEvent('onCardArchived', { card: card, context: context }, () => {
-            let player = this.owner ? card.owner : context.player;
+            let player = this.owner
+                ? card.owner
+                : this.opponent
+                ? context.player.opponent
+                : context.player;
             if (card.location === 'play area') {
                 context.game.raiseEvent('onCardLeavesPlay', { card, context }, () =>
                     player.moveCard(card, 'archives')

--- a/server/game/cards/07-GR/CurseOfDisappearances.js
+++ b/server/game/cards/07-GR/CurseOfDisappearances.js
@@ -16,7 +16,9 @@ class CurseOfDisappearances extends Card {
                     activePromptTitle: 'Choose a creature to archive',
                     cardType: 'creature',
                     controller: 'self'
-                }
+                },
+                owner: false,
+                opponent: true
             })
         });
     }

--- a/test/server/cards/07-GR/CurseOfDisappearances.spec.js
+++ b/test/server/cards/07-GR/CurseOfDisappearances.spec.js
@@ -39,12 +39,14 @@ describe('Curse Of Disappearances', function () {
 
                 it("should archive one of opponent's creature", function () {
                     expect(this.johnSmyth.location).toBe('archives');
+                    expect(this.player1.player.archives).toContain(this.johnSmyth);
                     expect(this.mindwarper.location).toBe('play area');
                 });
 
                 describe('at the end of self turn', function () {
                     it('should not archive friendly creature', function () {
                         this.player1.clickPrompt('mars');
+                        this.player1.clickPrompt('No');
                         this.player1.endTurn();
                         expect(this.brammo.location).toBe('play area');
                     });


### PR DESCRIPTION
It is the first card that lets you add your card to your opponent's archive on your turn.

Closes: #3815