### PR TITLE
GR: fix non-anomaly images for Grim Reaper and Near-Future Lens

### DIFF
--- a/server/scripts/fetchdata/CardImport.js
+++ b/server/scripts/fetchdata/CardImport.js
@@ -54,7 +54,7 @@ class CardImport {
         let specialCards = {
             479: { 'dark-æmber-vault': true, 'it-s-coming': true, 'orb-of-wonder': true },
             496: { 'orb-of-wonder': true, valoocanth: true },
-            700: { 'ecto-charge': true, 'near-future-lens': true }
+            700: { 'ecto-charge': true, 'near-future-lens': true, 'the-grim-reaper': true }
         };
 
         const gigantic = ['deusillus', 'ultra-gravitron', 'niffle-kong'];

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -715,7 +715,7 @@ class DeckService {
 
         let anomalies = {
             'ecto-charge': { anomalySet: 600, house: 'geistoid' },
-            'near-future-lens': { anomalySet: 600, house: 'star-alliance' },
+            'near-future-lens': { anomalySet: 600, house: 'staralliance' },
             'orb-of-wonder': { anomalySet: 453, house: 'sanctum' },
             'the-grim-reaper': { anomalySet: 453, house: 'geistoid' },
             valoocanth: { anomalySet: 453, house: 'unfathomable' }


### PR DESCRIPTION
The Grim Reaper will be fixed on the next fetchdata run.

Near-Future Lens must be fixed by updating every row in `DeckCards` where "ImageURL" is "near-future-lens-star-alliance" to "near-future-lens-staralliance" instead.

Closes: #3942
