### PR TITLE
AS: move Refined Adhesive to right directory, and fix for scrap

### DIFF
--- a/server/game/cards/08-AS/RefinedAdhesive.js
+++ b/server/game/cards/08-AS/RefinedAdhesive.js
@@ -5,16 +5,22 @@ class RefinedAdhesive extends Card {
     // reveal the card and put it facedown under this creature
     // instead.
     setupCardAbilities(ability) {
-        this.reaction({
+        this.interrupt({
             when: {
                 onCardDiscarded: (event, context) =>
                     event.location === 'hand' && context.source.parent
             },
-            gameAction: ability.actions.placeUnder((context) => ({
-                target: context.event.card,
-                parent: context.source.parent,
-                facedown: true
-            }))
+            gameAction: [
+                ability.actions.placeUnder((context) => ({
+                    target: context.event.card,
+                    parent: context.source.parent,
+                    facedown: true
+                })),
+                ability.actions.changeEvent((context) => ({
+                    event: context.event,
+                    cancel: true
+                }))
+            ]
         });
     }
 }

--- a/test/server/cards/08-AS/RefinedAdhesive.spec.js
+++ b/test/server/cards/08-AS/RefinedAdhesive.spec.js
@@ -4,11 +4,12 @@ describe('Refined Adhesive', function () {
             this.setupTest({
                 player1: {
                     house: 'skyborn',
-                    hand: ['refined-adhesive', 'bomb-arang'],
+                    hand: ['refined-adhesive', 'bomb-arang', 'bux-bastian'],
                     inPlay: ['flaxia']
                 },
                 player2: {
-                    hand: ['dust-pixie', 'hunting-witch']
+                    hand: ['dust-pixie', 'hunting-witch'],
+                    inPlay: ['troll']
                 }
             });
         });
@@ -24,6 +25,13 @@ describe('Refined Adhesive', function () {
             expect(this.huntingWitch.location).toBe('under');
             expect(this.flaxia.childCards).toContain(this.huntingWitch);
             expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should stop scrap effects', function () {
+            this.player1.playUpgrade(this.refinedAdhesive, this.flaxia);
+            this.player1.scrap(this.buxBastian);
+            expect(this.troll.amber).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });
 });


### PR DESCRIPTION
Refined Adhesive should cancel discard events, making scrap events not
fire.