### PR TITLE
GR: The Common Cold should destroy warded Mars creatures

### DIFF
--- a/server/game/cards/01-Core/TheCommonCold.js
+++ b/server/game/cards/01-Core/TheCommonCold.js
@@ -10,6 +10,7 @@ class TheCommonCold extends Card {
                 target: context.game.creaturesInPlay
             })),
             then: {
+                alwaysTriggers: true,
                 may: 'destroy all Mars creatures',
                 gameAction: ability.actions.destroy((context) => ({
                     target: context.game.creaturesInPlay.filter((card) => card.hasHouse('mars'))

--- a/test/server/cards/01-Core/TheCommonCold.spec.js
+++ b/test/server/cards/01-Core/TheCommonCold.spec.js
@@ -1,0 +1,22 @@
+describe('The Common Cold', function () {
+    describe("The Common Cold's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'untamed',
+                    hand: ['the-common-cold']
+                },
+                player2: {
+                    inPlay: ['grabber-jammer']
+                }
+            });
+            this.grabberJammer.tokens.ward = 1;
+        });
+
+        it('should be able to destroy warded Mars creatures', function () {
+            this.player1.play(this.theCommonCold);
+            this.player1.clickPrompt('Yes');
+            expect(this.grabberJammer.location).toBe('discard');
+        });
+    });
+});


### PR DESCRIPTION
Previously, if it didn't deal damage to any creatures, the player would not get an option to destroy Mars creatures.  So for example if all creatures were warded, the player wouldn't be able to get the second effect.