### PR TITLE
server: onCardPlaced events should track clone as the original card

### DIFF
--- a/server/game/Events/Event.js
+++ b/server/game/Events/Event.js
@@ -15,10 +15,11 @@ class Event {
         this.childEvent = null;
         this.subEvent = null;
         this.openReactionWindow = true;
+        this.clone = null;
 
         _.extend(this, params);
-
-        if (this.card) {
+        this.clone = this.cloneOverride;
+        if (this.card && !this.clone) {
             this.clone = this.card.createSnapshot();
         }
     }
@@ -94,7 +95,7 @@ class Event {
             return;
         }
 
-        if (this.card) {
+        if (this.card && !this.cloneOverride) {
             this.clone = this.card.createSnapshot();
         }
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -484,6 +484,8 @@ class Player extends GameObject {
      * @param {Object} options
      */
     moveCard(card, targetLocation, options = {}) {
+        let origCard = card.createSnapshot();
+
         if (targetLocation.endsWith(' bottom')) {
             options.bottom = true;
             targetLocation = targetLocation.replace(' bottom', '');
@@ -574,6 +576,9 @@ class Player extends GameObject {
 
         this.game.raiseEvent('onCardPlaced', {
             card: card,
+            // Remember the card as it was originally (e.g.,
+            // tokens that have left play need to be remembered as tokens).
+            cloneOverride: origCard,
             from: location,
             to: targetLocation,
             drawn: options.drawn

--- a/test/server/cards/01-Core/AnnihilationRitual.spec.js
+++ b/test/server/cards/01-Core/AnnihilationRitual.spec.js
@@ -13,7 +13,7 @@ describe('Annihilation Ritual', function () {
                         'mighty-tiger',
                         'snufflegator',
                         'inka-the-spider',
-                        'grumpus:flaxia',
+                        'grumpus:lost-in-the-woods',
                         'brammo'
                     ],
                     hand: ['niffle-kong', 'niffle-kong2', 'ancient-bear']

--- a/test/server/cards/05-DT/Bombyx.spec.js
+++ b/test/server/cards/05-DT/Bombyx.spec.js
@@ -24,7 +24,6 @@ describe('Bombyx', function () {
         });
 
         it('should be destroyed if played when there are no ceatures', function () {
-            this.player1.moveCard(this.flaxia, 'discard');
             this.player1.play(this.bombyx);
             this.player1.endTurn();
             expect(this.bombyx.location).toBe('discard');

--- a/test/server/cards/05-DT/KaupeEvilTwin.spec.js
+++ b/test/server/cards/05-DT/KaupeEvilTwin.spec.js
@@ -161,7 +161,6 @@ describe('Kaupe Evil Twin', function () {
         });
 
         it('should be able to discard even when no enemy creatures are in play', function () {
-            this.player2.moveCard(this.lamindra, 'discard');
             this.player2.moveCard(this.gladiodontus, 'discard');
             this.player2.moveCard(this.troll, 'discard');
             this.player1.reap(this.kaupeEvilTwin);

--- a/test/server/cards/12-PV/GeneticStrain.spec.js
+++ b/test/server/cards/12-PV/GeneticStrain.spec.js
@@ -45,7 +45,6 @@ describe('Genetic Strain', function () {
 
         it('should not make opponent gain amber when fate is triggered if they have no Mutants', function () {
             this.player1.moveCard(this.citizenShrix, 'discard');
-            this.player1.moveCard(this.bordanTheRedeemed, 'discard');
             this.player1.activateProphecy(this.overreach, this.geneticStrain);
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');


### PR DESCRIPTION
Otherwise tokens that have gone through `onLeavesPlay` will already not be tokens, and thus not be purged by Annihilation Ritual.

Closes: #4577