### PR TITLE
Blank effects to extend to all effects related to text box

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -3,6 +3,7 @@ const _ = require('underscore');
 const AbilityDsl = require('./abilitydsl.js');
 const CardAction = require('./cardaction.js');
 const Constants = require('../constants.js');
+const Effects = require('./effects.js');
 const EffectSource = require('./EffectSource.js');
 const TriggeredAbility = require('./triggeredability');
 
@@ -115,6 +116,28 @@ class Card extends EffectSource {
 
     get type() {
         return this.mostRecentEffect('changeType') || this.clonedType || this.printedType;
+    }
+
+    getEffects(type, predicate = () => true) {
+        if (!Effects.unblankableEffects.includes(type) && this.isBlank()) {
+            return [];
+        }
+        return super.getEffects(type, predicate);
+    }
+
+    sumEffects(type) {
+        if (!Effects.unblankableEffects.includes(type) && this.isBlank()) {
+            return 0;
+        }
+        return super.sumEffects(type);
+    }
+
+    anyEffect(type) {
+        if (!Effects.unblankableEffects.includes(type) && this.isBlank()) {
+            return false;
+        }
+        let x = super.anyEffect(type);
+        return x;
     }
 
     isToken() {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -13,6 +13,25 @@ const GainAbility = require('./Effects/Values/GainAbility');
 */
 
 const Effects = {
+    unblankableEffects: [
+        'modifyPower',
+        'setPower',
+        'modifyArmor',
+        'setArmor',
+        'addTrait',
+        'takeControl',
+        'takeControlOn',
+        'takeControlOnLeft',
+        'takeControlOnRight',
+        'changeType',
+        'changeHouse',
+        'addHouse',
+        'addTrait',
+        'flipToken',
+        'copyCard',
+        'blank'
+    ],
+
     // Card effects
     actionCardLocationAfterPlay: (location) =>
         EffectBuilder.card.static('actionCardLocationAfterPlay', location),

--- a/test/server/cards/02-AoA/ShadowOfDis.spec.js
+++ b/test/server/cards/02-AoA/ShadowOfDis.spec.js
@@ -92,7 +92,7 @@ describe('Shadow of Dis', function () {
             this.player2.clickPrompt('untamed');
         });
 
-        it("test hideway-hole artifact's elusive still works", function () {
+        it("test hideway-hole artifact's elusive does not work", function () {
             this.player1.moveCard(this.autocannon, 'discard');
             this.player1.clickCard(this.hideawayHole);
             this.player1.clickPrompt("Use this card's Omni ability");
@@ -100,8 +100,8 @@ describe('Shadow of Dis', function () {
             this.player2.clickPrompt('dis');
             this.player2.play(this.shadowOfDis);
             this.player2.fightWith(this.tezmal, this.kindrithLongshot);
-            expect(this.tezmal.hasToken('damage')).toBe(false);
-            expect(this.kindrithLongshot.hasToken('damage')).toBe(false);
+            expect(this.tezmal.location).toBe('discard');
+            expect(this.kindrithLongshot.tokens.damage).toBe(2); // 2 from tezmal ignoring kindrith's elusive
         });
 
         it("should wear off after the opponent's turn", function () {

--- a/test/server/cards/07-GR/FortuneReverser.spec.js
+++ b/test/server/cards/07-GR/FortuneReverser.spec.js
@@ -9,7 +9,7 @@ describe('Fortune Reverser', function () {
                     inPlay: ['the-old-tinker', 'gemcoat-vendor']
                 },
                 player2: {
-                    hand: ['stealth-mode'],
+                    hand: ['stealth-mode', 'ethereal-adaptor'],
                     discard: new Array(9).fill('poke') // not yet haunted
                 }
             });
@@ -31,6 +31,17 @@ describe('Fortune Reverser', function () {
         it('blanks creature with the upgrade', function () {
             this.player1.playUpgrade(this.fortuneReverser, this.theOldTinker);
             this.player1.reap(this.theOldTinker);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('blanks future "this creature gains" upgrades', function () {
+            this.player1.playUpgrade(this.fortuneReverser, this.theOldTinker);
+            this.player1.endTurn();
+            this.player2.clickPrompt('geistoid');
+            this.player2.playUpgrade(this.etherealAdaptor, this.theOldTinker);
+            this.theOldTinker.amber = 10;
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });


### PR DESCRIPTION
Blanking did not previously apply to keywords granted to cards, or effects granted to cards by an unblanked card.  For example, when an upgrade is attached to a blanked creature that grants it a keyword, it should not do anything.

There was a Shadow of Dis test that explicitly was testing for the opposite of what it should be doing.

It is a bit brittle to specify the difference between effects that relate to the text box of a creature, and those that do not (which would not be blanked by other effects), ubt I do my best here with an explicit list of those that should be unblankable.

Closes: #4308