### PR TITLE
Fixes for Befuddle: house enhancements and playing cards using in-play cards

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -564,18 +564,7 @@ class Card extends EffectSource {
         }
 
         house = house.toLowerCase();
-        let copyEffect = this.mostRecentEffect('copyCard');
-        let currentHouse;
-        if (this.anyEffect('changeHouse')) {
-            currentHouse = this.getEffects('changeHouse');
-        } else {
-            currentHouse = [copyEffect ? copyEffect.printedHouse : this.printedHouse];
-            currentHouse = currentHouse.concat(
-                copyEffect ? copyEffect.getHouseEnhancements() : this.getHouseEnhancements()
-            );
-        }
-
-        return currentHouse.includes(house) || this.getEffects('addHouse').includes(house);
+        return this.getHouses().includes(house);
     }
 
     hasHouseThatIsNot(house) {
@@ -583,6 +572,7 @@ class Card extends EffectSource {
             return true;
         }
 
+        house = house.toLowerCase();
         return this.getHouses().some((h) => h !== house);
     }
 

--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -578,6 +578,14 @@ class Card extends EffectSource {
         return currentHouse.includes(house) || this.getEffects('addHouse').includes(house);
     }
 
+    hasHouseThatIsNot(house) {
+        if (!house) {
+            return true;
+        }
+
+        return this.getHouses().some((h) => h !== house);
+    }
+
     applyAnyLocationPersistentEffects() {
         _.each(this.persistentEffects, (effect) => {
             if (effect.location === 'any') {

--- a/server/game/cards/06-WoE/Befuddle.js
+++ b/server/game/cards/06-WoE/Befuddle.js
@@ -24,7 +24,7 @@ class Befuddle extends Card {
                         // for cards already in play.
                         sourceContext.source.location !== 'play area' &&
                         // A card can't be played if it has any house that's not the called house.
-                        sourceContext.source.getHouses().some((h) => h !== context.house)
+                        sourceContext.source.hasHouseThatIsNot(context.house)
                 )
             }))
         });

--- a/server/game/cards/06-WoE/Befuddle.js
+++ b/server/game/cards/06-WoE/Befuddle.js
@@ -14,8 +14,17 @@ class Befuddle extends Card {
             effectAlert: true,
             gameAction: ability.actions.nextRoundEffect((context) => ({
                 targetController: 'opponent',
-                effect: ability.effects.playerCannot('play', (sourceContext) =>
-                    sourceContext.source.getHouses().some((h) => h !== context.house)
+                effect: ability.effects.playerCannot(
+                    'play',
+                    (sourceContext) =>
+                        // When an in-play source plays another card, for
+                        // some reason the play restriction is still
+                        // checked on that card, even though it's already
+                        // in play.  So ignore those restriction checks
+                        // for cards already in play.
+                        sourceContext.source.location !== 'play area' &&
+                        // A card can't be played if it has any house that's not the called house.
+                        sourceContext.source.getHouses().some((h) => h !== context.house)
                 )
             }))
         });

--- a/server/game/cards/06-WoE/Befuddle.js
+++ b/server/game/cards/06-WoE/Befuddle.js
@@ -14,9 +14,8 @@ class Befuddle extends Card {
             effectAlert: true,
             gameAction: ability.actions.nextRoundEffect((context) => ({
                 targetController: 'opponent',
-                effect: ability.effects.playerCannot(
-                    'play',
-                    (sourceContext) => !sourceContext.source.hasHouse(context.house)
+                effect: ability.effects.playerCannot('play', (sourceContext) =>
+                    sourceContext.source.getHouses().some((h) => h !== context.house)
                 )
             }))
         });

--- a/test/server/cards/06-WoE/Befuddle.spec.js
+++ b/test/server/cards/06-WoE/Befuddle.spec.js
@@ -63,5 +63,17 @@ describe('Befuddle', function () {
             this.player2.reap(this.subjectKirby);
             expect(this.player2).not.toBeAbleToSelect(this.helperBot);
         });
+
+        it('should block opponent from playing cards with house enhancements', function () {
+            this.sensorChiefGarcia.enhancements = ['logos'];
+            this.player1.play(this.befuddle);
+            this.player1.clickPrompt('staralliance');
+            this.player1.endTurn();
+            this.player2.clickPrompt('staralliance');
+            this.player2.clickCard(this.sensorChiefGarcia);
+            expect(this.player2).not.toHavePromptButton('Play this creature');
+            expect(this.player2).toHavePromptButton('Discard this card');
+            this.player2.clickPrompt('Cancel');
+        });
     });
 });

--- a/test/server/cards/06-WoE/Befuddle.spec.js
+++ b/test/server/cards/06-WoE/Befuddle.spec.js
@@ -10,14 +10,13 @@ describe('Befuddle', function () {
                 },
                 player2: {
                     amber: 3,
-                    inPlay: ['batdrone', 'mother', 'subject-kirby'],
+                    inPlay: ['batdrone', 'mother', 'subject-kirby', 'sandhopper'],
                     hand: [
                         'helper-bot',
                         'dimension-door',
                         'sensor-chief-garcia',
                         'red-alert',
-                        'disruption-field',
-                        'flaxia'
+                        'disruption-field'
                     ]
                 }
             });
@@ -74,6 +73,20 @@ describe('Befuddle', function () {
             expect(this.player2).not.toHavePromptButton('Play this creature');
             expect(this.player2).toHavePromptButton('Discard this card');
             this.player2.clickPrompt('Cancel');
+        });
+
+        it('should not prevent playing cards of that house off house', function () {
+            this.player1.play(this.befuddle);
+            this.player1.clickPrompt('logos');
+            this.player1.endTurn();
+            this.player2.clickPrompt('ekwidon');
+            this.player2.useAction(this.sandhopper);
+            this.player2.clickCard(this.batdrone);
+            expect(this.batdrone.location).toBe('hand');
+            this.player2.clickCard(this.batdrone);
+            this.player2.clickPrompt('Right');
+            expect(this.batdrone.location).toBe('play area');
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
         });
     });
 });


### PR DESCRIPTION
This fixes 2 issues with Befuddle:

1. It should prevent cards with house enhancements from being played, since they always belong to a house other than the one that was called.
2. It should _not_ prevent cards of that house from being played by an in-play card from the chosen house (for example, Sandhopper playing a card from the house that was called).  The play restriction code here is being too strict and was applying the play restriction to the source doing the playing.

Closes: #3416. 