### PR TITLE
Fix shuffling on ReturnToDeckAction

### DIFF
--- a/server/game/GameActions/ReturnToDeckAction.js
+++ b/server/game/GameActions/ReturnToDeckAction.js
@@ -4,6 +4,7 @@ class ReturnToDeckAction extends CardGameAction {
     setDefaultProperties() {
         this.bottom = false;
         this.shuffle = false;
+        this.shufflePlayer = null;
         this.shuffleDiscardIntoDeck = false;
     }
 
@@ -24,7 +25,6 @@ class ReturnToDeckAction extends CardGameAction {
     }
 
     getEventArray(context) {
-        let shufflePlayer = context.player;
         if (this.shuffle && !this.shuffleDiscardIntoDeck) {
             // Figure out if the entire discard has been shuffled into the
             // deck for either player.
@@ -43,11 +43,14 @@ class ReturnToDeckAction extends CardGameAction {
             ) {
                 this.shuffleDiscardIntoDeck =
                     context.player.opponent.discard === this.originalTarget;
-                shufflePlayer = context.player.opponent;
             }
         }
 
         if (this.target.length === 0 && this.shuffle) {
+            let shufflePlayer = context.player;
+            if (this.shufflePlayer) {
+                shufflePlayer = this.shufflePlayer;
+            }
             shufflePlayer.shuffleDeck(this.shuffleDiscardIntoDeck);
         }
 

--- a/server/game/cards/01-Core/LostInTheWoods.js
+++ b/server/game/cards/01-Core/LostInTheWoods.js
@@ -17,7 +17,10 @@ class LostInTheWoods extends Card {
                     numCards: 2,
                     cardType: 'creature',
                     controller: 'opponent',
-                    gameAction: ability.actions.returnToDeck({ shuffle: true })
+                    gameAction: ability.actions.returnToDeck((context) => ({
+                        shuffle: true,
+                        shufflePlayer: context.player.opponent
+                    }))
                 }
             },
             effect: "shuffle {1} into their owner's deck",

--- a/server/game/cards/01-Core/MatingSeason.js
+++ b/server/game/cards/01-Core/MatingSeason.js
@@ -8,20 +8,31 @@ class MatingSeason extends Card {
                 "shuffle each Mars creature into their owner's deck, and each player gains 1 amber for each creature shuffled into their deck",
             gameAction: [
                 ability.actions.gainAmber((context) => ({
-                    amount: context.player.creaturesInPlay.filter((card) => card.hasHouse('mars'))
-                        .length
+                    amount: context.game.creaturesInPlay.filter(
+                        (card) => card.hasHouse('mars') && card.owner === context.player
+                    ).length
                 })),
                 ability.actions.gainAmber((context) => ({
                     target: context.player.opponent,
                     amount: context.player.opponent
-                        ? context.player.opponent.creaturesInPlay.filter((card) =>
-                              card.hasHouse('mars')
+                        ? context.game.creaturesInPlay.filter(
+                              (card) =>
+                                  card.hasHouse('mars') && card.owner === context.player.opponent
                           ).length
                         : 0
                 })),
                 ability.actions.returnToDeck((context) => ({
                     shuffle: true,
-                    target: context.game.creaturesInPlay.filter((card) => card.hasHouse('mars'))
+                    target: context.game.creaturesInPlay.filter(
+                        (card) => card.hasHouse('mars') && card.owner === context.player
+                    )
+                })),
+                ability.actions.returnToDeck((context) => ({
+                    shuffle: true,
+                    shufflePlayer: context.player.opponent,
+                    target: context.game.creaturesInPlay.filter(
+                        (card) => card.hasHouse('mars') && card.owner === context.player.opponent
+                    )
                 }))
             ]
         });

--- a/server/game/cards/03-WC/KymoorEclipse.js
+++ b/server/game/cards/03-WC/KymoorEclipse.js
@@ -4,10 +4,21 @@ class KymoorEclipse extends Card {
     // Play: Shuffle each flank creature into its owners deck.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.returnToDeck((context) => ({
-                target: context.game.creaturesInPlay.filter((card) => card.isOnFlank()),
-                shuffle: true
-            }))
+            gameAction: [
+                ability.actions.returnToDeck((context) => ({
+                    target: context.game.creaturesInPlay.filter(
+                        (card) => card.isOnFlank() && card.owner === context.player
+                    ),
+                    shuffle: true
+                })),
+                ability.actions.returnToDeck((context) => ({
+                    target: context.game.creaturesInPlay.filter(
+                        (card) => card.isOnFlank() && card.owner === context.player.opponent
+                    ),
+                    shuffle: true,
+                    shufflePlayer: context.player.opponent
+                }))
+            ]
         });
     }
 }

