### PR TITLE
AS: fix Shard of Change to disallow cards with no matching types

### DIFF
--- a/server/game/GameActions/SwapDiscardWithHandAction.js
+++ b/server/game/GameActions/SwapDiscardWithHandAction.js
@@ -24,6 +24,7 @@ class SwapDiscardWithHandAction extends CardGameAction {
     canAffect(card, context) {
         return (
             card.location === 'hand' &&
+            this.discardCard &&
             this.discardCard.location === 'discard' &&
             super.canAffect(card, context)
         );

--- a/server/game/cards/08-AS/ShardOfChange.js
+++ b/server/game/cards/08-AS/ShardOfChange.js
@@ -18,7 +18,9 @@ class ShardOfChange extends Card {
                 first: {
                     controller: 'self',
                     location: 'hand',
-                    optional: true
+                    optional: true,
+                    cardCondition: (card, context) =>
+                        context.player.discard.some((c) => c.type === card.type)
                 },
                 second: {
                     dependsOn: 'first',

--- a/test/server/cards/08-AS/ShardOfChange.spec.js
+++ b/test/server/cards/08-AS/ShardOfChange.spec.js
@@ -114,5 +114,12 @@ describe('Shard of Change', function () {
             this.player1.clickPrompt('Done');
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
+
+        it('should do nothing with no card matches', function () {
+            this.player1.player.hand = [this.wayOfThePixie];
+            this.player1.player.discard = [this.theOldTinker];
+            this.player1.useAction(this.shardOfChange);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
     });
 });


### PR DESCRIPTION
If you had a card in your hand that didn't match any cards in your discard, you shouldn't be able to select it.  Before, selecting it just caused a crash.