### PR TITLE
GR: Corporal Bridger only allows creature use, not card use

### DIFF
--- a/server/game/cards/07-GR/CorporalBridger.js
+++ b/server/game/cards/07-GR/CorporalBridger.js
@@ -7,9 +7,9 @@ class CorporalBridger extends Card {
         this.play({
             fight: true,
             reap: true,
-            effect: 'allow them to play or use one non staralliance card this turn',
+            effect: 'allow them to use one non staralliance creature this turn',
             gameAction: ability.actions.forRemainderOfTurn({
-                effect: ability.effects.canUseNonHouse('staralliance')
+                effect: ability.effects.canUseNonHouseCreature('staralliance')
             })
         });
     }

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -3,6 +3,7 @@ const DestroyAction = require('./GameActions/DestroyAction');
 
 const HouseUseEffects = ['canUseHouse', 'canPlayOrUseHouse'];
 const NonHouseUseEffects = ['canPlayOrUseNonHouse', 'canUseNonHouse'];
+const NonHouseCreatureUseEffects = ['canPlayOrUseNonHouseCreature', 'canUseNonHouseCreature'];
 const HousePlayEffects = ['canPlayHouse', 'canPlayOrUseHouse'];
 const NonHousePlayEffects = ['canPlayNonHouse', 'canPlayOrUseNonHouse'];
 
@@ -32,6 +33,9 @@ const Costs = {
                     ((HouseUseEffects.includes(effect.type) &&
                         context.source.hasHouse(effect.getValue(context.player))) ||
                         (NonHouseUseEffects.includes(effect.type) &&
+                            !context.source.hasHouse(effect.getValue(context.player))) ||
+                        (NonHouseCreatureUseEffects.includes(effect.type) &&
+                            context.source.type === 'creature' &&
                             !context.source.hasHouse(effect.getValue(context.player)))) &&
                     !context.game.effectsUsed.includes(effect)
             );
@@ -48,7 +52,8 @@ const Costs = {
                 let houseEffects = context.player.effects.filter(
                     (effect) =>
                         (HouseUseEffects.includes(effect.type) ||
-                            NonHouseUseEffects.includes(effect.type)) &&
+                            NonHouseUseEffects.includes(effect.type) ||
+                            NonHouseCreatureUseEffects.includes(effect.type)) &&
                         !context.game.effectsUsed.includes(effect)
                 );
                 let effect = houseEffects.find(
@@ -56,6 +61,9 @@ const Costs = {
                         (HouseUseEffects.includes(effect.type) &&
                             context.source.hasHouse(effect.getValue(context.player))) ||
                         (NonHouseUseEffects.includes(effect.type) &&
+                            !context.source.hasHouse(effect.getValue(context.player))) ||
+                        (NonHouseCreatureUseEffects.includes(effect.type) &&
+                            context.source.type === 'creature' &&
                             !context.source.hasHouse(effect.getValue(context.player)))
                 );
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -109,6 +109,7 @@ const Effects = {
     canPlayOrUseHouse: (house) => EffectBuilder.player.static('canPlayOrUseHouse', house),
     canPlayOrUseNonHouse: (house) => EffectBuilder.player.static('canPlayOrUseNonHouse', house),
     canUseNonHouse: (house) => EffectBuilder.player.static('canUseNonHouse', house),
+    canUseNonHouseCreature: (house) => EffectBuilder.player.static('canUseNonHouseCreature', house),
     canUse: (match) => EffectBuilder.player.static('canUse', new CanUse(match)),
     canUseHouse: (house) => EffectBuilder.player.static('canUseHouse', house),
     chooseCardsFromArchives: (card) => EffectBuilder.player.static('chooseCardsFromArchives', card),

--- a/test/server/cards/07-GR/CorporalBridger.spec.js
+++ b/test/server/cards/07-GR/CorporalBridger.spec.js
@@ -6,7 +6,7 @@ describe('Corporal Bridger', function () {
                     amber: 1,
                     house: 'staralliance',
                     hand: ['corporal-bridger', 'batdrone'],
-                    inPlay: ['dust-pixie', 'flaxia']
+                    inPlay: ['dust-pixie', 'flaxia', 'library-of-babble']
                 },
                 player2: {
                     inPlay: ['timetraveller']
@@ -21,6 +21,13 @@ describe('Corporal Bridger', function () {
             this.player1.reap(this.dustPixie);
             expect(this.player1.amber).toBe(2);
             this.player1.clickCard(this.flaxia);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should not allow artifact use on play', function () {
+            this.player1.play(this.corporalBridger);
+            this.player1.clickCard(this.libraryOfBabble);
+            expect(this.player1.hand.length).toBe(1);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
 


### PR DESCRIPTION
The existing out-of-house-use effect allowed for artifact use as well, so a new effect was needed.