### PR TITLE
server: fix imports for decks that contain "Annihilation Ritual"

### DIFF
--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -837,6 +837,16 @@ class DeckService {
                 id += '-evil-twin';
             }
 
+            // These are "fixes" for card IDs in the master vault API
+            // that make it hard to import new decks with those cards.
+            // Use the old ID instead, so we can match it against the
+            // previously-imported cards.  E.g.,
+            // 'annihilation-ritual-' is now just
+            // 'annihilation-ritual'.
+            if (!(id in allCards) && id + '-' in allCards) {
+                id += '-';
+            }
+
             let retCard;
             let count = deckResponse.data._links.cards.filter((uuid) => uuid === card.id).length;
             if (card.is_maverick) {


### PR DESCRIPTION
Looks like someone changed the card ID for the card "Annihilation Ritual".  It used to contain an extra space at the end of the name, leading to an ID of "annihilation-ritual-" in the DB.  Now the cards don't have that extra space, making them unable to match against the old cards.

An alternate fix might be to re-fetch all the card data for CotA, and update all the decks in the DB to use the new name.