### PR TITLE
Sort card enhacements with discard pips being last

### DIFF
--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -2,6 +2,7 @@ const logger = require('../log');
 const util = require('../util');
 const db = require('../db');
 const { expand, flatten } = require('../Array');
+const BonusOrder = ['amber', 'capture', 'damage', 'draw', 'discard'];
 
 class DeckService {
     constructor(configService, cardService) {
@@ -374,7 +375,7 @@ class DeckService {
                 ? card.Enhancements.replace(/[[{}"\]]/gi, '')
                       .split(',')
                       .filter((c) => c.length > 0)
-                      .sort()
+                      .sort((a, b) => BonusOrder.indexOf(a) - BonusOrder.indexOf(b))
                 : undefined
         }));
 


### PR DESCRIPTION
Card enhancements on the physical cards are no longer sorted by alphabetical order. Discard pips are always evaluated last.

Suggested by SkyJedi.