### PR TITLE
GR: Curse of Cowardice should only destroy self at end of turn

### DIFF
--- a/server/game/cards/07-GR/CurseOfCowardice.js
+++ b/server/game/cards/07-GR/CurseOfCowardice.js
@@ -14,21 +14,18 @@ class CurseOfCowardice extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) =>
-                    context.player === this.game.activePlayer && this.fights === 0
+                onRoundEnded: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.loseAmber((context) => ({
                 target: context.player,
-                amount: 2
-            }))
-        });
-
-        this.persistentEffect({
-            effect: ability.effects.terminalCondition({
+                amount: this.fights === 0 ? 2 : 0
+            })),
+            then: {
+                alwaysTriggers: true,
                 condition: (context) => context.player.creaturesInPlay.length === 0,
-                message: '{0} is destroyed as there are no friendly creatures in play',
-                gameAction: ability.actions.destroy()
-            })
+                gameAction: ability.actions.destroy(),
+                message: '{1} is destroyed as there are no friendly creatures in play'
+            }
         });
     }
 

--- a/test/server/cards/07-GR/CurseOfCowardice.spec.js
+++ b/test/server/cards/07-GR/CurseOfCowardice.spec.js
@@ -53,11 +53,21 @@ describe('Curse Of Cowardice', function () {
                     expect(this.player1.amber).toBe(1);
                 });
 
-                it('should be destroyed when no friendly creatures', function () {
+                it('should be destroyed when no friendly creatures at end of turn', function () {
                     this.player2.fightWith(this.troll, this.thingFromTheDeep);
-                    expect(this.curseOfCowardice.location).toBe('discard');
+                    expect(this.curseOfCowardice.location).toBe('play area');
                     this.player2.endTurn();
+                    expect(this.curseOfCowardice.location).toBe('discard');
                     expect(this.player2.amber).toBe(5);
+                    expect(this.player1.amber).toBe(1);
+                });
+
+                it('should be destroyed when no friendly creatures after amber loss', function () {
+                    this.player2.moveCard(this.troll, 'discard');
+                    expect(this.curseOfCowardice.location).toBe('play area');
+                    this.player2.endTurn();
+                    expect(this.curseOfCowardice.location).toBe('discard');
+                    expect(this.player2.amber).toBe(3);
                     expect(this.player1.amber).toBe(1);
                 });
             });


### PR DESCRIPTION
The clause of Curse of Cowardice that destroys itself if there are no creatures in play is part of the overall end of turn effect.  This means that the player still loses 2 amber if they didn't fight that turn, even if Curse of Cowardice is destroyed.