### PR TITLE
AS: fix Barter and Games when there's no opponent

### DIFF
--- a/server/game/cards/08-AS/BarterAndGames.js
+++ b/server/game/cards/08-AS/BarterAndGames.js
@@ -33,7 +33,9 @@ function zoneFromContext(context) {
             : context.player.archives
         : context.select === "Opponent's Hand"
         ? context.player.opponent.hand
-        : context.player.opponent.archives;
+        : context.player.opponent
+        ? context.player.opponent.archives
+        : [];
 }
 
 class BarterAndGames extends Card {


### PR DESCRIPTION
It must somehow run this function even before the context is selected.