### PR TITLE
AS: fix Reap the Wild Wind so it doesn't log random cards

### DIFF
--- a/server/game/cards/08-AS/ReapTheWildWind.js
+++ b/server/game/cards/08-AS/ReapTheWildWind.js
@@ -17,6 +17,7 @@ class ReapTheWildWind extends Card {
                             : []
                     )
             })),
+            effect: "reveal a random card from each player's hand",
             then: (
                 preThenContext,
                 revealedCards = preThenContext.ability.gameAction[0].target


### PR DESCRIPTION
I guess the default log message re-evaluates the randomness of the revealed cards when constructing the log message. Who knew?

Closes: #4190