### PR TITLE
Fix discard selector -- 'self' might not be active player

### DIFF
--- a/server/game/GameActions/DiscardCardAction.js
+++ b/server/game/GameActions/DiscardCardAction.js
@@ -56,7 +56,6 @@ class DiscardCardAction extends CardGameAction {
             context.game.promptForSelect(activePlayer, {
                 activePromptTitle: 'Select next card to discard',
                 context: context,
-                controller: 'self',
                 location: 'hand',
                 cardCondition: (card) => this._remainingDiscardCards.includes(card),
                 onSelect: (player, card) => {


### PR DESCRIPTION
If the discards are caused by a fate, then 'self' is not the active player.

Fixes: #4601