### PR TITLE
GR: fix Grisly Exchange for solo play

### DIFF
--- a/server/game/cards/07-GR/GrislyExchange.js
+++ b/server/game/cards/07-GR/GrislyExchange.js
@@ -14,10 +14,12 @@ class GrislyExchange extends Card {
                         context.player.opponent && context.player.opponent.discard.length > 0,
                     trueGameAction: ability.actions.returnToDeck({
                         bottom: true,
-                        target: context.player.opponent.discard.slice(
-                            0,
-                            Math.min(5, context.player.opponent.discard.length)
-                        )
+                        target: context.player.opponent
+                            ? context.player.opponent.discard.slice(
+                                  0,
+                                  Math.min(5, context.player.opponent.discard.length)
+                              )
+                            : []
                     })
                 })),
                 ability.actions.discard((context) => ({


### PR DESCRIPTION
Apparently it still evaluates the true game action's target even if
the condition is false.