### PR TITLE
AS: fix Doppelganger infinite loop

### DIFF
--- a/server/game/AbilityTargets/AbilityTargetCard.js
+++ b/server/game/AbilityTargets/AbilityTargetCard.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 
 const CardSelector = require('../CardSelector.js');
 const AbilityTarget = require('./AbilityTarget.js');
+const Optional = require('../optional.js');
 
 class AbilityTargetCard extends AbilityTarget {
     constructor(name, properties, ability) {
@@ -99,7 +100,7 @@ class AbilityTargetCard extends AbilityTarget {
     }
 
     checkTarget(context) {
-        if (this.properties.optional) {
+        if (Optional.EvalOptional(context, this.properties.optional)) {
             return super.checkTarget(context);
         } else if (!context.targets[this.name]) {
             return false;

--- a/server/game/AbilityTargets/AbilityTargetSelect.js
+++ b/server/game/AbilityTargets/AbilityTargetSelect.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 const SelectChoice = require('./SelectChoice.js');
 const AbilityTarget = require('./AbilityTarget.js');
+const Optional = require('../optional.js');
 
 class AbilityTargetSelect extends AbilityTarget {
     constructor(name, properties, ability) {
@@ -104,7 +105,7 @@ class AbilityTargetSelect extends AbilityTarget {
             };
         });
 
-        if (this.properties.optional) {
+        if (Optional.EvalOptional(context, this.properties.optional)) {
             choices.push('Done');
             handlers.push(() => (targetResults.cancelled = true));
         }

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -1,3 +1,5 @@
+const Optional = require('../optional.js');
+
 class BaseCardSelector {
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
@@ -108,7 +110,7 @@ class BaseCardSelector {
 
     // eslint-disable-next-line no-unused-vars
     hasEnoughSelected(selectedCards, context) {
-        return this.optional || selectedCards.length > 0;
+        return Optional.EvalOptional(context, this.optional) || selectedCards.length > 0;
     }
 
     hasEnoughTargets(context) {

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -56,7 +56,7 @@ class BaseAbility {
     buildTargets(properties) {
         this.targets = [];
         if (properties.target) {
-            this.optionalTarget = !!properties.target.optional;
+            this.optionalTarget = properties.target.optional;
             this.targets.push(this.getAbilityTarget('target', properties.target));
         } else if (properties.targets) {
             for (const key of Object.keys(properties.targets)) {

--- a/server/game/cards/08-AS/Doppelganger.js
+++ b/server/game/cards/08-AS/Doppelganger.js
@@ -9,6 +9,11 @@ class Doppelganger extends Card {
             when: {
                 onBeginRound: (_, context) => context.player === this.game.activePlayer
             },
+            // The card doesn't say this ability it optional, but 2
+            // next to each other leads to an infinite loop that can't
+            // otherwise be broken by the engine (but is breakable by
+            // the Keyforge Infinite Loop rules).
+            optional: (context) => context.source.neighbors.some((c) => c.hasTrait('shapeshifter')),
             target: {
                 cardCondition: (card, context) => context.source.neighbors.includes(card),
                 gameAction: ability.actions.cardLastingEffect((context) => {

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 
 const BaseStep = require('./basestep.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
+const Optional = require('../optional.js');
 
 class ForcedTriggeredAbilityWindow extends BaseStep {
     constructor(game, abilityType, window, eventsToExclude = []) {
@@ -63,7 +64,9 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
             return false;
         }
 
-        this.noOptionalChoices = this.choices.every((context) => !context.ability.optional);
+        this.noOptionalChoices = this.choices.every((context) =>
+            Optional.EvalOptional(context, !context.ability.optional)
+        );
         if (
             this.noOptionalChoices &&
             (this.autoResolve ||
@@ -92,7 +95,9 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
         if (lastingTriggerCards.length === 0) {
             if (
                 choices.some(
-                    (context) => !context.ability.optional && !context.ability.optionalTarget
+                    (context) =>
+                        !Optional.EvalOptional(context, context.ability.optional) &&
+                        !Optional.EvalOptional(context, context.ability.optionalTarget)
                 )
             ) {
                 let sourceCount = 0;
@@ -153,7 +158,9 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
         let buttons = [];
         if (
             this.choices.every(
-                (context) => context.ability.optional || context.ability.optionalTarget
+                (context) =>
+                    Optional.EvalOptional(context, context.ability.optional) ||
+                    Optional.EvalOptional(context, context.ability.optionalTarget)
             )
         ) {
             buttons.push({ text: 'Done', arg: 'done' });

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -4,6 +4,7 @@ const AbilityContext = require('../AbilityContext.js');
 const CardSelector = require('../CardSelector.js');
 const EffectSource = require('../EffectSource.js');
 const UiPrompt = require('./uiprompt.js');
+const Optional = require('../optional.js');
 
 /**
  * General purpose prompt that asks the user to select 1 or more cards.
@@ -155,7 +156,7 @@ class SelectCardPrompt extends UiPrompt {
     activePrompt() {
         let buttons = this.properties.buttons;
         if (
-            this.properties.optional ||
+            Optional.EvalOptional(this.context, this.properties.optional) ||
             (!this.selector.automaticFireOnSelect(this.context) && this.hasEnoughSelected())
         ) {
             if (buttons.every((button) => button.text !== 'Done')) {
@@ -264,7 +265,9 @@ class SelectCardPrompt extends UiPrompt {
     menuCommand(player, arg) {
         if (
             arg === 'cancel' ||
-            (arg === 'done' && this.properties.optional && this.selectedCards.length === 0)
+            (arg === 'done' &&
+                Optional.EvalOptional(this.context, this.properties.optional) &&
+                this.selectedCards.length === 0)
         ) {
             this.properties.onCancel(player);
             this.complete();

--- a/server/game/optional.js
+++ b/server/game/optional.js
@@ -1,0 +1,12 @@
+const _ = require('underscore');
+
+class Optional {}
+
+Optional.EvalOptional = function (context, optional) {
+    if (_.isFunction(optional)) {
+        return optional(context);
+    }
+    return !!optional;
+};
+
+module.exports = Optional;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -41,7 +41,7 @@ class TriggeredAbility extends CardAbility {
         this.useEventPlayer = !!properties.useEventPlayer;
         this.autoResolve = !!properties.autoResolve;
         this.abilityType = abilityType;
-        this.optional = !!properties.optional;
+        this.optional = properties.optional;
         this.isLastingAbilityTrigger = !!properties.player;
         this.multipleTrigger = !!properties.multipleTrigger;
         if (properties.location === 'any') {

--- a/test/server/cards/08-AS/Doppelganger.spec.js
+++ b/test/server/cards/08-AS/Doppelganger.spec.js
@@ -6,7 +6,8 @@ describe('Doppelganger', function () {
                     amber: 1,
                     house: 'geistoid',
                     hand: ['touchstone'],
-                    inPlay: ['umbra', 'doppelganger', 'hunting-witch']
+                    inPlay: ['umbra', 'doppelganger', 'hunting-witch'],
+                    discard: ['doppelganger']
                 },
                 player2: {
                     amber: 2,
@@ -14,6 +15,7 @@ describe('Doppelganger', function () {
                 }
             });
 
+            this.doppelganger2 = this.player1.player.discard[0];
             this.player1.endTurn();
             this.player2.clickPrompt('brobnar');
             this.player2.endTurn();
@@ -48,6 +50,25 @@ describe('Doppelganger', function () {
             this.player1.playCreature(this.touchstone);
             this.player1.clickCard(this.doppelganger);
             expect(this.player1.amber).toBe(3);
+        });
+
+        it('should not be optional unless there are 2 adjacent shapeshifters', function () {
+            expect(this.player1).not.toHavePromptButton('Done');
+        });
+
+        it('should allow breaking from infinite loop with 2 next to each other', function () {
+            this.player1.clickCard(this.huntingWitch);
+            this.player1.clickPrompt('geistoid');
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player1.moveCard(this.huntingWitch, 'discard');
+            this.player1.moveCard(this.doppelganger2, 'play area');
+            this.player2.endTurn();
+
+            this.player1.clickCard(this.doppelganger);
+            this.player1.clickCard(this.doppelganger2);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('geistoid');
         });
     });
 });


### PR DESCRIPTION
2 Doppelgangers next to each other can keep choosing each other, and keep giving each other a new copy of their text box, leading to an infinite loop that can only be broken by the choice of the player, under Keyforge's Infinite Loops clause.  So in this situation, give the user the optional to break out of the loop by making copying a neighbor optional only if one of those neighbors is also a shapeshifter.

Unfortunately, `properties.optional` is not something that could previously be evaluated dynamically, so that needed to be added.