### PR TITLE
fix: Too Low not selecting lowest power creature

### DIFF
--- a/server/game/cards/12-PV/TooLow.js
+++ b/server/game/cards/12-PV/TooLow.js
@@ -7,24 +7,44 @@ class TooLow extends Card {
         this.play({
             target: {
                 cardType: 'creature',
-                controller: 'opponent',
-                gameAction: ability.actions.destroy((context) => ({
-                    target: context.game.creaturesInPlay.filter(
-                        (card) => card.power < context.target.power
-                    )
-                }))
+                controller: 'opponent'
             },
-            effect: "destroy each creature with power less than {0}'s power"
+            gameAction: ability.actions.destroy((context) => ({
+                target: context.game.creaturesInPlay.filter((card) =>
+                    Object.values(context.targets).some((target) => card.power < target.power)
+                )
+            })),
+            effect: 'destroy each creature with power less than {0}: {1}',
+            effectArgs: (context) => [
+                context.game.creaturesInPlay.filter((card) =>
+                    Object.values(context.targets).some((target) => card.power < target.power)
+                )
+            ]
         });
 
         this.fate({
-            effect: 'destroy each friendly creature with the lowest power',
+            effect: 'destroy each friendly creature with the lowest power: {1}',
+            effectArgs: (context) => {
+                if (context.game.activePlayer.creaturesInPlay.length === 0) {
+                    return [];
+                }
+
+                const lowestPower = context.game.activePlayer.creaturesInPlay.sort(
+                    (a, b) => a.power - b.power
+                )[0].power;
+
+                return [
+                    context.game.activePlayer.creaturesInPlay.filter(
+                        (card) => card.power === lowestPower
+                    )
+                ];
+            },
             gameAction: ability.actions.destroy((context) => {
                 if (context.game.activePlayer.creaturesInPlay.length === 0) {
                     return { target: [] };
                 }
 
-                let lowestPower = context.game.activePlayer.creaturesInPlay.sort(
+                const lowestPower = context.game.activePlayer.creaturesInPlay.sort(
                     (a, b) => a.power - b.power
                 )[0].power;
 

--- a/test/server/cards/12-PV/TooLow.spec.js
+++ b/test/server/cards/12-PV/TooLow.spec.js
@@ -24,7 +24,7 @@ describe('Too Low', function () {
         it('should destroy creatures with power less than the chosen creature', function () {
             this.player1.play(this.tooLow);
             expect(this.player1).toBeAbleToSelect(this.krump);
-            expect(this.player1).not.toBeAbleToSelect(this.dustPixie);
+            expect(this.player1).toBeAbleToSelect(this.dustPixie);
             expect(this.player1).not.toBeAbleToSelect(this.urchin);
             expect(this.player1).not.toBeAbleToSelect(this.huntingWitch);
             expect(this.player1).not.toBeAbleToSelect(this.tantadlin);


### PR DESCRIPTION
fix: Too Low not selecting lowest power creature - fixes #4591 