### PR TITLE
Handle upgrades, child cards, and leave play events on placeUnder()

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -585,6 +585,21 @@ class Card extends EffectSource {
         this.endRound();
     }
 
+    clearDependentCards() {
+        for (let upgrade of this.upgrades) {
+            upgrade.onLeavesPlay();
+            upgrade.owner.moveCard(upgrade, 'discard');
+        }
+
+        for (let child of this.childCards) {
+            child.onLeavesPlay();
+            child.owner.moveCard(child, 'discard');
+        }
+
+        this.purgedCards.forEach((c) => (c.purgedBy = null));
+        this.purgedCards = [];
+    }
+
     endRound() {
         this.armorUsed = 0;
         this.elusiveUsed = false;

--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -596,7 +596,9 @@ class Card extends EffectSource {
             child.owner.moveCard(child, 'discard');
         }
 
-        this.purgedCards.forEach((c) => (c.purgedBy = null));
+        for (let card of this.purgedCards) {
+            card.purgedBy = null;
+        }
         this.purgedCards = [];
     }
 

--- a/server/game/GameActions/PlaceUnderAction.js
+++ b/server/game/GameActions/PlaceUnderAction.js
@@ -26,24 +26,31 @@ class PlaceUnderAction extends CardGameAction {
         return this.parent && super.canAffect(card, context);
     }
 
+    placeUnder(card) {
+        card.controller.removeCardFromPile(card);
+        if (card.location === 'play area') {
+            card.clearDependentCards();
+            card.onLeavesPlay();
+        }
+        card.controller = this.parent.controller;
+        card.parent = this.parent;
+        card.moveTo(this.isGraft ? 'grafted' : 'under');
+        card.facedown = this.facedown;
+        this.parent.childCards.push(card);
+    }
+
     getEvent(card, context) {
         return super.createEvent(
             this.isGraft ? 'onCardGrafted' : 'onPlaceUnder',
             { card, context },
             () => {
-                card.controller.removeCardFromPile(card);
                 if (card.location === 'play area') {
-                    card.onLeavesPlay();
-                    for (let upgrade of card.upgrades) {
-                        upgrade.onLeavesPlay();
-                        upgrade.owner.moveCard(upgrade, 'discard');
-                    }
+                    context.game.raiseEvent('onCardLeavesPlay', { card, context }, () =>
+                        this.placeUnder(card)
+                    );
+                } else {
+                    this.placeUnder(card);
                 }
-                card.controller = this.parent.controller;
-                card.parent = this.parent;
-                card.moveTo(this.isGraft ? 'grafted' : 'under');
-                card.facedown = this.facedown;
-                this.parent.childCards.push(card);
             }
         );
     }

