### PR TITLE
GR: `placeUnder` should remove from pile before `onLeavesPlay`

### DIFF
--- a/server/game/GameActions/PlaceUnderAction.js
+++ b/server/game/GameActions/PlaceUnderAction.js
@@ -31,11 +31,11 @@ class PlaceUnderAction extends CardGameAction {
             this.isGraft ? 'onCardGrafted' : 'onPlaceUnder',
             { card, context },
             () => {
+                card.controller.removeCardFromPile(card);
                 if (card.location === 'play area') {
                     card.onLeavesPlay();
                 }
-                card.controller.removeCardFromPile(card);
-                card.controller = card.owner;
+                card.controller = this.parent.controller;
                 card.parent = this.parent;
                 card.moveTo(this.isGraft ? 'grafted' : 'under');
                 card.facedown = this.facedown;

--- a/test/server/cards/07-GR/Plan10.spec.js
+++ b/test/server/cards/07-GR/Plan10.spec.js
@@ -5,7 +5,7 @@ describe('Plan 10', function () {
                 player1: {
                     amber: 1,
                     house: 'mars',
-                    hand: ['plan-10'],
+                    hand: ['plan-10', 'hypnobeam'],
                     inPlay: ['echofly', 'john-smyth']
                 },
                 player2: {
@@ -65,6 +65,21 @@ describe('Plan 10', function () {
             expect(this.player2.player.hand).toContain(this.thingFromTheDeep);
 
             expect(this.plan10.location).toBe('discard');
+        });
+
+        it('works correctly for non-owned creatures', function () {
+            this.player1.play(this.hypnobeam);
+            this.player1.clickCard(this.thingFromTheDeep);
+            this.player1.clickPrompt('Right');
+            this.player1.play(this.plan10);
+            expect(this.thingFromTheDeep.location).toBe('under');
+            expect(this.player1.player.creaturesInPlay).not.toContain(this.thingFromTheDeep);
+            expect(this.player2.player.creaturesInPlay).not.toContain(this.thingFromTheDeep);
+            this.player1.endTurn();
+            this.player1.clickCard(this.thingFromTheDeep);
+            expect(this.plan10.childCards).not.toContain(this.thingFromTheDeep);
+            expect(this.thingFromTheDeep.location).toBe('hand');
+            expect(this.player2.player.hand).toContain(this.thingFromTheDeep);
         });
     });
 });


### PR DESCRIPTION
If we call `onLeavesPlay` first, the controller of the card will revert back to the owner, and the owner will be the one to remove it from the corresponding pile (even if the card is actually currently controlled by the opponent).  The result is that the card will remain in the original pile and also be a child card of the new parent, which causes chaos.

Closes: #3825