### PR TITLE
Log message updates 3

### DIFF
--- a/server/game/cards/03-WC/CityStateInterest.js
+++ b/server/game/cards/03-WC/CityStateInterest.js
@@ -7,7 +7,7 @@ class CityStateInterest extends Card {
             gameAction: ability.actions.capture((context) => ({
                 target: context.player.creaturesInPlay
             })),
-            effect: 'to capture 1 amber onto each friendly creature',
+            preferActionPromptMessage: true,
             then: {
                 alwaysTriggers: true,
                 message: '{0} uses {1} to capture 1 amber onto {3}',

--- a/server/game/cards/03-WC/CityStateInterest.js
+++ b/server/game/cards/03-WC/CityStateInterest.js
@@ -7,7 +7,16 @@ class CityStateInterest extends Card {
             gameAction: ability.actions.capture((context) => ({
                 target: context.player.creaturesInPlay
             })),
-            effect: 'make each friendly creature capture 1 amber'
+            effect: 'to capture 1 amber onto each friendly creature',
+            then: {
+                alwaysTriggers: true,
+                message: '{0} uses {1} to capture 1 amber onto {3}',
+                messageArgs: (context) => [
+                    context.preThenEvents
+                        .filter((event) => !event.cancelled && event.card)
+                        .map((event) => event.card)
+                ]
+            }
         });
     }
 }

--- a/server/game/cards/04-MM/AutoVac5150.js
+++ b/server/game/cards/04-MM/AutoVac5150.js
@@ -21,7 +21,16 @@ class AutoVac5150 extends Card {
                     ]),
                     falseGameAction: ability.actions.archive()
                 })
-            }
+            },
+            message: '{0} uses {1} to {2}',
+            messageArgs: (context) => [
+                context.player,
+                context.source,
+                context.target
+                    ? "raise key cost by 3 during their opponent's next turn"
+                    : 'archive a card',
+                'y'
+            ]
         });
     }
 }

--- a/server/game/cards/04-MM/CurseOfVanity.js
+++ b/server/game/cards/04-MM/CurseOfVanity.js
@@ -19,7 +19,9 @@ class CurseOfVanity extends Card {
                     controller: 'opponent',
                     gameAction: ability.actions.exalt()
                 }
-            }
+            },
+            effect: 'exalt {1}',
+            effectArgs: (context) => [Object.values(context.targets)]
         });
     }
 }

--- a/server/game/cards/04-MM/Deusillus.js
+++ b/server/game/cards/04-MM/Deusillus.js
@@ -23,8 +23,15 @@ class Deusillus extends GiganticCard {
                         activePromptTitle: 'Choose a creature',
                         cardType: 'creature',
                         controller: 'opponent',
-                        message: '{0} uses {1} to capture all amber and deal 5 damage to {2}',
-                        messageArgs: (card) => [context.player, context.source, card]
+                        message:
+                            '{0} uses {1} to capture all {2} amber from {3} and deal 5 damage to {4}',
+                        messageArgs: (card) => [
+                            context.player,
+                            context.source,
+                            context.player.opponent ? context.player.opponent.amber : 0,
+                            context.player.opponent,
+                            card
+                        ]
                     }
                 }))
             ])