--- a/server/game/cards/07-GR/3LLI0T.js
+++ b/server/game/cards/07-GR/3LLI0T.js
@@ -20,10 +20,22 @@ class ThreeLLI0T extends Card {
         });
 
         this.scrap({
-            gameAction: ability.actions.returnToDeck((context) => ({
-                target: context.game.creaturesInPlay.flatMap((card) => card.upgrades || []),
-                shuffle: true
-            }))
+            gameAction: [
+                ability.actions.returnToDeck((context) => ({
+                    target: context.game.cardsInPlay.flatMap(
+                        (card) => card.upgrades.filter((u) => u.owner === context.player) || []
+                    ),
+                    shuffle: true
+                })),
+                ability.actions.returnToDeck((context) => ({
+                    target: context.game.cardsInPlay.flatMap(
+                        (card) =>
+                            card.upgrades.filter((u) => u.owner === context.player.opponent) || []
+                    ),
+                    shuffle: true,
+                    shufflePlayer: context.player.opponent
+                }))
+            ]
         });
     }
 }

--- a/server/game/cards/07-GR/FutureIsPast.js
+++ b/server/game/cards/07-GR/FutureIsPast.js
@@ -14,9 +14,12 @@ class FutureIsPast extends Card {
                 })),
                 ability.actions.returnToDeck((context) => ({
                     shuffle: true,
-                    target: context.player.discard.concat(
-                        context.player.opponent ? context.player.opponent.discard : []
-                    )
+                    target: context.player.discard
+                })),
+                ability.actions.returnToDeck((context) => ({
+                    shuffle: true,
+                    shufflePlayer: context.player.opponent,
+                    target: context.player.opponent ? context.player.opponent.discard : []
                 }))
             ]
         });

--- a/server/game/cards/07-GR/LostInTheWild.js
+++ b/server/game/cards/07-GR/LostInTheWild.js
@@ -14,7 +14,8 @@ class LostInTheWild extends Card {
                 condition: (context) => context.player.isHaunted(),
                 gameAction: ability.actions.returnToDeck((context) => ({
                     target: context.game.creaturesInPlay.filter((card) => card.isOnFlank()),
-                    shuffle: true
+                    shuffle: true,
+                    shufflePlayer: context.player.opponent
                 })),
                 message: '{0} uses {1} to repeat the preceding effect'
             }

--- a/server/game/cards/07-GR/TillTheEarth.js
+++ b/server/game/cards/07-GR/TillTheEarth.js
@@ -15,6 +15,7 @@ class TillTheEarth extends Card {
                     condition: !!context.player.opponent,
                     trueGameAction: ability.actions.returnToDeck((context) => ({
                         shuffle: true,
+                        shufflePlayer: context.player.opponent,
                         target: context.player.opponent ? context.player.opponent.discard : []
                     }))
                 }))

--- a/server/game/cards/07-GR/Warfaline.js
+++ b/server/game/cards/07-GR/Warfaline.js
@@ -17,6 +17,10 @@ class Warfaline extends Card {
             effect: "shuffle the top 5 cards of a discard pile into the owner's deck",
             gameAction: ability.actions.returnToDeck((context) => ({
                 shuffle: true,
+                shufflePlayer:
+                    !context.select || context.select === 'Mine'
+                        ? context.player
+                        : context.player.opponent,
                 target:
                     !context.select || context.select === 'Mine'
                         ? context.player.getDiscardSlice(5)


### PR DESCRIPTION
If the action targets 0 cards, and the opponent happened to have an empty discard pile, `ReturnToDeckAction` would incorrectly shuffle the opponent's deck rather than the active player's deck.

Instead, fix it to explicitly specify the player whose deck is supposed to be shuffled, if it's not the active player's deck.  Do this in all the cards that shuffle the opponent's deck.

This also fixes a few cards that are supposed to shuffle both player's decks, but wouldn't if no cards from a player were being shuffled back in.  Also fixes a bug in Mating Season that was awarding amber by control, rather than by ownership.

Closes: #3960