### PR TITLE
fix: Add tests for cards missing tests

### DIFF
--- a/server/game/cards/01-Core/AmmoniaClouds.js
+++ b/server/game/cards/01-Core/AmmoniaClouds.js
@@ -4,7 +4,8 @@ class AmmoniaClouds extends Card {
     // Play: Deal 3<D> to each creature.
     setupCardAbilities(ability) {
         this.play({
-            effect: 'deal 3 damage to all creatures',
+            effect: 'deal 3 damage to all creatures ({1})',
+            effectArgs: (context) => [context.game.creaturesInPlay],
             gameAction: ability.actions.dealDamage((context) => ({
                 amount: 3,
                 target: context.game.creaturesInPlay

--- a/test/server/cards/01-Core/AmmoniaClouds.spec.js
+++ b/test/server/cards/01-Core/AmmoniaClouds.spec.js
@@ -1,0 +1,30 @@
+describe('Ammonia Clouds', function () {
+    describe("Ammonia Clouds's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['ammonia-clouds'],
+                    inPlay: ['troll']
+                },
+                player2: {
+                    inPlay: ['hunting-witch', 'mother']
+                }
+            });
+        });
+
+        it('should deal 3 damage to all creatures when played', function () {
+            this.mother.tokens.ward = 1;
+            this.player1.play(this.ammoniaClouds);
+            expect(this.troll.tokens.damage).toBe(3);
+            expect(this.mother.tokens.damage).toBe(undefined);
+        });
+
+        it('should destroy creatures with 3 or less power', function () {
+            this.player1.play(this.ammoniaClouds);
+            expect(this.troll.location).toBe('play area');
+            expect(this.huntingWitch.location).toBe('discard');
+            expect(this.mother.location).toBe('play area');
+        });
+    });
+});


### PR DESCRIPTION
- fix: Add tests for cards missing tests

Updated some messages as well:
- Ammonia Clouds
```
2025-10-04 21:07:07 player1 plays Ammonia Clouds
2025-10-04 21:07:07 player1 uses Ammonia Clouds to deal 3 damage to all creatures (Troll, Hunting Witch, and Mother)
2025-10-04 21:07:07 Mother's ward token prevents the damage dealt by Ammonia Clouds and is discarded
```