### PR TITLE
fix: nextRoundEffects wait for opponent's next turn

### DIFF
--- a/server/game/Effects/Effect.js
+++ b/server/game/Effects/Effect.js
@@ -38,6 +38,8 @@ class Effect {
         this.location = properties.location || 'play area';
         this.printedAbility = properties.printedAbility !== false;
         this.nextRound = !!properties.nextRound;
+        this.waitForOpponentTurn = properties.waitForOpponentTurn !== false;
+        this.effectController = properties.effectController;
         this.targets = [];
         this.effect = effect;
         this.refreshContext(properties.context);

--- a/server/game/GameActions/LastingEffectAction.js
+++ b/server/game/GameActions/LastingEffectAction.js
@@ -13,6 +13,7 @@ class LastingEffectAction extends GameAction {
         this.effect = [];
         this.targetController = null;
         this.until = null;
+        this.waitForOpponentTurn = true;
 
         // lasting ability trigger properties
         this.when = null;
@@ -63,7 +64,9 @@ class LastingEffectAction extends GameAction {
                 this.targetController || (this.roundDuration === 1 ? 'current' : 'opponent'),
             until: this.until,
             roundDuration: !this.until ? this.roundDuration : undefined,
-            nextRound: this.nextRound
+            nextRound: this.nextRound,
+            waitForOpponentTurn: this.waitForOpponentTurn,
+            effectController: context.player
         };
 
         return [

--- a/server/game/cards/03-WC/SensorChiefGarcia.js
+++ b/server/game/cards/03-WC/SensorChiefGarcia.js
@@ -9,7 +9,7 @@ class SensorChiefGarcia extends Card {
             effect: "increase key cost by 2 during {1}'s next turn",
             effectArgs: (context) => context.player.opponent,
             gameAction: ability.actions.nextRoundEffect({
-                targetController: 'any',
+                targetController: 'opponent',
                 effect: ability.effects.modifyKeyCost(2)
             })
         });

--- a/server/game/cards/03-WC/SensorChiefGarcia.js
+++ b/server/game/cards/03-WC/SensorChiefGarcia.js
@@ -9,7 +9,7 @@ class SensorChiefGarcia extends Card {
             effect: "increase key cost by 2 during {1}'s next turn",
             effectArgs: (context) => context.player.opponent,
             gameAction: ability.actions.nextRoundEffect({
-                targetController: 'opponent',
+                targetController: 'any',
                 effect: ability.effects.modifyKeyCost(2)
             })
         });

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -114,12 +114,32 @@ class EffectEngine {
 
         _.each(this.nextRoundEffects, (effect) => {
             if (effect.roundDuration > 1) {
-                effect.nextRound = false;
-                effect.roundDuration -= 1;
-                this.add(effect);
+                // Check if we should wait for opponent turn
+                let shouldActivate = true;
+                if (effect.waitForOpponentTurn && effect.effectController) {
+                    // Only activate if it's now the opponent's turn
+                    shouldActivate = this.game.activePlayer !== effect.effectController;
+                }
+
+                if (shouldActivate) {
+                    effect.nextRound = false;
+                    effect.roundDuration -= 1;
+                    this.add(effect);
+                } else {
+                    // The effect stays in nextRoundEffects for another round
+                }
             }
         });
-        this.nextRoundEffects = [];
+
+        // Only remove effects that were activated
+        this.nextRoundEffects = this.nextRoundEffects.filter((effect) => {
+            if (effect.roundDuration > 1) {
+                if (effect.waitForOpponentTurn && effect.effectController) {
+                    return this.game.activePlayer === effect.effectController;
+                }
+            }
+            return false;
+        });
     }
 
     registerCustomDurationEvents(effect) {

--- a/test/server/cards/01-Core/Lifeward.spec.js
+++ b/test/server/cards/01-Core/Lifeward.spec.js
@@ -32,4 +32,37 @@ describe('Lifeward', function () {
             expect(this.player2).toHavePromptButton('Cancel');
         });
     });
+
+    describe('after taking another turn', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 0,
+                    house: 'dis',
+                    hand: [],
+                    inPlay: ['tachyon-manifold', 'lifeward']
+                },
+                player2: {
+                    amber: 0,
+                    inPlay: [],
+                    hand: ['troll']
+                }
+            });
+            this.tachyonManifold.printedHouse = 'dis';
+            this.tachyonManifold.maverick = 'dis';
+            this.player1.useAction(this.tachyonManifold);
+        });
+
+        it("should affect opponent's next turn", function () {
+            this.player1.clickCard(this.lifeward);
+            this.player1.clickPrompt("Use this card's Omni ability");
+            this.player1.endTurn();
+            this.player1.clickPrompt('dis');
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.clickCard(this.troll);
+            expect(this.player2).toHavePrompt('Troll');
+            expect(this.player2).not.toHavePromptButton('Play this creature');
+        });
+    });
 });

--- a/test/server/cards/03-WC/SensorChiefGarcia.spec.js
+++ b/test/server/cards/03-WC/SensorChiefGarcia.spec.js
@@ -64,4 +64,35 @@ describe('Sensor Chief Garcia', function () {
             expect(this.player2.player.amber).toBe(6);
         });
     });
+
+    describe('after taking another turn', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 0,
+                    house: 'staralliance',
+                    hand: ['sensor-chief-garcia'],
+                    inPlay: ['tachyon-manifold']
+                },
+                player2: {
+                    amber: 6,
+                    inPlay: ['dust-pixie'],
+                    hand: ['remote-access']
+                }
+            });
+            this.tachyonManifold.printedHouse = 'staralliance';
+            this.tachyonManifold.maverick = 'staralliance';
+            this.player1.useAction(this.tachyonManifold);
+        });
+
+        it("should affect opponent's next turn", function () {
+            this.player1.play(this.sensorChiefGarcia);
+            this.player1.endTurn();
+            this.player1.clickPrompt('staralliance');
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+            this.player1.endTurn();
+            expect(this.player2.player.getCurrentKeyCost()).toBe(8);
+            expect(this.player2.player.getForgedKeys()).toBe(0);
+        });
+    });
 });

--- a/test/server/cards/03-WC/SensorChiefGarcia.spec.js
+++ b/test/server/cards/03-WC/SensorChiefGarcia.spec.js
@@ -55,6 +55,8 @@ describe('Sensor Chief Garcia', function () {
             this.player1.endTurn();
             expect(this.player2.player.getForgedKeys()).toBe(0);
             expect(this.player2.player.amber).toBe(6);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(8);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(8);
         });
 
         it('should stop a key being forged when fighting', function () {


### PR DESCRIPTION
- fix: nextRoundEffects wait for opponent's next turn

By default nextRoundEffects would always go off during the next turn, even if it was your turn with cards like Tachyon Manifold or Ancestral Timekeeper. This PR updates the default behavior to wait until the opponent's next turn as found by Copilot.

I added tests for all cards that use nextRoundEffect, and checked that the current tests pass, but I'm not the expert on this codebase so let me know if you think there's a better way to do this.