### PR TITLE
PV: fix Parallel Thinking log messages

### DIFF
--- a/server/game/GameActions/ChosenDiscardAction.js
+++ b/server/game/GameActions/ChosenDiscardAction.js
@@ -40,7 +40,9 @@ class ChosenDiscardAction extends PlayerAction {
                         controller: player === context.player ? 'self' : 'opponent',
                         onSelect: (player, cards) => {
                             context.game.addMessage('{0} discards {1}', player, cards);
-                            context.game.actions.discard().resolve(cards, context);
+                            context.game.actions
+                                .discard({ chatMessage: false })
+                                .resolve(cards, context);
                             return true;
                         }
                     });

--- a/server/game/GameActions/DeactivateProphecyAction.js
+++ b/server/game/GameActions/DeactivateProphecyAction.js
@@ -31,7 +31,7 @@ class DeactivateProphecyAction extends PlayerAction {
             // Discard any cards under the prophecy
             if (this.prophecyCard.childCards && this.prophecyCard.childCards.length > 0) {
                 let childCard = this.prophecyCard.childCards[0];
-                context.game.actions.discard().resolve(childCard, context);
+                context.game.actions.discard({ chatMessage: false }).resolve(childCard, context);
             }
 
             // Deactivate the prophecy

--- a/server/game/GameActions/DiscardCardAction.js
+++ b/server/game/GameActions/DiscardCardAction.js
@@ -6,6 +6,10 @@ class DiscardCardAction extends CardGameAction {
         this.cost = 'discarding {0}';
     }
 
+    setDefaultProperties() {
+        this.chatMessage = true;
+    }
+
     getEvent(card, context) {
         let location = card.location;
         return super.createEvent('onCardDiscarded', { card, context, location }, () => {
@@ -18,7 +22,14 @@ class DiscardCardAction extends CardGameAction {
     }
 
     getEventArray(context) {
-        if (this.target && this.target.length > 0) {
+        if (!this.target || this.target.length === 0) {
+            return [];
+        }
+
+        const events = this.target
+            .filter((target) => this.canAffect(target, context))
+            .map((card) => this.getEvent(card, context));
+        if (events.length > 0 && this.chatMessage) {
             context.game.addMessage(
                 '{0} uses {1} to discard {2}',
                 context.player,
@@ -26,7 +37,7 @@ class DiscardCardAction extends CardGameAction {
                 this.target
             );
         }
-        return this.target.map((card) => this.getEvent(card, context));
+        return events;
     }
 }
 

--- a/server/game/GameActions/DiscardCardAction.js
+++ b/server/game/GameActions/DiscardCardAction.js
@@ -3,8 +3,6 @@ const CardGameAction = require('./CardGameAction');
 class DiscardCardAction extends CardGameAction {
     setup() {
         super.setup();
-        this.name = 'discard';
-        this.effectMsg = 'discard {0}';
         this.cost = 'discarding {0}';
     }
 
@@ -17,6 +15,18 @@ class DiscardCardAction extends CardGameAction {
 
             card.owner.moveCard(card, 'discard');
         });
+    }
+
+    getEventArray(context) {
+        if (this.target && this.target.length > 0) {
+            context.game.addMessage(
+                '{0} uses {1} to discard {2}',
+                context.player,
+                context.source,
+                this.target
+            );
+        }
+        return this.target.map((card) => this.getEvent(card, context));
     }
 }
 

--- a/server/game/GameActions/DiscardTopOfDeckAction.js
+++ b/server/game/GameActions/DiscardTopOfDeckAction.js
@@ -22,7 +22,7 @@ class DiscardTopOfDeckAction extends PlayerAction {
         let amount = Math.min(this.amount, player.deck.length);
         return super.createEvent('unnamedEvent', { player, context, amount }, (event) => {
             let cards = player.deck.slice(0, event.amount);
-            context.game.actions.discard().resolve(cards, context);
+            context.game.actions.discard({ chatMessage: false }).resolve(cards, context);
         });
     }
 }

--- a/server/game/GameActions/RandomDiscardAction.js
+++ b/server/game/GameActions/RandomDiscardAction.js
@@ -41,7 +41,7 @@ class RandomDiscardAction extends PlayerAction {
             (event) => {
                 event.cards = _.shuffle(this.getCards(player)).slice(0, event.amount);
                 context.game.addMessage('{0} discards {1} at random', player, event.cards);
-                context.game.actions.discard().resolve(event.cards, context);
+                context.game.actions.discard({ chatMessage: false }).resolve(event.cards, context);
             }
         );
     }

--- a/server/game/GameActions/ResolveBonusIconsAction.js
+++ b/server/game/GameActions/ResolveBonusIconsAction.js
@@ -100,7 +100,7 @@ class ResolveBonusIconsAction extends CardGameAction {
                         controller: 'self',
                         onSelect: (player, card) => {
                             context.game.actions
-                                .discard()
+                                .discard({ chatMessage: false })
                                 .resolve(card, context.game.getFrameworkContext(player));
                             context.game.addMessage(
                                 "{0} discards {1} due to {2}'s bonus icon",

--- a/server/game/GameActions/SearchAction.js
+++ b/server/game/GameActions/SearchAction.js
@@ -98,7 +98,9 @@ class SearchAction extends PlayerAction {
                             for (let card of cards) {
                                 switch (this.destination) {
                                     case 'discard':
-                                        context.game.actions.discard().resolve(card, context);
+                                        context.game.actions
+                                            .discard({ chatMessage: false })
+                                            .resolve(card, context);
                                         break;
                                     case 'archives':
                                         context.game.actions.archive().resolve(card, context);

--- a/server/game/cards/12-PV/ParallelThinking.js
+++ b/server/game/cards/12-PV/ParallelThinking.js
@@ -39,7 +39,7 @@ class ParallelThinking extends Card {
                     );
                 },
                 gameAction: ability.actions.steal({ amount: 2 }),
-                message: '{0} uses {1} to steal 2 amber from {2}',
+                message: '{0} uses {1} to steal 2 amber from {3}',
                 messageArgs: (context) => context.player.opponent
             }
         });


### PR DESCRIPTION
Random discards shouldn't print message until target is fully set in stone.

Fixes: #4556