### PR TITLE
Allow house choice for all houses of cards in play

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -686,15 +686,22 @@ class Player extends GameObject {
 
     getAvailableHouses() {
         let availableHouses = this.hand.concat(this.cardsInPlay).reduce((houses, card) => {
-            let cardHouse = (card.isToken() && card.tokenCard() ? card.tokenCard() : card)
-                .printedHouse;
+            let cardForHouses = card.isToken() && card.tokenCard() ? card.tokenCard() : card;
+
+            // Only cards in play can use their house enhancements to control what houses are available.
+            let cardHouses =
+                cardForHouses.location === 'play area'
+                    ? cardForHouses.getHouses()
+                    : [cardForHouses.printedHouse];
 
             if (card.anyEffect('changeHouse')) {
-                cardHouse = card.getEffects('changeHouse');
+                cardHouses = card.getEffects('changeHouse');
             }
 
-            if (!houses.includes(cardHouse)) {
-                return houses.concat(cardHouse);
+            for (let house of cardHouses) {
+                if (!houses.includes(house)) {
+                    houses.push(house);
+                }
             }
 
             return houses;

--- a/test/server/houseenhancements.spec.js
+++ b/test/server/houseenhancements.spec.js
@@ -54,5 +54,12 @@ describe('house enhancements', function () {
             expect(this.cpoZytar.location).toBe('discard');
             expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
         });
+
+        it('can call house from enhancement even if not in deck houses', function () {
+            this.cpoZytar.enhancements = ['saurian'];
+            this.player1.endTurn();
+            this.player2.clickPrompt('saurian');
+            expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
     });
 });


### PR DESCRIPTION
If a card in play has a house enhancement on it that is not one of the three houses in the deck, TCO doesn't currently allow you to choose that house.  Not sure why anyone would want this but apparently it's an alliance edge case.