### PR TITLE
server: allow ordering a make token action even if deck is empty

### DIFF
--- a/server/game/GameActions/CardGameAction.js
+++ b/server/game/GameActions/CardGameAction.js
@@ -24,6 +24,11 @@ class CardGameAction extends GameAction {
             );
         }
 
+        // If no legal targets but we could get targets when other actions are in the same window, allow it for simultaneous ability ordering
+        if (!result && this.targetsCanChangeViaSimultaneousAction(context)) {
+            return true;
+        }
+
         return result;
     }
 
@@ -119,6 +124,11 @@ class CardGameAction extends GameAction {
             this.canAffect(event.card, event.context) &&
             event.card.checkRestrictions(this.name, event.context, event)
         );
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    targetsCanChangeViaSimultaneousAction(context) {
+        return false;
     }
 }
 

--- a/server/game/GameActions/MakeTokenCreatureAction.js
+++ b/server/game/GameActions/MakeTokenCreatureAction.js
@@ -28,6 +28,17 @@ class MakeTokenCreatureAction extends CardGameAction {
         return player && player.tokenCard && super.canAffect(card, context);
     }
 
+    targetsCanChangeViaSimultaneousAction(context) {
+        const player = this.targetPlayer(context);
+        if (!player) {
+            return false;
+        }
+
+        // If any simultaneous action makes us refill the deck (e.g., via shuffling the discard pile),
+        // we need to allow the player to choose which ability to use first.
+        return true;
+    }
+
     getEvent(card, context) {
         return super.createEvent(
             'onMakeToken',

--- a/test/server/cards/06-WoE/FOFTransponder.spec.js
+++ b/test/server/cards/06-WoE/FOFTransponder.spec.js
@@ -76,4 +76,58 @@ describe('FOF Transponder', function () {
             expect(this.player1.player.creaturesInPlay.length).toBe(0);
         });
     });
+
+    describe('FOF Transponder with prospector', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 1,
+                    token: 'prospector',
+                    house: 'staralliance',
+                    inPlay: ['prospector:helmsman-spears'],
+                    hand: ['fof-transponder', 'particle-sweep'],
+                    discard: ['sensor-chief-garcia', 'cxo-taber']
+                },
+                player2: {
+                    inPlay: ['bumpsy']
+                }
+            });
+
+            this.helmsmanSpears = this.player1.player.creaturesInPlay[0];
+        });
+
+        it('should allow you to draw before making a token on an empty deck', function () {
+            this.player1.player.deck = [];
+            this.player1.playUpgrade(this.fofTransponder, this.helmsmanSpears);
+            this.player1.play(this.particleSweep);
+            this.player1.clickCard(this.helmsmanSpears);
+            this.player1.clickPrompt('Prospector');
+            expect(this.player1.player.deck.length).toBe(1);
+            this.player1.clickPrompt('Right');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should allow you to try to make a token on an empty deck before drawing', function () {
+            this.player1.player.deck = [];
+            this.player1.playUpgrade(this.fofTransponder, this.helmsmanSpears);
+            this.player1.play(this.particleSweep);
+            this.player1.clickCard(this.helmsmanSpears);
+            this.player1.clickPrompt('FOF Transponder');
+            expect(this.player1.player.creaturesInPlay.length).toBe(0);
+            expect(this.helmsmanSpears.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should allow you to order even if no token can be made', function () {
+            this.player1.player.deck = [];
+            this.player1.player.discard = [];
+            this.player1.playUpgrade(this.fofTransponder, this.helmsmanSpears);
+            this.player1.play(this.particleSweep);
+            this.player1.clickCard(this.helmsmanSpears);
+            this.player1.clickPrompt('FOF Transponder');
+            expect(this.player1.player.creaturesInPlay.length).toBe(0);
+            expect(this.helmsmanSpears.location).toBe('discard');
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+    });
 });

--- a/test/server/tokens.spec.js
+++ b/test/server/tokens.spec.js
@@ -28,6 +28,13 @@ describe('Token', function () {
             this.player1.clickPrompt('Left');
         });
 
+        it('should make no token if the deck is empty', function () {
+            this.player1.player.deck = [];
+            this.player1.play(this.hireOn);
+            expect(this.player1.player.creaturesInPlay.length).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
+        });
+
         it('should lose token abilities after destroyed', function () {
             let token = this.antiquitiesDealer;
             this.player1.moveCard(token, 'deck');


### PR DESCRIPTION
For some actions, their targets can change as a result of another simultaneous action.  Allow that to happen specifically for making a token creature with an empty deck.  There may be other actions that need this in the future, but the general solution is too onerous (it would require ordering assault vs hazardous for every fight, even when those values are 0).