### PR TITLE
GR: cards under Plan 10 and Cauldron should be visible to both players

### DIFF
--- a/server/game/CardVisibility.js
+++ b/server/game/CardVisibility.js
@@ -1,4 +1,4 @@
-const OpenInformationLocations = ['play area', 'purged', 'grafted', 'discard'];
+const OpenInformationLocations = ['play area', 'purged', 'grafted', 'discard', 'under'];
 
 class CardVisibility {
     constructor(game) {

--- a/test/server/cards/07-GR/Plan10.spec.js
+++ b/test/server/cards/07-GR/Plan10.spec.js
@@ -20,6 +20,8 @@ describe('Plan 10', function () {
         it('puts each non-Mars creature under it on play', function () {
             this.player1.play(this.plan10);
             expect(this.echofly.location).toBe('under');
+            expect(this.game.isCardVisible(this.echofly, this.player1.player)).toBe(true);
+            expect(this.game.isCardVisible(this.echofly, this.player2.player)).toBe(true);
             expect(this.ritualOfBalance.location).toBe('under');
             expect(this.thingFromTheDeep.location).toBe('under');
             expect(this.johnSmyth.location).toBe('play area');


### PR DESCRIPTION
Right now faceup cards that are 'under' another card are only visible to the controller.  But both Plan 10 and Cauldron say that the cards under them are faceup, and thus should be visible to everyone.  All other cards that place cards under another card using the `placeUnder` action specify `facedown` explicitly.

Closes: #3819