### PR TITLE
GR: Cauldron should work for more than 3 cards under it

### DIFF
--- a/server/game/GameActions/SequentialPlayAction.js
+++ b/server/game/GameActions/SequentialPlayAction.js
@@ -6,6 +6,7 @@ class SequentialPlayAction extends GameAction {
         this.revealList = [];
         this.ready = false;
         this.forEach = [];
+        this.num = 0;
     }
 
     setup() {
@@ -40,11 +41,16 @@ class SequentialPlayAction extends GameAction {
     }
 
     filterAndApplyAction(context, forEach) {
+        if (this.num !== 0 && this.played >= this.num) {
+            return;
+        }
+
         let filteredForEach = forEach.filter(
             (card) => !card.gigantic || forEach.some((part) => part.id === card.compositeId)
         );
 
         if (filteredForEach.length > 1) {
+            this.played++;
             context.game.promptForSelect(context.game.activePlayer, {
                 activePromptTitle: 'Choose a card to play',
                 selector: new CardListSelector(filteredForEach, this.revealList),
@@ -64,11 +70,13 @@ class SequentialPlayAction extends GameAction {
                 }
             });
         } else if (filteredForEach.length === 1) {
+            this.played++;
             this.queueActionSteps(context, filteredForEach[0]);
         }
     }
 
     getEventArray(context) {
+        this.played = 0;
         return [
             super.createEvent('unnamedEvent', {}, () => {
                 this.filterAndApplyAction(context, this.forEach);

--- a/server/game/cards/07-GR/Cauldron.js
+++ b/server/game/cards/07-GR/Cauldron.js
@@ -13,9 +13,10 @@ class Cauldron extends Card {
             })),
             then: {
                 alwaysTriggers: true,
-                condition: (context) => context.source.childCards.length === 3,
+                condition: (context) => context.source.childCards.length >= 3,
                 gameAction: ability.actions.sequentialPlay((context) => ({
-                    forEach: context.source.childCards
+                    forEach: context.source.childCards,
+                    num: 3
                 }))
             }
         });

--- a/test/server/cards/07-GR/Cauldron.spec.js
+++ b/test/server/cards/07-GR/Cauldron.spec.js
@@ -5,12 +5,14 @@ describe('Cauldron', function () {
                 player1: {
                     amber: 1,
                     house: 'untamed',
-                    hand: ['dust-pixie'],
+                    hand: ['snufflegator', 'knoxx', 'poke'],
                     inPlay: ['cauldron', 'near-future-lens'],
                     discard: ['witch-of-the-eye', 'ganger-chieftain', 'smith']
                 },
                 player2: {
-                    inPlay: ['umbra']
+                    inPlay: ['umbra'],
+                    hand: ['befuddle'],
+                    discard: ['quixxle-stone']
                 }
             });
             this.player1.chains = 36;
@@ -24,48 +26,94 @@ describe('Cauldron', function () {
             expect(this.cauldron.childCards).toContain(this.witchOfTheEye);
         });
 
-        it('place top 3 cards of deck under itself then play them', function () {
-            this.player1.useAction(this.cauldron, true);
-            this.player1.endTurn();
-            this.player2.clickPrompt('shadows');
-            this.player2.endTurn();
-            this.player1.clickPrompt('untamed');
-            this.player1.useAction(this.cauldron, true);
-            this.player1.endTurn();
-            this.player2.clickPrompt('shadows');
-            this.player2.endTurn();
-            this.player1.clickPrompt('untamed');
-            this.player1.useAction(this.cauldron, true);
-            this.player1.clickCard(this.witchOfTheEye);
-            this.player1.clickCard(this.gangerChieftain);
-            this.player1.clickPrompt('Right');
-            this.player1.clickPrompt('Done');
-            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
-            expect(this.player1.amber).toBe(4);
-            expect(this.cauldron.childCards.length).toBe(0);
-            expect(this.witchOfTheEye.location).toBe('play area');
-            expect(this.gangerChieftain.location).toBe('play area');
-            expect(this.smith.location).toBe('discard');
-        });
+        describe('with 3 cards under', function () {
+            beforeEach(function () {
+                this.player1.useAction(this.cauldron, true);
+                this.player1.endTurn();
+                this.player2.clickPrompt('shadows');
+                this.player2.endTurn();
+                this.player1.clickPrompt('untamed');
+                this.player1.useAction(this.cauldron, true);
+                this.player1.endTurn();
+                this.player2.clickPrompt('shadows');
+                this.player2.endTurn();
+                this.player1.clickPrompt('untamed');
+            });
 
-        it('play cards in any order', function () {
-            this.player1.useAction(this.cauldron, true);
-            this.player1.endTurn();
-            this.player2.clickPrompt('shadows');
-            this.player2.endTurn();
-            this.player1.clickPrompt('untamed');
-            this.player1.useAction(this.cauldron, true);
-            this.player1.endTurn();
-            this.player2.clickPrompt('shadows');
-            this.player2.endTurn();
-            this.player1.clickPrompt('untamed');
-            this.player1.useAction(this.cauldron, true);
-            this.player1.clickCard(this.smith);
-            this.player1.clickCard(this.witchOfTheEye);
-            this.player1.clickPrompt('Right');
-            this.player1.clickPrompt('Done');
-            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
-            expect(this.player1.amber).toBe(2);
+            it('play 3 cards', function () {
+                this.player1.useAction(this.cauldron, true);
+                this.player1.clickCard(this.witchOfTheEye);
+                this.player1.clickCard(this.gangerChieftain);
+                this.player1.clickPrompt('Right');
+                this.player1.clickPrompt('Done');
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+                expect(this.player1.amber).toBe(4);
+                expect(this.cauldron.childCards.length).toBe(0);
+                expect(this.witchOfTheEye.location).toBe('play area');
+                expect(this.gangerChieftain.location).toBe('play area');
+                expect(this.smith.location).toBe('discard');
+            });
+
+            it('play 3 cards in any order', function () {
+                this.player1.useAction(this.cauldron, true);
+                this.player1.clickCard(this.smith);
+                this.player1.clickCard(this.witchOfTheEye);
+                this.player1.clickPrompt('Right');
+                this.player1.clickPrompt('Done');
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+                expect(this.player1.amber).toBe(2);
+            });
+
+            it('puts cards that cannot be played back under itself', function () {
+                this.player2.moveCard(this.quixxleStone, 'play area');
+                this.player1.playCreature(this.snufflegator);
+                this.player1.playCreature(this.knoxx);
+                this.player1.useAction(this.cauldron, true);
+                this.player1.clickCard(this.witchOfTheEye);
+                expect(this.witchOfTheEye.location).toBe('under');
+                this.player1.clickCard(this.gangerChieftain);
+                expect(this.gangerChieftain.location).toBe('under');
+                expect(this.player1.amber).toBe(4);
+                expect(this.smith.location).toBe('discard');
+                expect(this.cauldron.childCards.length).toBe(2);
+            });
+
+            it('lets players choose 3 if there are more than 3', function () {
+                this.player1.endTurn();
+                this.player2.clickPrompt('unfathomable');
+                this.player2.play(this.befuddle);
+                this.player2.clickPrompt('logos');
+                this.player2.endTurn();
+                this.player1.clickPrompt('untamed');
+                this.player1.useAction(this.cauldron, true);
+                this.player1.clickCard(this.witchOfTheEye);
+                expect(this.witchOfTheEye.location).toBe('under');
+                this.player1.clickCard(this.gangerChieftain);
+                expect(this.gangerChieftain.location).toBe('under');
+                expect(this.smith.location).toBe('under');
+                expect(this.player1.amber).toBe(1);
+                this.player1.endTurn();
+                this.player2.clickPrompt('unfathomable');
+                this.player2.endTurn();
+                this.player1.clickPrompt('untamed');
+                this.player1.moveCard(this.poke, 'deck');
+                this.player1.useAction(this.cauldron, true);
+                expect(this.poke.location).toBe('under');
+                expect(this.cauldron.childCards.length).toBe(4);
+                this.player1.clickCard(this.witchOfTheEye);
+                this.player1.clickCard(this.gangerChieftain);
+                this.player1.clickPrompt('Right');
+                this.player1.clickPrompt('Done');
+                this.player1.clickCard(this.smith);
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+                expect(this.player1.amber).toBe(4);
+                expect(this.cauldron.childCards.length).toBe(1);
+                expect(this.witchOfTheEye.location).toBe('play area');
+                expect(this.gangerChieftain.location).toBe('play area');
+                expect(this.smith.location).toBe('discard');
+                expect(this.poke.location).toBe('under');
+                expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+            });
         });
 
         it('trigger Near-Future Lens message', function () {


### PR DESCRIPTION
If the cards under Cauldron can't be played for a turn, it's possible to get more than 3 cards under it.  However, only three cards (of the active player's choice) can be played with one activation in a later turn.

Closes: #3878