--- a/server/game/GameActions/PlaceUnderAction.js
+++ b/server/game/GameActions/PlaceUnderAction.js
@@ -34,6 +34,10 @@ class PlaceUnderAction extends CardGameAction {
                 card.controller.removeCardFromPile(card);
                 if (card.location === 'play area') {
                     card.onLeavesPlay();
+                    for (let upgrade of card.upgrades) {
+                        upgrade.onLeavesPlay();
+                        upgrade.owner.moveCard(upgrade, 'discard');
+                    }
                 }
                 card.controller = this.parent.controller;
                 card.parent = this.parent;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -507,18 +507,7 @@ class Player extends GameObject {
                 return;
             }
 
-            for (let upgrade of card.upgrades) {
-                upgrade.onLeavesPlay();
-                upgrade.owner.moveCard(upgrade, 'discard');
-            }
-
-            for (let child of card.childCards) {
-                child.onLeavesPlay();
-                child.owner.moveCard(child, 'discard');
-            }
-
-            card.purgedCards.forEach((c) => (c.purgedBy = null));
-            card.purgedCards = [];
+            card.clearDependentCards();
 
             card.onLeavesPlay();
             card.controller = this;

--- a/test/server/cards/06-WoE/ReplayPod.spec.js
+++ b/test/server/cards/06-WoE/ReplayPod.spec.js
@@ -4,7 +4,7 @@ describe('Replay Pod', function () {
             this.setupTest({
                 player1: {
                     house: 'mars',
-                    hand: ['ammonia-clouds', 'ether-spider'],
+                    hand: ['ammonia-clouds', 'ether-spider', 'jammer-pack'],
                     inPlay: ['replay-pod', 'yxilo-bolter', 'john-smyth', 'blypyp', 'pelf']
                 },
                 player2: {
@@ -24,6 +24,16 @@ describe('Replay Pod', function () {
             expect(this.replayPod.childCards).toContain(this.blypyp);
             expect(this.pelf.location).toBe('discard');
             expect(this.yxiliMarauder.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should cause upgrades to fall off', function () {
+            this.player1.playUpgrade(this.jammerPack, this.johnSmyth);
+            this.player1.play(this.ammoniaClouds);
+            this.player1.clickCard(this.yxiloBolter);
+            this.player1.clickCard(this.johnSmyth);
+            expect(this.jammerPack.location).toBe('discard');
+            expect(this.jammerPack.parent).toBe(null);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
 

--- a/test/server/cards/07-GR/Plan10.spec.js
+++ b/test/server/cards/07-GR/Plan10.spec.js
@@ -3,7 +3,7 @@ describe('Plan 10', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
-                    amber: 1,
+                    amber: 3,
                     house: 'mars',
                     hand: ['plan-10', 'hypnobeam'],
                     inPlay: ['echofly', 'john-smyth']
@@ -11,7 +11,8 @@ describe('Plan 10', function () {
                 player2: {
                     amber: 1,
                     token: 'priest',
-                    inPlay: ['priest:ritual-of-balance', 'thing-from-the-deep', 'ironyx-rebel']
+                    hand: ['magda-the-rat'],
+                    inPlay: ['priest:ritual-of-balance', 'umbra', 'ironyx-rebel']
                 }
             });
             this.ritualOfBalance = this.priest;
@@ -23,11 +24,25 @@ describe('Plan 10', function () {
             expect(this.game.isCardVisible(this.echofly, this.player1.player)).toBe(true);
             expect(this.game.isCardVisible(this.echofly, this.player2.player)).toBe(true);
             expect(this.ritualOfBalance.location).toBe('under');
-            expect(this.thingFromTheDeep.location).toBe('under');
+            expect(this.umbra.location).toBe('under');
             expect(this.johnSmyth.location).toBe('play area');
             expect(this.ironyxRebel.location).toBe('play area');
             expect(this.plan10.childCards.length).toBe(3);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('triggers leave play effects', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.playCreature(this.magdaTheRat);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(3);
+            this.player2.endTurn();
+            this.player1.clickPrompt('mars');
+            this.player1.play(this.plan10);
+            expect(this.magdaTheRat.location).toBe('under');
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(1);
         });
 
         it('allows the active player to return a card at the end of each turn', function () {
@@ -35,7 +50,7 @@ describe('Plan 10', function () {
             this.player1.endTurn();
             expect(this.player1).toBeAbleToSelect(this.echofly);
             expect(this.player1).toBeAbleToSelect(this.ritualOfBalance);
-            expect(this.player1).toBeAbleToSelect(this.thingFromTheDeep);
+            expect(this.player1).toBeAbleToSelect(this.umbra);
             expect(this.player1).not.toBeAbleToSelect(this.johnSmyth);
             expect(this.player1).not.toBeAbleToSelect(this.ironyxRebel);
             this.player1.clickCard(this.echofly);
@@ -46,7 +61,7 @@ describe('Plan 10', function () {
             this.player2.endTurn();
             expect(this.player2).not.toBeAbleToSelect(this.echofly);
             expect(this.player2).toBeAbleToSelect(this.ritualOfBalance);
-            expect(this.player2).toBeAbleToSelect(this.thingFromTheDeep);
+            expect(this.player2).toBeAbleToSelect(this.umbra);
             expect(this.player2).not.toBeAbleToSelect(this.johnSmyth);
             expect(this.player2).not.toBeAbleToSelect(this.ironyxRebel);
             this.player2.clickCard(this.ritualOfBalance);
@@ -57,29 +72,29 @@ describe('Plan 10', function () {
             this.player1.endTurn();
             expect(this.player1).not.toBeAbleToSelect(this.echofly);
             expect(this.player1).not.toBeAbleToSelect(this.ritualOfBalance);
-            expect(this.player1).toBeAbleToSelect(this.thingFromTheDeep);
+            expect(this.player1).toBeAbleToSelect(this.umbra);
             expect(this.player1).not.toBeAbleToSelect(this.johnSmyth);
             expect(this.player1).not.toBeAbleToSelect(this.ironyxRebel);
-            this.player1.clickCard(this.thingFromTheDeep);
-            expect(this.thingFromTheDeep.location).toBe('hand');
-            expect(this.player2.player.hand).toContain(this.thingFromTheDeep);
+            this.player1.clickCard(this.umbra);
+            expect(this.umbra.location).toBe('hand');
+            expect(this.player2.player.hand).toContain(this.umbra);
 
             expect(this.plan10.location).toBe('discard');
         });
 
         it('works correctly for non-owned creatures', function () {
             this.player1.play(this.hypnobeam);
-            this.player1.clickCard(this.thingFromTheDeep);
+            this.player1.clickCard(this.umbra);
             this.player1.clickPrompt('Right');
             this.player1.play(this.plan10);
-            expect(this.thingFromTheDeep.location).toBe('under');
-            expect(this.player1.player.creaturesInPlay).not.toContain(this.thingFromTheDeep);
-            expect(this.player2.player.creaturesInPlay).not.toContain(this.thingFromTheDeep);
+            expect(this.umbra.location).toBe('under');
+            expect(this.player1.player.creaturesInPlay).not.toContain(this.umbra);
+            expect(this.player2.player.creaturesInPlay).not.toContain(this.umbra);
             this.player1.endTurn();
-            this.player1.clickCard(this.thingFromTheDeep);
-            expect(this.plan10.childCards).not.toContain(this.thingFromTheDeep);
-            expect(this.thingFromTheDeep.location).toBe('hand');
-            expect(this.player2.player.hand).toContain(this.thingFromTheDeep);
+            this.player1.clickCard(this.umbra);
+            expect(this.plan10.childCards).not.toContain(this.umbra);
+            expect(this.umbra.location).toBe('hand');
+            expect(this.player2.player.hand).toContain(this.umbra);
         });
     });
 });


### PR DESCRIPTION
Specifically for Replay Pod and Plan 10, cards in play should lose their upgrades, lose their child cards, and triggers any "leaves play" abilities.