### PR TITLE
Near-Future Lens shouldn't make the 2nd card in draw pile facedown

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -196,10 +196,6 @@ class Player extends GameObject {
         this.game.emitEvent('onDeckShuffled', { player: this });
         this.deck = _.shuffle(this.deck);
         if (this.isTopCardOfDeckVisible() && this.deck.length > 0) {
-            this.deck[0].facedown = false;
-            this.deck.slice(1).forEach((card) => {
-                card.facedown = true;
-            });
             this.addTopCardOfDeckVisibleMessage();
         }
     }


### PR DESCRIPTION
This makes the card show facedown in the draw pile, and lets the player know what card is second in their deck.

This faceup/facedown thing for Near-Future Lens never worked anyway; the card is revealed in the chat log and that's good enough.