### PR TITLE
Lasting effects don't use `cardType`

### DIFF
--- a/server/game/cards/06-WoE/MirrorShell.js
+++ b/server/game/cards/06-WoE/MirrorShell.js
@@ -17,7 +17,6 @@ class MirrorShell extends Card {
                 effect: 'make all friendly token creatures a copy of {0}',
                 gameAction: ability.actions.forRemainderOfTurn((context) => ({
                     controller: 'self',
-                    cardType: 'creature',
                     match: (card) => card.isToken(),
                     effect: ability.effects.copyCard(context.source)
                 }))

--- a/server/game/cards/06-WoE/PhalanxLeader.js
+++ b/server/game/cards/06-WoE/PhalanxLeader.js
@@ -14,7 +14,6 @@ class PhalanxLeader extends Card {
             reap: true,
             gameAction: ability.actions.forRemainderOfTurn((context) => ({
                 controller: 'self',
-                cardType: 'creature',
                 match: (card) =>
                     context.player.creaturesInPlay.indexOf(card) <
                     context.player.creaturesInPlay.indexOf(context.source),

--- a/server/game/cards/07-GR/TheBodySnatchers.js
+++ b/server/game/cards/07-GR/TheBodySnatchers.js
@@ -10,7 +10,7 @@ class TheBodySnatchers extends Card {
                 "give each enemy creature 'Destroyed: Fully heal this creature and give control of it to your opponent instead' for the remainder of the turn",
             gameAction: ability.actions.forRemainderOfTurn({
                 targetController: 'opponent',
-                cardType: 'creature',
+                match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('destroyed', {
                     effect: 'heal all damage from {0} and give control to {1}',
                     effectArgs: (context) => context.source.controller.opponent,

--- a/test/server/cards/07-GR/TheBodySnatchers.spec.js
+++ b/test/server/cards/07-GR/TheBodySnatchers.spec.js
@@ -4,11 +4,11 @@ describe('The Body Snatchers', function () {
             this.setupTest({
                 player1: {
                     house: 'mars',
-                    hand: ['the-body-snatchers', 'kaboom'],
+                    hand: ['the-body-snatchers', 'kaboom', 'destroy-them-all'],
                     inPlay: ['tunk']
                 },
                 player2: {
-                    inPlay: ['dust-pixie', 'thing-from-the-deep']
+                    inPlay: ['dust-pixie', 'thing-from-the-deep', 'ritual-of-balance']
                 }
             });
         });
@@ -44,6 +44,19 @@ describe('The Body Snatchers', function () {
             this.player2.fightWith(this.dustPixie, this.tunk);
             expect(this.dustPixie.location).toBe('discard');
             expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('only affects creatures', function () {
+            this.player1.play(this.theBodySnatchers);
+            this.player1.play(this.destroyThemAll);
+            this.player1.clickCard(this.ritualOfBalance);
+            this.player1.clickCard(this.thingFromTheDeep);
+            this.player1.clickPrompt('Left');
+            expect(this.thingFromTheDeep.location).toBe('play area');
+            expect(this.thingFromTheDeep.tokens.damage).toBeUndefined();
+            expect(this.player1.player.creaturesInPlay).toContain(this.thingFromTheDeep);
+            expect(this.ritualOfBalance.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });
 });


### PR DESCRIPTION
This fixes a situation where The Body Snatchers can incorrectly take control of non-creatures when they are destroyed.

Closes: #3897