### PR TITLE
fix: set up clone before action resolves

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -86,7 +86,6 @@ class CardAction extends CardAbility {
     }
 
     executeHandler(context) {
-        super.executeHandler(context);
         if (!this.reap && !this.fight) {
             context.game.raiseEvent(
                 'onUseCard',
@@ -94,6 +93,7 @@ class CardAction extends CardAbility {
                 () => {}
             );
         }
+        super.executeHandler(context);
     }
 
     isAction() {

--- a/server/game/cards/06-WoE/FriendlyGuide.js
+++ b/server/game/cards/06-WoE/FriendlyGuide.js
@@ -8,8 +8,7 @@ class FriendlyGuide extends Card {
             when: {
                 onUseCard: (event, context) =>
                     context.game.activePlayer === context.source.controller &&
-                    !!event.clone &&
-                    event.clone.neighbors.includes(context.source)
+                    event.clone?.clonedNeighbors.includes(context.source)
             },
             optional: true,
             gameAction: ability.actions.use()

--- a/test/server/cards/03-WC/NogiSmartfist.spec.js
+++ b/test/server/cards/03-WC/NogiSmartfist.spec.js
@@ -16,9 +16,6 @@ describe('Nogi Smartfist', function () {
         it('should draw 2 cards and discard 2 cards when fight', function () {
             this.player1.fightWith(this.nogiSmartfist, this.duskwitch);
             expect(this.player1.player.discard.length).toBe(2);
-            console.log(this.player1.player.discard.map((c) => c.name));
-            console.log(this.player1.player.hand.map((c) => c.name));
-            console.log(this.player1.player.deck.map((c) => c.name));
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
     });

--- a/test/server/cards/06-WoE/FriendlyGuide.spec.js
+++ b/test/server/cards/06-WoE/FriendlyGuide.spec.js
@@ -4,7 +4,13 @@ describe('Friendly Guide', function () {
             this.setupTest({
                 player1: {
                     house: 'untamed',
-                    inPlay: ['niffle-ape', 'friendly-guide', 'dark-faerie', 'rustgnawer']
+                    inPlay: [
+                        'niffle-ape',
+                        'friendly-guide',
+                        'dark-faerie',
+                        'rustgnawer',
+                        'guji-dinosaur-hunter'
+                    ]
                 },
                 player2: {
                     inPlay: ['dextre', 'hunting-witch', 'shĭzyokŭ-swopper']
@@ -45,6 +51,22 @@ describe('Friendly Guide', function () {
             this.player2.clickPrompt('ekwidon');
             this.player2.fightWith(this.shĭzyokŭSwopper, this.niffleApe);
             expect(this.player2).toHavePrompt('Choose a card to play, discard or use');
+        });
+
+        it('should allow use on action ability that removes from play', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('ekwidon');
+            this.player2.endTurn();
+            this.player1.clickPrompt('brobnar');
+            this.player1.fightWith(this.gujiDinosaurHunter, this.huntingWitch);
+            this.player1.moveCard(this.darkFaerie, 'discard');
+            this.player1.moveCard(this.rustgnawer, 'discard');
+            this.gujiDinosaurHunter.ready();
+            this.player1.useAction(this.gujiDinosaurHunter);
+            this.player1.clickCard(this.gujiDinosaurHunter);
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            this.player1.clickCard(this.friendlyGuide);
+            this.player1.clickPrompt('Reap with this creature');
         });
     });
 });


### PR DESCRIPTION
Fixes #4421 - using copilot we found that for action abilities the cloning process was happening after the ability resolves, whereas for fight/reap its before. Moved the clone to happen first.