### PR TITLE
GR: fix Loyal Packmate and Psychic Haze target controller

### DIFF
--- a/server/game/cards/07-GR/LoyalPackmate.js
+++ b/server/game/cards/07-GR/LoyalPackmate.js
@@ -5,7 +5,7 @@ class LoyalPackmate extends Card {
     // unless the friendly creature has taunt.
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetController: 'self',
+            targetController: 'current',
             match: (card) => card.type === 'creature' && !card.getKeywordValue('taunt'),
             effect: ability.effects.cardCannot('attack')
         });

--- a/server/game/cards/07-GR/PsychicHaze.js
+++ b/server/game/cards/07-GR/PsychicHaze.js
@@ -13,7 +13,7 @@ class PsychicHaze extends Card {
         });
 
         this.persistentEffect({
-            targetController: 'self',
+            targetController: 'current',
             match: (card) => card.type === 'creature' && card.hasHouse('mars'),
             effect: ability.effects.cardCannot('attack', (context) => context.source.enraged)
         });

--- a/test/server/cards/07-GR/LoyalPackmate.spec.js
+++ b/test/server/cards/07-GR/LoyalPackmate.spec.js
@@ -28,6 +28,9 @@ describe('Loyal Packmate', function () {
             this.player1.endTurn();
             this.player2.clickPrompt('shadows');
             this.player2.fightWith(this.umbra, this.troll);
+            expect(this.troll.tokens.damage).toBe(2);
+            expect(this.player1.amber).toBe(0);
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
         });
     });
 });


### PR DESCRIPTION
'self' is not a valid `targetController` value; it should be 'current' for some reason.

Closes: #3855