### PR TITLE
GR: fix crash when Legerdemain is discarded by Myers

### DIFF
--- a/server/game/cards/07-GR/Legerdemain.js
+++ b/server/game/cards/07-GR/Legerdemain.js
@@ -13,7 +13,7 @@ class Legerdemain extends Card {
             then: (preThenContext) => ({
                 gameAction: ability.actions.gainAmber({
                     amount: 1,
-                    target: preThenContext.target.controller
+                    target: preThenContext.target ? preThenContext.target.controller : []
                 })
             })
         });

--- a/test/server/cards/07-GR/MissileOfficerMyers.spec.js
+++ b/test/server/cards/07-GR/MissileOfficerMyers.spec.js
@@ -5,7 +5,7 @@ describe('Missile Officer Myers', function () {
                 player1: {
                     amber: 1,
                     house: 'staralliance',
-                    hand: ['missile-officer-myers', 'exhume'],
+                    hand: ['missile-officer-myers', 'exhume', 'legerdemain'],
                     inPlay: ['charette', 'medic-ingram'],
                     discard: ['gub']
                 },
@@ -47,6 +47,12 @@ describe('Missile Officer Myers', function () {
             expect(this.missileOfficerMyers.location).toBe('discard');
             expect(this.exhume.location).toBe('discard');
             expect(this.gub.location).toBe('play area');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('can discard Legerdemain without crashing when there is no target', function () {
+            this.player1.scrap(this.missileOfficerMyers);
+            this.player1.clickCard(this.legerdemain);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });


### PR DESCRIPTION
For some reason, the `gameAction` in Legerdemain's `then:` ability is fully evaluated when it's play effect is triggered by Missile Officer Myers's scrap ability.  When there are no creatures to target, this leads to a crash trying to resolve `preThenContext.target.controller`. This doesn't happen when it's played normally and there are no creatures to target though, so something else weird is going on but this is just a quick fix for now.