### PR TITLE
GR: Lifting Buddy's second effect is for _another_ creature

### DIFF
--- a/server/game/cards/07-GR/LiftingBuddy.js
+++ b/server/game/cards/07-GR/LiftingBuddy.js
@@ -16,6 +16,7 @@ class LiftingBuddy extends Card {
                 target: {
                     cardType: 'creature',
                     controller: 'self',
+                    cardCondition: (card, context) => card != context.source,
                     gameAction: ability.actions.addPowerCounter({
                         amount: 2
                     })

--- a/test/server/cards/07-GR/LiftingBuddy.spec.js
+++ b/test/server/cards/07-GR/LiftingBuddy.spec.js
@@ -20,6 +20,7 @@ describe('Lifting Buddy', function () {
                 expect(this.player1).toBeAbleToSelect(this.cpoZytar);
                 expect(this.player1).toBeAbleToSelect(this.groke);
                 expect(this.player1).not.toBeAbleToSelect(this.batdrone);
+                expect(this.player1).not.toBeAbleToSelect(this.liftingBuddy);
                 this.player1.clickCard(this.groke);
             });
 


### PR DESCRIPTION
It cannot target itself twice.