### PR TITLE
GR: make Be Our Geist work for treachery and enters play abilities

### DIFF
--- a/server/game/TerminalCondition.js
+++ b/server/game/TerminalCondition.js
@@ -31,7 +31,9 @@ class TerminalCondition {
             (!this.gameAction || this.gameAction.canAffect(this.target, this.context)) &&
             (!this.event ||
                 this.event.cancelled ||
-                (this.event.leavesPlayEvent.resolved && this.event.card !== this.target))
+                (this.event.leavesPlayEvent &&
+                    this.event.leavesPlayEvent.resolved &&
+                    this.event.card !== this.target))
         );
     }
 

--- a/test/server/cards/07-GR/BeOurGeist.spec.js
+++ b/test/server/cards/07-GR/BeOurGeist.spec.js
@@ -12,7 +12,9 @@ describe('Be Our Geist', function () {
                 player2: {
                     amber: 4,
                     inPlay: ['dust-pixie'],
-                    discard: new Array(8).fill('poke').concat(['bot-bookton']) // not yet haunted
+                    discard: new Array(6)
+                        .fill('poke')
+                        .concat(['bot-bookton', 'ælbia-stray', 'infiltrator']) // not yet haunted
                 }
             });
         });
@@ -29,6 +31,8 @@ describe('Be Our Geist', function () {
             expect(this.player1).not.toBeAbleToSelect(this.libraryOfBabble);
             expect(this.player1).not.toBeAbleToSelect(this.poke);
             expect(this.player1).not.toBeAbleToSelect(this.botBookton);
+            expect(this.player1).not.toBeAbleToSelect(this.ælbiaStray);
+            expect(this.player1).not.toBeAbleToSelect(this.infiltrator);
             expect(this.player1).not.toBeAbleToSelect(this.dustPixie);
             expect(this.player1).not.toBeAbleToSelect(this.missChievous);
             this.player1.clickCard(this.charette);
@@ -49,12 +53,32 @@ describe('Be Our Geist', function () {
             expect(this.player1).not.toBeAbleToSelect(this.poke);
             expect(this.player1).toBeAbleToSelect(this.botBookton);
             expect(this.player1).toBeAbleToSelect(this.dustPixie);
+            expect(this.player1).toBeAbleToSelect(this.ælbiaStray);
+            expect(this.player1).toBeAbleToSelect(this.infiltrator);
             expect(this.player1).not.toBeAbleToSelect(this.missChievous);
             this.player1.clickCard(this.dustPixie);
             this.player1.clickPrompt('Right');
             expect(this.dustPixie.location).toBe('play area');
             expect(this.player1.amber).toBe(4);
             expect(this.player1.player.creaturesInPlay).toContain(this.dustPixie);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('cannot play Aelbia Stray ready when not haunted', function () {
+            this.player1.fightWith(this.missChievous, this.dustPixie);
+            this.player1.play(this.beOurGeist);
+            this.player1.clickCard(this.ælbiaStray);
+            this.player1.clickPrompt('Right');
+            expect(this.ælbiaStray.exhausted).toBe(true);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('respects treachery', function () {
+            this.player1.fightWith(this.missChievous, this.dustPixie);
+            this.player1.play(this.beOurGeist);
+            this.player1.clickCard(this.infiltrator);
+            expect(this.infiltrator.location).toBe('play area');
+            expect(this.player2.player.creaturesInPlay).toContain(this.infiltrator);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });


### PR DESCRIPTION
`treachery`/`entersPlayUnderOpponentControl` was always using the card's owner's opponent as the new controller, but that is not correct in cases like Be Our Geist or Lateral Shift, where you're playing someone else's creature as if it were in your hand.  Instead, use the active player's opponent (if they would otherwise be taking control of the put-into-played creature).

Similarly, "entersPlay" effects like `entersPlayReady`, which have a player-dependent condition (such as the tide being high, or being haunted) need to calculate their effects taking into account the active player / new controller of the card. This requires updating the game state to recalculate all the new conditions.

Closes: #3863