### PR TITLE
GR: fix scrap ability to apply to targetted card

### DIFF
--- a/server/game/cards/07-GR/ShrinkRayTechnician.js
+++ b/server/game/cards/07-GR/ShrinkRayTechnician.js
@@ -25,8 +25,7 @@ class ShrinkRayTechnician extends Card {
                 mode: 'mostStat',
                 numCards: 1,
                 cardStat: (card) => card.power,
-                gameAction: ability.actions.forRemainderOfTurn({
-                    targetController: 'opponent',
+                gameAction: ability.actions.cardLastingEffect({
                     effect: [ability.effects.setPower(1), ability.effects.setArmor(0)]
                 })
             },

--- a/test/server/cards/07-GR/ShrinkRayTechnician.spec.js
+++ b/test/server/cards/07-GR/ShrinkRayTechnician.spec.js
@@ -54,6 +54,9 @@ describe('Shrink-Ray Technician', function () {
             this.player1.clickCard(this.firespitter);
             expect(this.firespitter.power).toBe(1);
             expect(this.firespitter.armor).toBe(0);
+            expect(this.foozle.power).toBe(5);
+            expect(this.dustPixie.power).toBe(1);
+            expect(this.dustPixie.location).toBe('play area');
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });


### PR DESCRIPTION
Instead of applying to all enemy cards.