### PR TITLE
GR: fix Aberrant Warp Event when there are no cards in deck

### DIFF
--- a/server/game/cards/07-GR/AberrantWarpEvent.js
+++ b/server/game/cards/07-GR/AberrantWarpEvent.js
@@ -19,7 +19,10 @@ function wasCreatureDiscarded(context) {
 function playLastDiscardedCardAndDestroyNeighbors(ability) {
     return ability.actions.sequential([
         ability.actions.putIntoPlay((context) => ({
-            target: context.preThenEvents[context.preThenEvents.length - 1].card
+            target:
+                context.preThenEvents.length > 0
+                    ? context.preThenEvents[context.preThenEvents.length - 1].card
+                    : []
         })),
         ability.actions.destroy((context) => ({
             promptForSelect: {

--- a/test/server/cards/07-GR/AberrantWarpEvent.spec.js
+++ b/test/server/cards/07-GR/AberrantWarpEvent.spec.js
@@ -138,5 +138,25 @@ describe('AberrantWarpEvent', function () {
             expect(this.mother.location).toBe('discard');
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
+
+        it('plays with no cards in own deck', function () {
+            this.player1.player.deck = [];
+
+            this.player2.moveCard(this.gub, 'deck');
+            this.player2.moveCard(this.daughter, 'deck');
+            this.player2.moveCard(this.crazyKillingMachine, 'deck');
+            this.player2.moveCard(this.staticCharge, 'deck');
+            this.player2.moveCard(this.causalLoop, 'deck');
+
+            // Self
+            this.player1.play(this.aberrantWarpEvent);
+            // Opponent
+            expect(this.player1).toHavePrompt('Which flank do you want to place this creature on?');
+            this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.mother);
+            expect(this.daughter.location).toBe('play area');
+            expect(this.mother.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
     });
 });


### PR DESCRIPTION
Yet another case of the action being evaluated even though the conditional already failed.