@@ -32,7 +39,14 @@ class Deusillus extends GiganticCard {
 
         this.fight({
             reap: true,
-            effect: 'remove 1 amber from {0} and deal 2 damage to all enemy creatures',
+            message:
+                "{0} uses {1} to remove {2} amber from {1} and deal 2 damage to all of {3}'s creatures",
+            messageArgs: (context) => [
+                context.player,
+                context.source,
+                Math.min(1, context.source.amber),
+                context.player.opponent
+            ],
             gameAction: ability.actions.sequential([
                 ability.actions.removeAmber(),
                 ability.actions.dealDamage((context) => ({

--- a/server/game/cards/04-MM/Deusillus.js
+++ b/server/game/cards/04-MM/Deusillus.js
@@ -9,14 +9,18 @@ class Deusillus extends GiganticCard {
     }
 
     setupCardAbilities(ability) {
+        this.oppAmber = 0;
         super.setupCardAbilities(ability);
 
         this.play({
             preferActionPromptMessage: true,
             gameAction: ability.actions.sequential([
-                ability.actions.capture((context) => ({
-                    amount: context.player.opponent ? context.player.opponent.amber : 0
-                })),
+                ability.actions.capture((context) => {
+                    this.oppAmber = context.player.opponent ? context.player.opponent.amber : 0;
+                    return {
+                        amount: this.oppAmber
+                    };
+                }),
                 ability.actions.dealDamage((context) => ({
                     amount: 5,
                     promptForSelect: {
@@ -28,7 +32,7 @@ class Deusillus extends GiganticCard {
                         messageArgs: (card) => [
                             context.player,
                             context.source,
-                            context.source.tokens.amber,
+                            this.oppAmber,
                             context.player.opponent,
                             card
                         ]

--- a/server/game/cards/04-MM/Deusillus.js
+++ b/server/game/cards/04-MM/Deusillus.js
@@ -28,7 +28,7 @@ class Deusillus extends GiganticCard {
                         messageArgs: (card) => [
                             context.player,
                             context.source,
-                            context.player.opponent ? context.player.opponent.amber : 0,
+                            context.source.tokens.amber,
                             context.player.opponent,
                             card
                         ]

--- a/server/game/cards/04-MM/Humble.js
+++ b/server/game/cards/04-MM/Humble.js
@@ -4,7 +4,8 @@ class Humble extends Card {
     // Play: Exhaust a creature. If you do, move 3 from that creature to the common supply.
     setupCardAbilities(ability) {
         this.play({
-            effect: 'exhaust {0} and move 3 amber from it to common supply',
+            effect: 'to exhaust {0} and move {1} amber from {0} to common supply',
+            effectArgs: (context) => [context.target.tokens.amber || 0],
             target: {
                 controller: 'any',
                 cardType: 'creature',

--- a/server/game/cards/04-MM/VaultsBlessing.js
+++ b/server/game/cards/04-MM/VaultsBlessing.js
@@ -4,7 +4,24 @@ class VaultsBlessing extends Card {
     // Play: Each player gains 1A for each Mutant creature they control.
     setupCardAbilities(ability) {
         this.play({
-            effect: 'give each player 1A for each mutant creature they control',
+            effect:
+                'have each player gain 1 amber for each mutant creature they control, {1} gains a total of {2} amber ({3}) and {4} gains a total of {5} amber ({6})',
+            effectArgs: (context) => [
+                context.player,
+                context.player.creaturesInPlay.filter((card) => card.hasTrait('mutant')).length,
+                context.player.creaturesInPlay.filter((card) => card.hasTrait('mutant')),
+                context.player.opponent,
+                context.player.opponent
+                    ? context.player.opponent.creaturesInPlay.filter((card) =>
+                          card.hasTrait('mutant')
+                      ).length
+                    : 0,
+                context.player.opponent
+                    ? context.player.opponent.creaturesInPlay.filter((card) =>
+                          card.hasTrait('mutant')
+                      )
+                    : []
+            ],
             gameAction: [
                 ability.actions.gainAmber((context) => ({
                     amount: context.player.creaturesInPlay.filter((card) => card.hasTrait('mutant'))

--- a/server/game/cards/06-WoE/CovetousHema.js
+++ b/server/game/cards/06-WoE/CovetousHema.js
@@ -9,7 +9,14 @@ class CovetousHema extends Card {
             effect: ability.effects.addKeyword({ elusive: 1 })
         });
         this.play({
-            gameAction: ability.actions.capture({ amount: 3 })
+            gameAction: ability.actions.capture({ amount: 3 }),
+            message: '{0} uses {1} to capture {2} amber from {3}, placing it on {1}',
+            messageArgs: (context) => [
+                context.player,
+                context.source,
+                Math.min(3, context.player.opponent ? context.player.opponent.amber : 0),
+                context.player.opponent
+            ]
         });
     }
 }

--- a/server/game/cards/06-WoE/CovetousHema.js
+++ b/server/game/cards/06-WoE/CovetousHema.js
@@ -10,7 +10,7 @@ class CovetousHema extends Card {
         });
         this.play({
             gameAction: ability.actions.capture({ amount: 3 }),
-            message: '{0} uses {1} to capture {2} amber from {3}, placing it on {1}',
+            message: '{0} uses {1} to capture {2} amber from {3}',
             messageArgs: (context) => [
                 context.player,
                 context.source,

--- a/server/game/cards/07-GR/MemorializeTheFallen.js
+++ b/server/game/cards/07-GR/MemorializeTheFallen.js
@@ -5,18 +5,25 @@ class MemorializeTheFallen extends Card {
     // their discard pile.
     setupCardAbilities(ability) {
         this.play({
-            effect:
-                'each player loses amber equal to the number of creatures in their discard pile',
+            effect: 'make {1} lose {2} amber and {3} lose {4} amber',
+            effectArgs: (context) => [
+                context.player,
+                context.player.discard.filter((c) => c.type === 'creature').length,
+                context.player.opponent,
+                context.player.opponent
+                    ? context.player.opponent.discard.filter((c) => c.type === 'creature').length
+                    : 0
+            ],
             gameAction: [
+                ability.actions.loseAmber((context) => ({
+                    target: context.player,
+                    amount: context.player.discard.filter((c) => c.type === 'creature').length
+                })),
                 ability.actions.loseAmber((context) => ({
                     amount: context.player.opponent
                         ? context.player.opponent.discard.filter((c) => c.type === 'creature')
                               .length
                         : 0
-                })),
-                ability.actions.loseAmber((context) => ({
-                    target: context.player,
-                    amount: context.player.discard.filter((c) => c.type === 'creature').length
                 }))
             ]
         });

--- a/server/game/cards/07-GR/TriangulatorNewsome.js
+++ b/server/game/cards/07-GR/TriangulatorNewsome.js
@@ -6,8 +6,12 @@ class TriangulatorNewsome extends Card {
     setupCardAbilities(ability) {
         this.reap({
             condition: (context) => context.player.isHaunted(),
-            effect: "move each amber from {0}'s neighbors creatures to their pool",
-            effectArgs: (context) => [context.source],
+            effect: "move all {2} amber from {0}'s neighbors to their pool: {3}",
+            effectArgs: (context) => [
+                context.source,
+                context.source.neighbors.reduce((total, card) => total + card.amber, 0),
+                context.source.neighbors
+            ],
             gameAction: [
                 ability.actions.removeAmber((context) => ({
                     all: true,

--- a/server/game/cards/07-GR/TriangulatorNewsome.js
+++ b/server/game/cards/07-GR/TriangulatorNewsome.js
@@ -6,7 +6,7 @@ class TriangulatorNewsome extends Card {
     setupCardAbilities(ability) {
         this.reap({
             condition: (context) => context.player.isHaunted(),
-            effect: "move all {2} amber from {0}'s neighbors to their pool: {3}",
+            effect: "move all {2} amber from {0}'s neighbors ({3}) to their pool",
             effectArgs: (context) => [
                 context.source,
                 context.source.neighbors.reduce((total, card) => total + card.amber, 0),

--- a/server/game/cards/12-PV/UnityPrism.js
+++ b/server/game/cards/12-PV/UnityPrism.js
@@ -10,10 +10,10 @@ class UnityPrism extends Card {
             effect: 'allow playing up to 4 cards from any house this turn',
             gameAction: ability.actions.forRemainderOfTurn({
                 effect: [
-                    ability.effects.canPlay((card, context) => {
+                    ability.effects.canPlay((context) => {
                         return context.game.cardsPlayedThisPhase.length < 4;
                     }),
-                    ability.effects.playerCannot('play', (card, context) => {
+                    ability.effects.playerCannot('play', (context) => {
                         return context.game.cardsPlayedThisPhase.length >= 4;
                     })
                 ]
@@ -25,7 +25,12 @@ class UnityPrism extends Card {
                 'reveal their hand ({1}) and gain 1 amber for each house represented in it, gaining a total of {2} amber',
             effectArgs: (context) => [
                 context.player.hand,
-                context.game.getHousesInPlay(context.player.hand).length
+                context.player.hand.reduce((houses, card) => {
+                    if (!houses.includes(card.printedHouse)) {
+                        houses.push(card.printedHouse);
+                    }
+                    return houses;
+                }, []).length
             ],
             gameAction: ability.actions.gainAmber((context) => ({
                 amount: context.game.getHousesInPlay(context.player.hand).length

--- a/server/game/cards/12-PV/UnityPrism.js
+++ b/server/game/cards/12-PV/UnityPrism.js
@@ -21,8 +21,12 @@ class UnityPrism extends Card {
         });
 
         this.scrap({
-            effect: 'reveal their hand ({1}) and gain 1 amber for each house represented in it',
-            effectArgs: (context) => [context.player.hand],
+            effect:
+                'reveal their hand ({1}) and gain 1 amber for each house represented in it, gaining a total of {2} amber',
+            effectArgs: (context) => [
+                context.player.hand,
+                context.game.getHousesInPlay(context.player.hand).length
+            ],
             gameAction: ability.actions.gainAmber((context) => ({
                 amount: context.game.getHousesInPlay(context.player.hand).length
             }))

--- a/server/game/cards/12-PV/UnityPrism.js
+++ b/server/game/cards/12-PV/UnityPrism.js
@@ -7,7 +7,7 @@ class UnityPrism extends Card {
     // Scrap: Reveal your hand. Gain 1 amber for each house represented in it.
     setupCardAbilities(ability) {
         this.play({
-            effect: 'allow playing cards from any house and limit to 4 cards this turn',
+            effect: 'allow playing up to 4 cards from any house this turn',
             gameAction: ability.actions.forRemainderOfTurn({
                 effect: [
                     ability.effects.canPlay((card, context) => {

--- a/test/server/cards/04-MM/AutoVac5150.spec.js
+++ b/test/server/cards/04-MM/AutoVac5150.spec.js
@@ -42,7 +42,7 @@ describe('Auto-Vac 5150', function () {
             expect(this.player2.player.amber).toBe(6);
         });
 
-        xit('should not increase opponents key cost on the current turn, allowing them to forge with keyfrog', function () {
+        it('should not increase opponents key cost on the current turn, allowing them to forge with keyfrog', function () {
             this.player1.clickCard(this.autoVac5150);
             this.player1.clickPrompt("Use this card's Action ability");
 
@@ -59,7 +59,7 @@ describe('Auto-Vac 5150', function () {
             this.player1.fightWith(this.dextre, this.keyfrog);
 
             expect(this.player1).toHavePrompt('Forge a Key');
-            expect(this.player1).clickPrompt('Red');
+            this.player1.clickPrompt('Red');
             expect(this.player2.player.getForgedKeys()).toBe(1);
             expect(this.player2.player.amber).toBe(0);
         });


### PR DESCRIPTION
Several log message updates:

- Triangulator Newsom: add total amount and creatures
```
2025-10-01 09:32:14 player1 uses Triangulator Newsome to reap with Triangulator Newsome
2025-10-01 09:32:14 player1 uses Triangulator Newsome to move all 5 amber from Triangulator Newsome's neighbors to their pool: Medic Ingram and CPO Zytar
```

- Unity Prism: add total amber and reword play
```
2025-10-01 09:35:40 player1 discards Unity Prism
2025-10-01 09:35:40 player1 uses Unity Prism to reveal their hand (Ember Imp, Ancient Bear, Poke, Draining Touch, and Batdrone) and gain 1 amber for each house represented in it, gaining a total of 3 amber
```

- Vault's Blessing: add total amber and creatures
```
2025-10-01 09:45:35 player1 plays Vault’s Blessing
2025-10-01 09:45:35 player1 gains an amber due to Vault’s Blessing's bonus icon
2025-10-01 09:45:35 player1 uses Vault’s Blessing to have each player gain 1 amber for each mutant creature they control, player1 gains a total of 4 amber (Chonkers, Chronus, Hapsis, and Dysania) and player2 gains a total of 0 amber ()
```

- Auto-Vac 5150 - add key cost or archive
```
2025-10-01 10:27:05 player2 uses Remote Access to use Auto-Vac 5150
2025-10-01 10:27:05 player2 uses Auto-Vac 5150 to raise key cost by 3

2025-10-01 10:27:05 player1 uses Auto-Vac 5150 to archive a card
```

- Covetous Hema - add amount captured
```
2025-10-01 17:42:47 player1 plays Covetous Hema
2025-10-01 17:42:47 player1 uses Covetous Hema to capture 2 amber from player2, placing it on Covetous Hema
```

- Curse of Vanity - add both creatures exalted
```
2025-10-01 17:50:36 player1 plays Curse of Vanity
2025-10-01 17:50:36 player1 gains an amber due to Curse of Vanity's bonus icon
2025-10-01 17:50:36 player1 uses Curse of Vanity to exalt Gub and Troll
```

- City-State Interest - add creatures capturing
```
2025-10-01 18:30:46 player1 plays City-State Interest
2025-10-01 18:30:46 player1 uses City-State Interest to to capture 1 amber onto each friendly creature
2025-10-01 18:30:46 player1 uses City-State Interest to capture 1 amber onto Troll and Valdr
```

- Deusillus - add amount captured and removed
```
2025-10-01 19:23:03 player1 plays Deusillus
2025-10-01 19:23:03 player1 uses Deusillus to capture all 3 amber from player2 and deal 5 damage to Narp

2025-10-01 19:23:03 player2 uses Deusillus to reap with Deusillus
2025-10-01 19:23:03 player2 uses Deusillus to remove 1 amber from Deusillus and deal 2 damage to all of player1's creatures
```

- Humble - add amount moved
```
2025-10-01 20:00:21 player1 plays Humble
2025-10-01 20:00:21 player1 gains an amber due to Humble's bonus icon
2025-10-01 20:00:21 player1 uses Humble to to exhaust Senator Shrix and move 0 amber from Senator Shrix to common supply
```

- Memorialize the Fallen - add aember counts
```
2025-10-01 20:07:50 player1 plays Memorialize the Fallen
2025-10-01 20:07:50 player1 uses Memorialize the Fallen to make player1 lose 2 amber and player2 lose 3 amber
```
