### PR TITLE
GR: fix Don't Believe Your Eyes for non-haunted case

### DIFF
--- a/server/game/cards/07-GR/DontBelieveYourEyes.js
+++ b/server/game/cards/07-GR/DontBelieveYourEyes.js
@@ -9,7 +9,9 @@ class DontBelieveYourEyes extends Card {
                 cardType: 'creature',
                 gameAction: ability.actions.capture((context) => ({
                     amount: context.player.isHaunted() ? 2 : 1,
-                    player: context.target.controller
+                    player: context.player.isHaunted()
+                        ? context.target.controller
+                        : context.target.controller.opponent
                 }))
             }
         });

--- a/test/server/cards/07-GR/DontBelieveYourEyes.spec.js
+++ b/test/server/cards/07-GR/DontBelieveYourEyes.spec.js
@@ -21,17 +21,17 @@ describe("Don't Believe Your Eyes", function () {
                 this.player1.play(this.donTBelieveYourEyes);
             });
 
-            it('should be able to select friendly creature and capture 1 from self', function () {
+            it('should be able to select friendly creature and capture 1 from opponent', function () {
                 this.player1.clickCard(this.flaxia);
-                expect(this.player1.amber).toBe(1);
-                expect(this.player2.amber).toBe(2);
+                expect(this.player1.amber).toBe(2);
+                expect(this.player2.amber).toBe(1);
                 expect(this.flaxia.amber).toBe(1);
             });
 
-            it('should be able to select enemy creature and capture 1 from opponent', function () {
+            it('should be able to select enemy creature and capture 1 from self', function () {
                 this.player1.clickCard(this.gub);
-                expect(this.player1.amber).toBe(2);
-                expect(this.player2.amber).toBe(1);
+                expect(this.player1.amber).toBe(1);
+                expect(this.player2.amber).toBe(2);
                 expect(this.gub.amber).toBe(1);
             });
         });


### PR DESCRIPTION
When not haunted, the creature should just do a normal capture from the controller's opponent.

Closes: #3837 