### PR TITLE
Upgrades can stay attached to artifacts

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -971,7 +971,10 @@ class Card extends EffectSource {
         this.persistentEffect({
             condition: properties.condition || (() => true),
             match: (card, context) =>
-                card === this.parent && (!properties.match || properties.match(card, context)),
+                card === this.parent &&
+                (!properties.match || properties.match(card, context)) &&
+                (card.type === 'creature' ||
+                    (this.anyEffect('canAttachToArtifacts') && card.type === 'artifact')),
             targetController: 'any',
             effect: properties.effect
         });
@@ -1144,16 +1147,6 @@ class Card extends EffectSource {
         }
 
         return this.anyEffect('consideredAsFlank') || this.neighbors.length < 2;
-    }
-
-    checkForIllegalAttachments() {
-        if (this.type === 'artifact' && this.upgrades.length > 0) {
-            this.upgrades.forEach((upgrade) => {
-                if (!upgrade.anyEffect('canAttachToArtifacts')) {
-                    upgrade.owner.moveCard(upgrade, 'discard');
-                }
-            });
-        }
     }
 
     isInCenter() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1227,8 +1227,6 @@ class Game extends EventEmitter {
                         this.takeControl(card.getModifiedController(), card, modifiedByPlayer);
                         modifiedControl = true;
                     }
-                    // any upgrades which are illegally attached
-                    card.checkForIllegalAttachments();
                 });
             }
 

--- a/test/server/cards/04-MM/Animator.spec.js
+++ b/test/server/cards/04-MM/Animator.spec.js
@@ -171,9 +171,9 @@ describe('Animator', function () {
                             this.player1.endTurn();
                         });
 
-                        it('should discard the upgrade', function () {
-                            expect(this.discombobulator.location).toBe('discard');
-                            expect(this.discombobulator.controller).toBe(this.player1.player);
+                        it('should keep the upgrade attached', function () {
+                            expect(this.discombobulator.location).toBe('play area');
+                            expect(this.discombobulator.parent).toBe(this.lashOfBrokenDreams);
                         });
                     });
                 });

--- a/test/server/cards/08-AS/DeAnimator.spec.js
+++ b/test/server/cards/08-AS/DeAnimator.spec.js
@@ -5,7 +5,13 @@ describe('De-Animator', function () {
                 player1: {
                     amber: 2,
                     house: 'logos',
-                    hand: ['de-animator', 'de-animator', 'positron-bolt', 'neutron-shark'],
+                    hand: [
+                        'de-animator',
+                        'de-animator',
+                        'positron-bolt',
+                        'neutron-shark',
+                        'rocket-boots'
+                    ],
                     inPlay: ['bot-bookton', 'seismo-entangler']
                 },
                 player2: {
@@ -117,6 +123,15 @@ describe('De-Animator', function () {
             this.player1.clickCard(this.noddyTheThief);
             this.player1.clickCard(this.botBookton);
             expect(this.botBookton.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should keep upgrades on de-animated creatures', function () {
+            this.player1.playUpgrade(this.rocketBoots, this.botBookton);
+            this.player1.playCreature(this.deAnimator);
+            this.player1.clickCard(this.botBookton);
+            expect(this.rocketBoots.location).toBe('play area');
+            expect(this.rocketBoots.parent).toBe(this.botBookton);
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });


### PR DESCRIPTION
Per the rulebook, upgrades stay attached until the card leaves play, even if a creature changes type to an artifact.

However, upgrades that cause a creature to gain an effect while attached do not affect artifacts.

Closes: #4403