### PR TITLE
GR: fix some tricky situations for Bryozoarch

### DIFF
--- a/server/game/BaseActions/BasePlayAction.js
+++ b/server/game/BaseActions/BasePlayAction.js
@@ -45,16 +45,30 @@ class BasePlayAction extends BaseAbility {
     }
 
     addSubEvent(event, context) {
-        event.addSubEvent(
-            context.game.getEvent('unnamedEvent', {}, () => {
-                context.game.checkGameState(true);
-                // update game state to consider effects
-                if (context.source.hasKeyword('omega')) {
-                    context.game.omegaCard = context.source;
+        let bonusEvent = context.game.getEvent('unnamedEvent', {}, () => {
+            context.game.checkGameState(true);
+            // update game state to consider effects
+            if (context.source.hasKeyword('omega')) {
+                context.game.omegaCard = context.source;
+            }
+            context.game.actions.resolveBonusIcons().resolve(context.source, context);
+        });
+        bonusEvent.addSubEvent(
+            context.game.getEvent(
+                'onCardPlayedAfterBonusIcons',
+                {
+                    player: context.player,
+                    card: context.source
+                },
+                () => {
+                    // Resolving the bonus icons might change the
+                    // ability events possible from this card, so
+                    // re-evaluate them here.
+                    context.source.updateAbilityEvents('hand', 'being played');
                 }
-                context.game.actions.resolveBonusIcons().resolve(context.source, context);
-            })
+            )
         );
+        event.addSubEvent(bonusEvent);
     }
 
     executeHandler(context) {

--- a/server/game/cards/06-WoE/Bryozoarch.js
+++ b/server/game/cards/06-WoE/Bryozoarch.js
@@ -10,12 +10,20 @@ class Bryozoarch extends Card {
 
         this.interrupt({
             when: {
-                onCardPlayed: (event, context) =>
-                    event.card.type === 'action' && event.player === context.player.opponent
+                onCardPlayedAfterBonusIcons: (event, context) =>
+                    event.card.type === 'action' &&
+                    event.player === context.player.opponent &&
+                    context.source.location === 'play area'
             },
-            gameAction: ability.actions.destroy((context) => ({
-                target: context.player.creaturesInPlay[0]
-            }))
+            gameAction: ability.actions.changeEvent((context) => ({
+                event: context.event,
+                cancel: true
+            })),
+            then: {
+                gameAction: ability.actions.destroy((context) => ({
+                    target: context.player.creaturesInPlay[0]
+                }))
+            }
         });
     }
 }

--- a/test/server/cards/06-WoE/Bryozoarch.spec.js
+++ b/test/server/cards/06-WoE/Bryozoarch.spec.js
@@ -11,9 +11,10 @@ describe('Bryozoarch', function () {
                 player2: {
                     token: 'grumpus',
                     inPlay: ['skullback-crab', 'bryozoarch'],
-                    hand: ['initiation']
+                    hand: ['initiation', 'bryozoarch']
                 }
             });
+            this.bryozoarch2 = this.player2.player.hand[1];
         });
 
         it('should blank opponent actions', function () {
@@ -21,7 +22,7 @@ describe('Bryozoarch', function () {
             expect(this.player2.player.creaturesInPlay.length).toBe(1);
             expect(this.skullbackCrab.location).toBe('discard');
             expect(this.bryozoarch.location).toBe('play area');
-            expect(this.player2.player.archives.length).toBe(0);
+            expect(this.player1.player.archives.length).toBe(0);
             expect(this.player1.amber).toBe(2);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
@@ -47,10 +48,44 @@ describe('Bryozoarch', function () {
             expect(this.player2.player.creaturesInPlay.length).toBe(1);
             expect(this.skullbackCrab.location).toBe('discard');
             expect(this.bryozoarch.location).toBe('play area');
-            expect(this.player2.player.archives.length).toBe(0);
+            expect(this.player1.player.archives.length).toBe(0);
             expect(this.player1.amber).toBe(3);
 
             expect(this.tribute.location).toBe('discard');
+        });
+
+        it('should only cause one destroy with 2 Bryozoarchs out', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('unfathomable');
+            this.player2.playCreature(this.bryozoarch2);
+            this.player2.endTurn();
+            this.player1.clickPrompt('logos');
+
+            this.player1.play(this.labwork);
+            this.player1.clickCard(this.bryozoarch); // which Bryo interrupts?
+            expect(this.player2.player.creaturesInPlay.length).toBe(2);
+            expect(this.skullbackCrab.location).toBe('discard');
+            expect(this.bryozoarch.location).toBe('play area');
+            expect(this.bryozoarch2.location).toBe('play area');
+            expect(this.player1.player.archives.length).toBe(0);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should resolve bonus icons before replacing the event', function () {
+            this.labwork.enhancements = ['damage'];
+            this.bryozoarch.tokens.damage = 5;
+            this.player1.play(this.labwork);
+            this.player1.clickCard(this.bryozoarch);
+            this.player1.clickCard(this.tribute);
+            expect(this.player2.player.creaturesInPlay.length).toBe(1);
+            expect(this.bryozoarch.location).toBe('discard');
+            expect(this.skullbackCrab.location).toBe('play area');
+            expect(this.tribute.location).toBe('archives');
+            expect(this.player1.player.archives.length).toBe(1);
+            expect(this.player1.amber).toBe(2);
+            expect(this.labwork.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });
 });


### PR DESCRIPTION
1. If an action card has a damage pip that is used to kill Bryo, that action's Play ability should still resolve.  This required: a. Re-updating the cards ability events after resolving bonus icons. b. Having Bryo trigger during a new event: `onCardPlayedAfterBonusIcons`.
2. If there are two Bryos on in a battleline, the replacement effect should only happen once.  In the code, this is done by canceling the `onCardPlayedAfterBonusIcons` event.

Closes: #3539
Closes: #3798
Closes: #3436