### PR TITLE
refactor: rename round to turn

### DIFF
--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import { useSelector } from 'react-redux';
 
-import Avatar from '../Site/Avatar';
-import AlertPanel from '../Site/AlertPanel';
-import { Constants } from '../../constants';
 import AmberImage from '../../assets/img/amber.png';
-import TideImage from '../../assets/img/tide/tide.png';
 import CardBackImage from '../../assets/img/idbacks/cardback.jpg';
+import TideImage from '../../assets/img/tide/tide.png';
+import { Constants } from '../../constants';
+import AlertPanel from '../Site/AlertPanel';
+import Avatar from '../Site/Avatar';
 import CardImage from './CardImage';
 
 const keyImages = {};
@@ -80,7 +80,7 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
             if (key === 'alert') {
                 let message = formatMessageText(fragment.message);
                 switch (fragment.type) {
-                    case 'endofround':
+                    case 'endofturn':
                     case 'phasestart':
                         messages.push(
                             <div
@@ -93,7 +93,7 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
                             </div>
                         );
                         break;
-                    case 'startofround':
+                    case 'startofturn':
                         messages.push(
                             <div
                                 className={'font-weight-bold text-white separator ' + fragment.type}

--- a/client/Components/GameBoard/Messages.scss
+++ b/client/Components/GameBoard/Messages.scss
@@ -119,11 +119,11 @@
     color: #ff38c7;
 }
 
-.endofround {
+.endofturn {
     font-size: 0.9rem;
 }
 
-.startofround {
+.startofturn {
     font-size: 1.05rem;
     background-image: url('~assets/img/panel-primary.png');
     border-top: 1px solid theme-color('primary');
@@ -134,7 +134,7 @@
     margin: 0px -6px -7px -6px;
 }
 
-.startofround .username{
+.startofturn .username{
     text-transform: none;
     font-weight: 300 !important;
 }

--- a/client/Components/Games/TournamentLobby.jsx
+++ b/client/Components/Games/TournamentLobby.jsx
@@ -1,24 +1,24 @@
-import React, { useState, useEffect } from 'react';
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useEffect, useState } from 'react';
+import { Button, Col, Form, Row } from 'react-bootstrap';
 import ReactClipboard from 'react-clipboardjs-copy';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { toastr } from 'react-redux-toastr';
-import { Trans, useTranslation } from 'react-i18next';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
-import { Col, Button, Form, Row } from 'react-bootstrap';
 
-import NewGame from './NewGame';
-import Panel from '../Site/Panel';
-import ApiStatus from '../Site/ApiStatus';
 import {
-    fetchTournaments,
-    fetchFullTournament,
     attachMatchLink,
-    navigate,
     clearApiStatus,
-    fetchMatches
+    fetchFullTournament,
+    fetchMatches,
+    fetchTournaments,
+    navigate
 } from '../../redux/actions';
 import { Challonge } from '../../redux/types';
+import ApiStatus from '../Site/ApiStatus';
+import Panel from '../Site/Panel';
+import NewGame from './NewGame';
 
 import './TournamentLobby.scss';
 
@@ -210,7 +210,7 @@ const TournamentLobby = () => {
                 <Row>
                     <Col>
                         {openMatches[0] && (
-                            <div className='match-round'>{'Round: ' + openMatches[0].round}</div>
+                            <div className='match-turn'>{'Turn: ' + openMatches[0].turn}</div>
                         )}
                         {openMatches.map((match, index) => {
                             const game = tournamentGames.find(

--- a/client/Components/Games/TournamentLobby.scss
+++ b/client/Components/Games/TournamentLobby.scss
@@ -1,4 +1,4 @@
-.match-round {
+.match-turn {
     font-size: 20px;
     font-weight: 800;
 }

--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -488,7 +488,7 @@ this.action({
 
 #### Lasting effects
 
-Unlike persistent effects, lasting effects are typically applied during an action, reaction or interrupt and expire after a specified period of time. Lasting effect use the same properties as persistent effects, above. Lasting effects are applied using the `cardLastingEffect`, `ringLastingEffect` or `playerLastingEffect`, depending on what they affect. They take a `duration:` property which is one of `untilEndOfConflict` (default), `untilEndOfPhase` or `untilEndOfRound`.
+Unlike persistent effects, lasting effects are typically applied during an action, reaction or interrupt and expire after a specified period of time. Lasting effect use the same properties as persistent effects, above. Lasting effects are applied using the `cardLastingEffect`, `ringLastingEffect` or `playerLastingEffect`, depending on what they affect. They take a `duration:` property which is one of `untilConflictEnd` (default), `untilPhaseEnd` or `untilPlayerTurnEnd`.
 
 ```javascript
 // Action: During a conflict, bow this character. Choose another [crane] character – that character
@@ -501,7 +501,7 @@ this.action({
         cardType: 'character',
         cardCondition: (card, context) => card !== context.source && card.isFaction('crane'),
         gameAction: ability.actions.cardLastingEffect(() => ({
-            duration: 'untilEndOfConflict',
+            duration: 'untilConflictEnd',
             effect: ability.effects.modifyPoliticalSkill(3)
         }))
     },
@@ -510,7 +510,7 @@ this.action({
 });
 ```
 
-To apply an effect to last until the end of the current phase, use `untilEndOfPhase`:
+To apply an effect to last until the end of the current phase, use `untilPhaseEnd`:
 
 ```javascript
 // Action: Reduce the cost of the next event you play this phase by 1.
@@ -518,16 +518,16 @@ this.action({
     title: 'Reduce cost of next event by 1',
     effect: 'reduce the cost of their next event by 1',
     gameAction: ability.actions.playerLastingEffect({
-        duration: 'untilEndOfPhase',
+        duration: 'untilPhaseEnd',
         effect: ability.effects.reduceNextPlayedCardCost(1, (card) => card.type === 'event')
     })
 });
 ```
 
-To apply an effect to last until the end of the round, use `untilEndOfRound`:
+To apply an effect to last until the end of the turn, use `untilPlayerTurnEnd`:
 
 ```javascript
-/// Action: Choose a holding you control – you may trigger each of that holding's triggered abilities an additional time this round (or specified period).
+/// Action: Choose a holding you control – you may trigger each of that holding's triggered abilities an additional time this turn (or specified period).
 this.action({
     title: 'Add an additional ability use to a holding',
     target: {
@@ -535,7 +535,7 @@ this.action({
         location: 'province',
         controller: 'self',
         gameAction: ability.actions.cardLastingEffect({
-            duration: 'untilEndOfPhase',
+            duration: 'untilPhaseEnd',
             targetLocation: 'province',
             effect: ability.effects.increaseLimitOnAbilities(1)
         })
@@ -633,7 +633,7 @@ this.forcedReaction({
     },
     effect: 'stop him being discarded or losing fate in this phase',
     gameAction: ability.actions.cardLastingEffect({
-        duration: 'untilEndOfPhase',
+        duration: 'untilPhaseEnd',
         effect: [
             ability.effects.cardCannot('removeFate'),
             ability.effects.cardCannot('discardFromPlay')
@@ -699,7 +699,7 @@ To limit an ability per conflict, use `ability.limit.perConflict(x)`.
 
 To limit an ability per phase, use `ability.limit.perPhase(x)`.
 
-To limit an ability per round, use `ability.limit.perRound(x)`.
+To limit an ability per turn, use `ability.limit.perTurn(x)`.
 
 In each case, `x` should be the number of times the ability is allowed to be used.
 

--- a/server/game/EffectSource.js
+++ b/server/game/EffectSource.js
@@ -15,27 +15,27 @@ class EffectSource extends GameObject {
     /**
      * Applies an immediate effect which lasts until the end of the phase.
      */
-    untilEndOfPhase(propertyFactory) {
+    untilPhaseEnd(propertyFactory) {
         var properties = propertyFactory(AbilityDsl);
         return this.addEffectToEngine(
-            Object.assign({ duration: 'untilEndOfPhase', location: 'any' }, properties)
+            Object.assign({ duration: 'untilPhaseEnd', location: 'any' }, properties)
         );
     }
 
     /**
-     * Applies an immediate effect which lasts until the end of the round.
+     * Applies an immediate effect which lasts until the end of the turn.
      */
-    untilEndOfRound(propertyFactory) {
+    untilPlayerTurnEnd(propertyFactory) {
         var properties = propertyFactory(AbilityDsl);
         return this.addEffectToEngine(
-            Object.assign({ duration: 'untilEndOfRound', location: 'any' }, properties)
+            Object.assign({ duration: 'untilPlayerTurnEnd', location: 'any' }, properties)
         );
     }
 
-    untilNextTurn(propertyFactory) {
+    untilPlayerNextTurnStart(propertyFactory) {
         let properties = propertyFactory(AbilityDsl);
         return this.addEffectToEngine(
-            Object.assign({ duration: 'untilNextTurn', location: 'any' }, properties)
+            Object.assign({ duration: 'untilPlayerNextTurnStart', location: 'any' }, properties)
         );
     }
 

--- a/server/game/GameActions.js
+++ b/server/game/GameActions.js
@@ -40,7 +40,7 @@ const Actions = {
     attach: (propertyFactory) => new GameActions.AttachAction(propertyFactory), // upgrade
     capture: (propertyFactory) => new GameActions.CaptureAction(propertyFactory),
     cardLastingEffect: (propertyFactory) =>
-        new GameActions.CardLastingEffectAction(propertyFactory), // duration = 'untilEndOfRound', effect, targetLocation, condition, until
+        new GameActions.CardLastingEffectAction(propertyFactory), // duration = 'untilPlayerTurnEnd', effect, targetLocation, condition, until
     clearGrowthTokens: (propertyFactory) =>
         new GameActions.RemoveTokenAction(propertyFactory, 'growth'),
     clearGloryCounters: (propertyFactory) =>
@@ -140,14 +140,14 @@ const Actions = {
     lastingEffect: (propertyFactory) =>
         new GameActions.LastingEffectAction(propertyFactory, 'custom'),
 
-    forRemainderOfTurn: (propertyFactory) =>
-        new GameActions.LastingEffectAction(propertyFactory, 'forRemainderOfTurn'),
+    untilPlayerTurnEnd: (propertyFactory) =>
+        new GameActions.LastingEffectAction(propertyFactory, 'untilPlayerTurnEnd'),
     duringOpponentNextTurn: (propertyFactory) =>
         new GameActions.LastingEffectAction(propertyFactory, 'duringOpponentNextTurn'),
-    untilNextTurn: (propertyFactory) =>
-        new GameActions.LastingEffectAction(propertyFactory, 'untilNextTurn'),
-    untilEndOfMyNextTurn: (propertyFactory) =>
-        new GameActions.LastingEffectAction(propertyFactory, 'untilEndOfMyNextTurn'),
+    untilPlayerNextTurnStart: (propertyFactory) =>
+        new GameActions.LastingEffectAction(propertyFactory, 'untilPlayerNextTurnStart'),
+    untilPlayerNextTurnEnd: (propertyFactory) =>
+        new GameActions.LastingEffectAction(propertyFactory, 'untilPlayerNextTurnEnd'),
 
     // meta actions
     addEventToWindow: (propertyFactory) => new GameActions.AddEventToWindowAction(propertyFactory),

--- a/server/game/GameActions/CardLastingEffectAction.js
+++ b/server/game/GameActions/CardLastingEffectAction.js
@@ -2,7 +2,7 @@ const CardGameAction = require('./CardGameAction');
 
 class CardLastingEffectAction extends CardGameAction {
     setDefaultProperties() {
-        this.duration = 'untilEndOfRound';
+        this.duration = 'untilPlayerTurnEnd';
         this.condition = null;
         this.until = null;
         this.effect = [];

--- a/server/game/GameActions/SequentialCardLastingEffectAction.js
+++ b/server/game/GameActions/SequentialCardLastingEffectAction.js
@@ -3,7 +3,7 @@ const GameAction = require('./GameAction');
 
 class SequentialCardLastingEffectAction extends GameAction {
     setDefaultProperties() {
-        this.duration = 'untilEndOfRound';
+        this.duration = 'untilPlayerTurnEnd';
         this.condition = null;
         this.until = null;
         this.effectForEach = [];

--- a/server/game/PlainTextGameChatFormatter.js
+++ b/server/game/PlainTextGameChatFormatter.js
@@ -32,9 +32,9 @@ class PlainTextGameChatFormatter {
                 let message = this.formatMessageFragment(fragment.message);
 
                 switch (fragment.type) {
-                    case 'endofround':
+                    case 'endofturn':
                     case 'phasestart':
-                    case 'startofround':
+                    case 'startofturn':
                         result += `${HeaderDivider} ${message} ${HeaderDivider}`;
                         break;
                     case 'success':

--- a/server/game/SimpleEventTracker.js
+++ b/server/game/SimpleEventTracker.js
@@ -5,10 +5,10 @@ class SimpleEventTracker {
         this.events = [];
         this.tracker = new EventRegistrar(game, this);
         this[event] = (event) => this.events.push(event);
-        this.tracker.register(['onRoundEnded', event]);
+        this.tracker.register(['onTurnEnd', event]);
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.events = [];
     }
 }

--- a/server/game/abilitylimit.js
+++ b/server/game/abilitylimit.js
@@ -70,11 +70,11 @@ AbilityLimit.repeatable = function (max, eventName) {
 };
 
 AbilityLimit.perPhase = function (max) {
-    return new RepeatableAbilityLimit(max, 'onPhaseEnded');
+    return new RepeatableAbilityLimit(max, 'onPhaseEnd');
 };
 
-AbilityLimit.perRound = function (max) {
-    return new RepeatableAbilityLimit(max, 'onRoundEnded');
+AbilityLimit.perTurn = function (max) {
+    return new RepeatableAbilityLimit(max, 'onTurnEnd');
 };
 
 module.exports = AbilityLimit;

--- a/server/game/cards/01-Core/Blypyp.js
+++ b/server/game/cards/01-Core/Blypyp.js
@@ -5,7 +5,7 @@ class Blypyp extends Card {
     setupCardAbilities(ability) {
         this.reap({
             effect: 'make the next Mars creature played this turn enter play ready',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.card.type === 'creature' &&

--- a/server/game/cards/01-Core/BrothersInBattle.js
+++ b/server/game/cards/01-Core/BrothersInBattle.js
@@ -9,7 +9,7 @@ class BrothersInBattle extends Card {
             },
             effect: 'allow creatures from {1} to fight this turn',
             effectArgs: (context) => context.house,
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 effect: ability.effects.canFight((card) => card.hasHouse(context.house))
             }))
         });

--- a/server/game/cards/01-Core/Charge.js
+++ b/server/game/cards/01-Core/Charge.js
@@ -4,7 +4,7 @@ class Charge extends Card {
     // Play: For the remainder of the turn, each creature you play gains, Play: Deal 2<D> to an enemy creature.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('play', {
                     target: {

--- a/server/game/cards/01-Core/CombatPheromones.js
+++ b/server/game/cards/01-Core/CombatPheromones.js
@@ -9,7 +9,7 @@ class CombatPheromones extends Card {
                 numCards: 2,
                 controller: 'self',
                 cardCondition: (card) => card.hasHouse('mars'),
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     effect: ability.effects.canUse((card) => context.target.includes(card))
                 }))
             },

--- a/server/game/cards/01-Core/CrystalHive.js
+++ b/server/game/cards/01-Core/CrystalHive.js
@@ -5,7 +5,7 @@ class CrystalHive extends Card {
     setupCardAbilities(ability) {
         this.action({
             effect: 'gain 1 amber each time a creature reaps for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onReap: () => true
                 },

--- a/server/game/cards/01-Core/DeipnoSpymaster.js
+++ b/server/game/cards/01-Core/DeipnoSpymaster.js
@@ -8,7 +8,7 @@ class DeipnoSpymaster extends Card {
             target: {
                 cardType: 'creature',
                 controller: 'self',
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     effect: ability.effects.canUse((card) => card === context.target)
                 }))
             },

--- a/server/game/cards/01-Core/DimensionDoor.js
+++ b/server/game/cards/01-Core/DimensionDoor.js
@@ -11,7 +11,7 @@ class DimensionDoor extends Card {
         this.play({
             condition: (context) => !!context.player.opponent,
             effect: 'steal amber instead of gaining it while reaping for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.customDetachedPlayer({
                     apply: (player) => (this.enabledForPlayers[player.uuid] = true),
                     unapply: (player) => (this.enabledForPlayers[player.uuid] = false)

--- a/server/game/cards/01-Core/FollowTheLeader.js
+++ b/server/game/cards/01-Core/FollowTheLeader.js
@@ -5,7 +5,7 @@ class FollowTheLeader extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow each friendly creature to fight until the end of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canFight(() => true)
             })
         });

--- a/server/game/cards/01-Core/FullMoon.js
+++ b/server/game/cards/01-Core/FullMoon.js
@@ -6,7 +6,7 @@ class FullMoon extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'gain 1 amber for each creature played for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card.type === 'creature'

--- a/server/game/cards/01-Core/HorsemanOfWar.js
+++ b/server/game/cards/01-Core/HorsemanOfWar.js
@@ -5,7 +5,7 @@ class HorsemanOfWar extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow all friendly creatures to only fight this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: [
                     ability.effects.canUse((card) => card.type === 'creature'),
                     ability.effects.cardCannot(

--- a/server/game/cards/01-Core/LibraryAccess.js
+++ b/server/game/cards/01-Core/LibraryAccess.js
@@ -6,7 +6,7 @@ class LibraryAccess extends Card {
         this.play({
             effect: 'draw a card after playing a card for the remainder of the turn, and purge {0}',
             gameAction: [
-                ability.actions.forRemainderOfTurn((context) => ({
+                ability.actions.untilPlayerTurnEnd((context) => ({
                     when: {
                         onCardPlayed: (event) =>
                             event.player === context.player && event.card !== context.source

--- a/server/game/cards/01-Core/LootTheBodies.js
+++ b/server/game/cards/01-Core/LootTheBodies.js
@@ -6,7 +6,7 @@ class LootTheBodies extends Card {
         this.play({
             effect:
                 'gain 1 amber each time an enemy creature is destroyed for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardDestroyed: (event) =>
                         event.clone.type === 'creature' && event.clone.controller !== context.player

--- a/server/game/cards/01-Core/LooterGoblin.js
+++ b/server/game/cards/01-Core/LooterGoblin.js
@@ -7,7 +7,7 @@ class LooterGoblin extends Card {
         this.reap({
             effect:
                 'gain 1 amber each time an enemy creature is destroyed for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardDestroyed: (event) =>
                         event.clone.type === 'creature' && event.clone.controller !== context.player

--- a/server/game/cards/01-Core/PhaseShift.js
+++ b/server/game/cards/01-Core/PhaseShift.js
@@ -5,7 +5,7 @@ class PhaseShift extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow them to play one non-Logos card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse('logos')
             })
         });

--- a/server/game/cards/01-Core/PotionOfInvulnerability.js
+++ b/server/game/cards/01-Core/PotionOfInvulnerability.js
@@ -7,7 +7,7 @@ class PotionOfInvulnerability extends Card {
             effect: 'sacrifice {0} so that their creatures take no damage this turn',
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.cardCannot('damage')
                 })
             ]

--- a/server/game/cards/01-Core/RitualOfTheHunt.js
+++ b/server/game/cards/01-Core/RitualOfTheHunt.js
@@ -6,7 +6,7 @@ class RitualOfTheHunt extends Card {
         this.omni({
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse(
                         (card) => card.hasHouse('untamed') && card.type === 'creature'
                     )

--- a/server/game/cards/01-Core/RogueOgre.js
+++ b/server/game/cards/01-Core/RogueOgre.js
@@ -5,7 +5,7 @@ class RogueOgre extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer && this.game.cardsPlayed.length === 1
             },
             gameAction: [ability.actions.heal({ amount: 2 }), ability.actions.capture()]

--- a/server/game/cards/01-Core/Shaffles.js
+++ b/server/game/cards/01-Core/Shaffles.js
@@ -5,7 +5,7 @@ class Shaffles extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.loseAmber()
         });

--- a/server/game/cards/01-Core/ShieldOfJustice.js
+++ b/server/game/cards/01-Core/ShieldOfJustice.js
@@ -5,7 +5,7 @@ class ShieldOfJustice extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'prevent their creatures from taking damage this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.cardCannot('damage')
             })
         });

--- a/server/game/cards/01-Core/SigilOfBrotherhood.js
+++ b/server/game/cards/01-Core/SigilOfBrotherhood.js
@@ -6,7 +6,7 @@ class SigilOfBrotherhood extends Card {
         this.omni({
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse(
                         (card) => card.hasHouse('sanctum') && card.type === 'creature'
                     )

--- a/server/game/cards/01-Core/Sniffer.js
+++ b/server/game/cards/01-Core/Sniffer.js
@@ -5,7 +5,7 @@ class Sniffer extends Card {
     setupCardAbilities(ability) {
         this.action({
             effect: 'make each creature lose elusive',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'any',
                 effect: ability.effects.removeKeyword('elusive')
             })

--- a/server/game/cards/01-Core/SoftLanding.js
+++ b/server/game/cards/01-Core/SoftLanding.js
@@ -5,7 +5,7 @@ class SoftLanding extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'make the next creature/artifact played this turn enter play ready',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         (event.card.type === 'creature' || event.card.type === 'artifact') &&

--- a/server/game/cards/01-Core/TakeHostages.js
+++ b/server/game/cards/01-Core/TakeHostages.js
@@ -6,7 +6,7 @@ class TakeHostages extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'capture amber after fighting with a creature until the end of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onFight: (event) =>
                         event.attacker.controller === context.player &&

--- a/server/game/cards/01-Core/TheWarchest.js
+++ b/server/game/cards/01-Core/TheWarchest.js
@@ -6,7 +6,7 @@ class TheWarchest extends Card {
     setupCardAbilities(ability) {
         this.creaturesDestroyed = [];
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onCardDestroyed', 'onRoundEnded']);
+        this.tracker.register(['onCardDestroyed', 'onTurnEnd']);
 
         this.action({
             gameAction: ability.actions.gainAmber((context) => ({
@@ -22,7 +22,7 @@ class TheWarchest extends Card {
         }
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creaturesDestroyed = [];
     }
 }

--- a/server/game/cards/01-Core/TranspositionSandals.js
+++ b/server/game/cards/01-Core/TranspositionSandals.js
@@ -11,7 +11,7 @@ class TranspositionSandals extends Card {
                     gameAction: ability.actions.swap()
                 },
                 effect: 'swap its position with {0}. You may use {0} this turn',
-                gameAction: ability.actions.forRemainderOfTurn((abilityContext) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((abilityContext) => ({
                     effect: ability.effects.canUse((card) => card === abilityContext.target)
                 }))
             })

--- a/server/game/cards/01-Core/TreasureMap.js
+++ b/server/game/cards/01-Core/TreasureMap.js
@@ -11,7 +11,7 @@ class TreasureMap extends Card {
                 ability.actions.gainAmber((context) => ({
                     amount: context.game.cardsPlayed.some((card) => card !== context.source) ? 0 : 3
                 })),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.playerCannot('play')
                 })
             ]

--- a/server/game/cards/01-Core/Warsong.js
+++ b/server/game/cards/01-Core/Warsong.js
@@ -7,7 +7,7 @@ class Warsong extends Card {
         this.play({
             effect:
                 'gain 1 amber each time a friendly creature fights for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onFight: (event) => event.attacker.controller === context.player
                 },

--- a/server/game/cards/02-AoA/AbondTheArmorsmith.js
+++ b/server/game/cards/02-AoA/AbondTheArmorsmith.js
@@ -11,7 +11,7 @@ class AbondTheArmorsmith extends Card {
         });
         this.action({
             effect: 'each other friendly creature gets +1 armor',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 target: context.player.creaturesInPlay.filter((card) => card !== context.source),
                 effect: ability.effects.modifyArmor(1)
             }))

--- a/server/game/cards/02-AoA/BrobnarAmbassador.js
+++ b/server/game/cards/02-AoA/BrobnarAmbassador.js
@@ -7,7 +7,7 @@ class BrobnarAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Brobnar card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('brobnar')
             })
         });

--- a/server/game/cards/02-AoA/CybergiantRig.js
+++ b/server/game/cards/02-AoA/CybergiantRig.js
@@ -7,7 +7,7 @@ class CybergiantRig extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('interrupt', {
                 when: {
-                    onRoundEnded: (_event, context) =>
+                    onTurnEnd: (_event, context) =>
                         context.player === context.game.activePlayer &&
                         context.source.hasToken('power')
                 },

--- a/server/game/cards/02-AoA/DirectorOfZyx.js
+++ b/server/game/cards/02-AoA/DirectorOfZyx.js
@@ -6,7 +6,7 @@ class DirectorOfZyx extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.archive((context) => ({
                 target: context.player.deck[0]

--- a/server/game/cards/02-AoA/DisAmbassador.js
+++ b/server/game/cards/02-AoA/DisAmbassador.js
@@ -7,7 +7,7 @@ class DisAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Dis card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('dis')
             })
         });

--- a/server/game/cards/02-AoA/Foozle.js
+++ b/server/game/cards/02-AoA/Foozle.js
@@ -6,7 +6,7 @@ class Foozle extends Card {
     setupCardAbilities(ability) {
         this.creatureDestroyedControllerUuid = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onCardDestroyed', 'onRoundEnded']);
+        this.tracker.register(['onCardDestroyed', 'onTurnEnd']);
 
         this.reap({
             condition: (context) =>
@@ -22,7 +22,7 @@ class Foozle extends Card {
         }
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creatureDestroyedControllerUuid = {};
     }
 }

--- a/server/game/cards/02-AoA/Grovekeeper.js
+++ b/server/game/cards/02-AoA/Grovekeeper.js
@@ -5,7 +5,7 @@ class Grovekeeper extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addPowerCounter(() => ({ target: this.neighbors }))
         });

--- a/server/game/cards/02-AoA/HelperBot.js
+++ b/server/game/cards/02-AoA/HelperBot.js
@@ -5,7 +5,7 @@ class HelperBot extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow them to play one non-Logos card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse('logos')
             })
         });

--- a/server/game/cards/02-AoA/HideawayHole.js
+++ b/server/game/cards/02-AoA/HideawayHole.js
@@ -8,7 +8,7 @@ class HideawayHole extends Card {
             effectAlert: true,
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.untilNextTurn({
+                ability.actions.untilPlayerNextTurnStart({
                     targetController: 'current',
                     effect: ability.effects.addKeyword({ elusive: 1 })
                 })

--- a/server/game/cards/02-AoA/LogosAmbassador.js
+++ b/server/game/cards/02-AoA/LogosAmbassador.js
@@ -7,7 +7,7 @@ class LogosAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Logos card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('logos')
             })
         });

--- a/server/game/cards/02-AoA/MarsAmbassador.js
+++ b/server/game/cards/02-AoA/MarsAmbassador.js
@@ -7,7 +7,7 @@ class MarsAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Mars card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('mars')
             })
         });

--- a/server/game/cards/02-AoA/Redlock.js
+++ b/server/game/cards/02-AoA/Redlock.js
@@ -6,7 +6,7 @@ class Redlock extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer &&
                     this.game.cardsPlayed.filter((card) => card.type === 'creature').length === 0
             },

--- a/server/game/cards/02-AoA/ScientificalHack.js
+++ b/server/game/cards/02-AoA/ScientificalHack.js
@@ -6,7 +6,7 @@ class ScientificalHack extends Card {
         this.omni({
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse((card) => card.type === 'artifact')
                 })
             ]

--- a/server/game/cards/02-AoA/ScowlyCaper.js
+++ b/server/game/cards/02-AoA/ScowlyCaper.js
@@ -20,7 +20,7 @@ class ScowlyCaper extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             target: {
                 cardType: 'creature',

--- a/server/game/cards/02-AoA/ShadowOfDis.js
+++ b/server/game/cards/02-AoA/ShadowOfDis.js
@@ -8,7 +8,7 @@ class ShadowOfDis extends Card {
             effect: "blank {1}'s creatures text boxes",
             effectArgs: (context) => context.player.opponent,
             effectAlert: true,
-            gameAction: ability.actions.untilNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'opponent',
                 match: (card) => card.location === 'play area' && card.type === 'creature',
                 effect: ability.effects.blank()

--- a/server/game/cards/02-AoA/ShadowsAmbassador.js
+++ b/server/game/cards/02-AoA/ShadowsAmbassador.js
@@ -7,7 +7,7 @@ class ShadowsAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Shadows card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('shadows')
             })
         });

--- a/server/game/cards/02-AoA/SignalFire.js
+++ b/server/game/cards/02-AoA/SignalFire.js
@@ -7,7 +7,7 @@ class SignalFire extends Card {
             effect: 'allow all friendly brobnar creatures to only fight this turn',
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: [
                         ability.effects.canUse(
                             (card) => card.type === 'creature' && card.hasHouse('brobnar')

--- a/server/game/cards/02-AoA/TitanLibrarian.js
+++ b/server/game/cards/02-AoA/TitanLibrarian.js
@@ -5,7 +5,7 @@ class TitanLibrarian extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer && !this.isOnFlank()
             },
             target: {

--- a/server/game/cards/02-AoA/UntamedAmbassador.js
+++ b/server/game/cards/02-AoA/UntamedAmbassador.js
@@ -7,7 +7,7 @@ class UntamedAmbassador extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one Untamed card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseHouse('untamed')
             })
         });

--- a/server/game/cards/03-WC/Alaka.js
+++ b/server/game/cards/03-WC/Alaka.js
@@ -6,7 +6,7 @@ class Alaka extends Card {
     setupCardAbilities(ability) {
         this.creaturesFoughtByPlayer = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onFight']);
+        this.tracker.register(['onTurnEnd', 'onFight']);
 
         this.persistentEffect({
             location: 'any',
@@ -15,7 +15,7 @@ class Alaka extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creaturesFoughtByPlayer = {};
     }
 

--- a/server/game/cards/03-WC/BarnRazing.js
+++ b/server/game/cards/03-WC/BarnRazing.js
@@ -5,7 +5,7 @@ class BarnRazing extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'cause their opponent to lose 1 amber each time a friendly creature fights',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onUseCard: (event) =>
                         event.fightEvent &&

--- a/server/game/cards/03-WC/BookOfLeq.js
+++ b/server/game/cards/03-WC/BookOfLeq.js
@@ -16,7 +16,7 @@ class BookOfLeQ extends Card {
                     trueGameAction: ability.actions.changeActiveHouse((context) => ({
                         house: context.player.deck[0].getHouses()
                     })),
-                    falseGameAction: ability.actions.forRemainderOfTurn({
+                    falseGameAction: ability.actions.untilPlayerTurnEnd({
                         targetController: 'current',
                         effect: [
                             ability.effects.skipStep('ready'),

--- a/server/game/cards/03-WC/BrambleLynx.js
+++ b/server/game/cards/03-WC/BrambleLynx.js
@@ -7,7 +7,7 @@ class BrambleLynx extends Card {
     setupCardAbilities(ability) {
         this.creaturesReapedByPlayer = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onReap']);
+        this.tracker.register(['onTurnEnd', 'onReap']);
 
         this.persistentEffect({
             location: 'any',
@@ -16,7 +16,7 @@ class BrambleLynx extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creaturesReapedByPlayer = {};
     }
 

--- a/server/game/cards/03-WC/CXOTaber.js
+++ b/server/game/cards/03-WC/CXOTaber.js
@@ -6,7 +6,7 @@ class CXOTaber extends Card {
         this.fight({
             reap: true,
             effect: 'allow them to play or use one non staralliance card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayOrUseNonHouse('staralliance')
             })
         });

--- a/server/game/cards/03-WC/ComOfficerKirby.js
+++ b/server/game/cards/03-WC/ComOfficerKirby.js
@@ -8,7 +8,7 @@ class ComOfficerKirby extends Card {
             reap: true,
             effect:
                 'allow them to play one non staralliance artifact, upgrade, or action​ card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse({
                     house: 'staralliance',
                     condition: (card) => ['action', 'artifact', 'upgrade'].includes(card.type)

--- a/server/game/cards/03-WC/DiploMacy.js
+++ b/server/game/cards/03-WC/DiploMacy.js
@@ -7,7 +7,7 @@ class DiploMacy extends Card {
         this.play({
             effect: 'to exalt each creature before fight until the start of their next turn',
             effectAlert: true,
-            gameAction: ability.actions.untilNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'any',
                 effect: ability.effects.gainAbility('beforeFight', {
                     gameAction: ability.actions.exalt()

--- a/server/game/cards/03-WC/FangtoothCavern.js
+++ b/server/game/cards/03-WC/FangtoothCavern.js
@@ -5,7 +5,7 @@ class FangtoothCavern extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             target: {
                 mode: 'mostStat',

--- a/server/game/cards/03-WC/GamblingDen.js
+++ b/server/game/cards/03-WC/GamblingDen.js
@@ -5,7 +5,7 @@ class GamblingDen extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (event) => event.player && event.player.deck.length > 0
+                onTurnStart: (event) => event.player && event.player.deck.length > 0
             },
             useEventPlayer: true,
             optional: true,

--- a/server/game/cards/03-WC/GeneralOrder24.js
+++ b/server/game/cards/03-WC/GeneralOrder24.js
@@ -5,7 +5,7 @@ class GeneralOrder24 extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: () => true
+                onTurnStart: () => true
             },
             gameAction: ability.actions.destroy((context) => ({
                 target: context.game.activePlayer.creaturesInPlay.length === 0 ? context.source : []

--- a/server/game/cards/03-WC/GreaterOxtet.js
+++ b/server/game/cards/03-WC/GreaterOxtet.js
@@ -6,7 +6,7 @@ class GreaterOxtet extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onPhaseEnded: (event, context) =>
+                onPhaseEnd: (event, context) =>
                     event.phase === 'ready' && this.game.activePlayer === context.player
             },
             target: {

--- a/server/game/cards/03-WC/InformationExchange.js
+++ b/server/game/cards/03-WC/InformationExchange.js
@@ -7,7 +7,7 @@ class InformationExchange extends Card {
         this.amberStolenControllerUuid = {};
         this.activePlayerStoleAmber = false;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onStealAmber', { 'onRoundEnded:preResolution': 'onRoundEnded' }]);
+        this.tracker.register(['onStealAmber', { 'onTurnEnd:preResolution': 'onTurnEnd' }]);
 
         this.play({
             gameAction: ability.actions.steal((context) => ({
@@ -26,7 +26,7 @@ class InformationExchange extends Card {
         }
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.amberStolenControllerUuid[this.game.activePlayer.uuid] = this.activePlayerStoleAmber;
         this.activePlayerStoleAmber = false;
     }

--- a/server/game/cards/03-WC/IntoTheNight.js
+++ b/server/game/cards/03-WC/IntoTheNight.js
@@ -7,7 +7,7 @@ class IntoTheNight extends Card {
             effect:
                 'stop all non-Shadows creatures from fighting until the start of their next turn',
             effectAlert: true,
-            gameAction: ability.actions.untilNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'any',
                 effect: ability.effects.cardCannot(
                     'fight',

--- a/server/game/cards/03-WC/LiviaTheElder.js
+++ b/server/game/cards/03-WC/LiviaTheElder.js
@@ -7,7 +7,7 @@ class LiviaTheElder extends Card {
             optional: true,
             gameAction: ability.actions.exalt(),
             then: {
-                gameAction: ability.actions.forRemainderOfTurn({
+                gameAction: ability.actions.untilPlayerTurnEnd({
                     effect: [
                         ability.effects.reapAbilitiesAddFight(),
                         ability.effects.fightAbilitiesAddReap()

--- a/server/game/cards/03-WC/Quant.js
+++ b/server/game/cards/03-WC/Quant.js
@@ -5,7 +5,7 @@ class Quant extends Card {
     setupCardAbilities(ability) {
         this.reap({
             effect: 'allow them to play one non-Logos action card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse({
                     house: 'logos',
                     condition: (card) => card.type === 'action'

--- a/server/game/cards/03-WC/Ragnarok.js
+++ b/server/game/cards/03-WC/Ragnarok.js
@@ -6,18 +6,18 @@ class Ragnarok extends Card {
     setupCardAbilities(ability) {
         this.play({
             gameAction: [
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.cardCannot('reap')
                 }),
-                ability.actions.forRemainderOfTurn((context) => ({
+                ability.actions.untilPlayerTurnEnd((context) => ({
                     when: {
                         onUseCard: (event) => !!event.fight
                     },
                     gameAction: ability.actions.gainAmber({ target: context.player })
                 })),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     when: {
-                        onRoundEnded: () => true
+                        onTurnEnd: () => true
                     },
                     triggeredAbilityType: 'interrupt',
                     gameAction: ability.actions.destroy((context) => ({

--- a/server/game/cards/03-WC/SnagsMirror.js
+++ b/server/game/cards/03-WC/SnagsMirror.js
@@ -25,7 +25,7 @@ class SnagsMirror extends Card {
             when: {
                 onChooseActiveHouse: (event, context) => event.player !== context.player
             },
-            gameAction: ability.actions.untilEndOfMyNextTurn((context) => ({
+            gameAction: ability.actions.untilPlayerNextTurnEnd((context) => ({
                 targetController: 'player',
                 effect: ability.effects.stopHouseChoice(context.event.house)
             })),

--- a/server/game/cards/03-WC/SongOfTheWild.js
+++ b/server/game/cards/03-WC/SongOfTheWild.js
@@ -6,7 +6,7 @@ class SongOfTheWild extends Card {
         this.play({
             effect:
                 "give each friendly creature 'Reap: Gain 1 amber' for the remainder of the turn",
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('reap', {
                     gameAction: ability.actions.gainAmber()

--- a/server/game/cards/03-WC/SowSalt.js
+++ b/server/game/cards/03-WC/SowSalt.js
@@ -7,7 +7,7 @@ class SowSalt extends Card {
         this.play({
             effect: 'stop creatures from reaping until their next turn',
             effectAlert: true,
-            gameAction: ability.actions.untilNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'any',
                 effect: ability.effects.cardCannot('reap')
             })

--- a/server/game/cards/03-WC/TheFloorIsLava.js
+++ b/server/game/cards/03-WC/TheFloorIsLava.js
@@ -5,7 +5,7 @@ class TheFloorIsLava extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             targets: {
                 friendly: {

--- a/server/game/cards/03-WC/UnitedAction.js
+++ b/server/game/cards/03-WC/UnitedAction.js
@@ -6,7 +6,7 @@ class UnitedAction extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow them to play from any house ​for which they have a card in play',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: [
                     ability.effects.canPlay((card, context) => {
                         let housesInPlay = context.game.getHousesInPlay(

--- a/server/game/cards/03-WC/WeCanAllWin.js
+++ b/server/game/cards/03-WC/WeCanAllWin.js
@@ -5,7 +5,7 @@ class WeCanAllWin extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'reduce key cost by 2 until the end of their next turn',
-            gameAction: ability.actions.untilEndOfMyNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnEnd({
                 targetController: 'any',
                 effect: ability.effects.modifyKeyCost(-2)
             })

--- a/server/game/cards/04-MM/Ant110ny.js
+++ b/server/game/cards/04-MM/Ant110ny.js
@@ -11,7 +11,7 @@ class Ant110ny extends Card {
         });
         this.interrupt({
             when: {
-                onRoundEnded: (_event, context) => context.player === context.game.activePlayer
+                onTurnEnd: (_event, context) => context.player === context.game.activePlayer
             },
             condition: (context) => context.source.hasToken('amber'),
             gameAction: [

--- a/server/game/cards/04-MM/Bonesaw.js
+++ b/server/game/cards/04-MM/Bonesaw.js
@@ -6,7 +6,7 @@ class Bonesaw extends Card {
     setupCardAbilities(ability) {
         this.creatureDestroyedControllerUuid = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onCardDestroyed']);
+        this.tracker.register(['onTurnEnd', 'onCardDestroyed']);
 
         this.persistentEffect({
             location: 'any',
@@ -16,7 +16,7 @@ class Bonesaw extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creatureDestroyedControllerUuid = {};
     }
 

--- a/server/game/cards/04-MM/Commandeer.js
+++ b/server/game/cards/04-MM/Commandeer.js
@@ -5,7 +5,7 @@ class Commandeer extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'capture an amber after playing a card for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source

--- a/server/game/cards/04-MM/FissionBloom.js
+++ b/server/game/cards/04-MM/FissionBloom.js
@@ -6,7 +6,7 @@ class FissionBloom extends Card {
     setupCardAbilities(ability) {
         this.action({
             effect: 'resolve the bonus icons of the next card played an additional time',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source

--- a/server/game/cards/04-MM/FontOfTheEye.js
+++ b/server/game/cards/04-MM/FontOfTheEye.js
@@ -6,7 +6,7 @@ class FontOfTheEye extends Card {
     setupCardAbilities(ability) {
         this.creatureDestroyedControllerUuid = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onCardDestroyed', 'onRoundEnded']);
+        this.tracker.register(['onCardDestroyed', 'onTurnEnd']);
 
         this.omni({
             target: {
@@ -29,7 +29,7 @@ class FontOfTheEye extends Card {
         }
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creatureDestroyedControllerUuid = {};
     }
 }

--- a/server/game/cards/04-MM/ForumOfGiants.js
+++ b/server/game/cards/04-MM/ForumOfGiants.js
@@ -5,7 +5,7 @@ class ForumOfGiants extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             target: {
                 mode: 'mostStat',

--- a/server/game/cards/04-MM/HighPriestTorvus.js
+++ b/server/game/cards/04-MM/HighPriestTorvus.js
@@ -7,7 +7,7 @@ class HighPriestTorvus extends Card {
             optional: true,
             gameAction: ability.actions.exalt(),
             then: {
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     when: {
                         onCardPlayed: (event) =>
                             event.player === context.player && event.card.type === 'action'

--- a/server/game/cards/04-MM/LegionsMarch.js
+++ b/server/game/cards/04-MM/LegionsMarch.js
@@ -6,7 +6,7 @@ class LegionsMarch extends Card {
         this.play({
             effect:
                 'deal 1 damage to each non-Dinosaur creature after using a Dinosaur creature for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onUseCard: (event) =>
                         event.context.player === context.player && event.card.hasTrait('dinosaur')

--- a/server/game/cards/04-MM/LiamSay.js
+++ b/server/game/cards/04-MM/LiamSay.js
@@ -6,7 +6,7 @@ class LiamSay extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             optional: true,
             target: {

--- a/server/game/cards/04-MM/LibraryCard.js
+++ b/server/game/cards/04-MM/LibraryCard.js
@@ -8,7 +8,7 @@ class LibraryCard extends Card {
                 'purge {0} and then draw a card after playing a card for the remainder of the turn',
             gameAction: ability.actions.purge(),
             then: {
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     when: {
                         onCardPlayed: (event) => event.player === context.player
                     },

--- a/server/game/cards/04-MM/MarkOfDis.js
+++ b/server/game/cards/04-MM/MarkOfDis.js
@@ -12,7 +12,7 @@ class MarkOfDis extends Card {
                         condition: () => context.target.location === 'play area',
                         trueGameAction:
                             context.player === context.target.controller
-                                ? ability.actions.untilEndOfMyNextTurn({
+                                ? ability.actions.untilPlayerNextTurnEnd({
                                       targetController: 'current',
                                       effect: ability.effects.restrictHouseChoice(
                                           context.target.getHouses()

--- a/server/game/cards/04-MM/Mastermindy.js
+++ b/server/game/cards/04-MM/Mastermindy.js
@@ -7,7 +7,7 @@ class Mastermindy extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addSchemeCounter()
         });

--- a/server/game/cards/04-MM/MutagenicSerum.js
+++ b/server/game/cards/04-MM/MutagenicSerum.js
@@ -6,7 +6,7 @@ class MutagenicSerum extends Card {
         this.omni({
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse(
                         (card) => card.type === 'creature' && card.hasTrait('mutant')
                     )

--- a/server/game/cards/04-MM/MutationOfCunning.js
+++ b/server/game/cards/04-MM/MutationOfCunning.js
@@ -8,7 +8,7 @@ class MutationOfCunning extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilNextTurn',
+                    duration: 'untilPlayerNextTurnStart',
                     effect: [
                         ability.effects.addKeyword({ elusive: 1 }),
                         ability.effects.addTrait('mutant')

--- a/server/game/cards/04-MM/MutationOfFury.js
+++ b/server/game/cards/04-MM/MutationOfFury.js
@@ -8,7 +8,7 @@ class MutationOfFury extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilNextTurn',
+                    duration: 'untilPlayerNextTurnStart',
                     effect: [
                         ability.effects.addKeyword({ assault: 3 }),
                         ability.effects.addTrait('mutant')

--- a/server/game/cards/04-MM/MutationOfInstinct.js
+++ b/server/game/cards/04-MM/MutationOfInstinct.js
@@ -8,7 +8,7 @@ class MutationOfInstinct extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilNextTurn',
+                    duration: 'untilPlayerNextTurnStart',
                     effect: [
                         ability.effects.addKeyword({ skirmish: 1 }),
                         ability.effects.addTrait('mutant')

--- a/server/game/cards/04-MM/NovuDynamo.js
+++ b/server/game/cards/04-MM/NovuDynamo.js
@@ -5,7 +5,7 @@ class NovuDynamo extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             target: {
                 activePromptTitle: {

--- a/server/game/cards/04-MM/Pincerator.js
+++ b/server/game/cards/04-MM/Pincerator.js
@@ -5,7 +5,7 @@ class Pincerator extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: () => true
+                onTurnEnd: () => true
             },
             gameAction: ability.actions.dealDamage((context) => ({
                 amount: 1,

--- a/server/game/cards/04-MM/RecklessRizzo.js
+++ b/server/game/cards/04-MM/RecklessRizzo.js
@@ -8,7 +8,7 @@ class RecklessRizzo extends Card {
             gameAction: [
                 ability.actions.steal({ amount: 2 }),
                 ability.actions.cardLastingEffect({
-                    duration: 'untilNextTurn',
+                    duration: 'untilPlayerNextTurnStart',
                     effect: ability.effects.removeKeyword('elusive')
                 })
             ]

--- a/server/game/cards/04-MM/Sloth.js
+++ b/server/game/cards/04-MM/Sloth.js
@@ -5,7 +5,7 @@ class Sloth extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer &&
                     context.game.cardsUsed.filter((card) => card.type === 'creature').length === 0
             },

--- a/server/game/cards/04-MM/Snarette.js
+++ b/server/game/cards/04-MM/Snarette.js
@@ -6,7 +6,7 @@ class Snarette extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.capture({ amount: 1 })
         });

--- a/server/game/cards/04-MM/SubjectKirby.js
+++ b/server/game/cards/04-MM/SubjectKirby.js
@@ -7,7 +7,7 @@ class SubjectKirby extends Card {
             fight: true,
             reap: true,
             effect: 'allow them to play one non staralliance creature this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse({
                     house: 'staralliance',
                     condition: (card) => card.type === 'creature'

--- a/server/game/cards/04-MM/TeleporterChiefTink.js
+++ b/server/game/cards/04-MM/TeleporterChiefTink.js
@@ -12,7 +12,7 @@ class TeleporterChiefTink extends Card {
                 gameAction: ability.actions.swap()
             },
             effect: 'swap its position with {0}. You may use {0} this turn',
-            gameAction: ability.actions.forRemainderOfTurn((abilityContext) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((abilityContext) => ({
                 effect: ability.effects.canUse((card) => card === abilityContext.target)
             }))
         });

--- a/server/game/cards/04-MM/ThePaleStar.js
+++ b/server/game/cards/04-MM/ThePaleStar.js
@@ -7,7 +7,7 @@ class ThePaleStar extends Card {
             effect: 'make each creature to be 1 power and 0 amor',
             gameAction: [
                 ability.actions.destroy(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     targetController: 'any',
                     effect: [ability.effects.setPower(1), ability.effects.setArmor(0)]
                 })

--- a/server/game/cards/04-MM/WildBounty.js
+++ b/server/game/cards/04-MM/WildBounty.js
@@ -5,7 +5,7 @@ class WildBounty extends Card {
     // Play: The next time you play a card this turn, resolve each of its bonus icons an additional time.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source

--- a/server/game/cards/04-MM/ZWaveEmitter.js
+++ b/server/game/cards/04-MM/ZWaveEmitter.js
@@ -6,7 +6,7 @@ class ZWaveEmitter extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reaction', {
                 when: {
-                    onBeginRound: (_event, context) => context.player === context.game.activePlayer
+                    onTurnStart: (_event, context) => context.player === context.game.activePlayer
                 },
                 gameAction: ability.actions.ward()
             })

--- a/server/game/cards/05-DT/AmberVac.js
+++ b/server/game/cards/05-DT/AmberVac.js
@@ -7,7 +7,7 @@ class AmberVac extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reaction', {
                 when: {
-                    onBeginRound: (_event, context) => context.player === context.game.activePlayer
+                    onTurnStart: (_event, context) => context.player === context.game.activePlayer
                 },
                 gameAction: ability.actions.capture((context) => ({
                     target: context.source,

--- a/server/game/cards/05-DT/AmberfinShark.js
+++ b/server/game/cards/05-DT/AmberfinShark.js
@@ -10,7 +10,7 @@ class AmberfinShark extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.removePowerCounter(),
             then: {

--- a/server/game/cards/05-DT/AmberfinSharkEvilTwin.js
+++ b/server/game/cards/05-DT/AmberfinSharkEvilTwin.js
@@ -5,7 +5,7 @@ class AmberfinSharkEvilTwin extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: [
                 ability.actions.loseAmber((context) => ({

--- a/server/game/cards/05-DT/AvengingAura.js
+++ b/server/game/cards/05-DT/AvengingAura.js
@@ -7,7 +7,7 @@ class AvengingAura extends Card {
             effect: 'give each friendly creature assault {0} for the remainder of the turn',
             effectArgs: (context) =>
                 context.player.opponent ? context.player.opponent.getForgedKeys() : 0,
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 target: context.player.creaturesInPlay,
                 effect: ability.effects.addKeyword({
                     assault: context.player.opponent ? context.player.opponent.getForgedKeys() : 0

--- a/server/game/cards/05-DT/Bracchanalia.js
+++ b/server/game/cards/05-DT/Bracchanalia.js
@@ -17,7 +17,7 @@ class Bracchanalia extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.game.activePlayer &&
                     context.game.activePlayer.creaturesInPlay.filter((card) => card.amber).length >=
                         4

--- a/server/game/cards/05-DT/Ceaseforge.js
+++ b/server/game/cards/05-DT/Ceaseforge.js
@@ -14,7 +14,7 @@ class Ceaseforge extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (event, context) => context.player === this.game.activePlayer
+                onTurnStart: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.removeTimeCounter((context) => ({
                 target: context.source

--- a/server/game/cards/05-DT/DeadMansChest.js
+++ b/server/game/cards/05-DT/DeadMansChest.js
@@ -7,7 +7,7 @@ class DeadMansChest extends Card {
     setupCardAbilities(ability) {
         this.creatureDestroyed = [];
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onCardDestroyed']);
+        this.tracker.register(['onTurnEnd', 'onCardDestroyed']);
 
         this.play({
             target: {
@@ -37,7 +37,7 @@ class DeadMansChest extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creatureDestroyed = [];
     }
 

--- a/server/game/cards/05-DT/EclecticAmbrosius.js
+++ b/server/game/cards/05-DT/EclecticAmbrosius.js
@@ -6,7 +6,7 @@ class EclecticAmbrosius extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addKnowledgeCounter()
         });

--- a/server/game/cards/05-DT/FlashFreeze.js
+++ b/server/game/cards/05-DT/FlashFreeze.js
@@ -4,7 +4,7 @@ class FlashFreeze extends Card {
     // Play: For the remainder of the turn, after you play another card, exhaust a creature.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player && event.card !== context.source

--- a/server/game/cards/05-DT/KiligogSTrench.js
+++ b/server/game/cards/05-DT/KiligogSTrench.js
@@ -5,7 +5,7 @@ class KiligogSTrench extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addDepthCounter((context) => ({
                 target: context.source

--- a/server/game/cards/05-DT/Mechabuoy.js
+++ b/server/game/cards/05-DT/Mechabuoy.js
@@ -5,7 +5,7 @@ class Mechabuoy extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: () => this.game.activePlayer.isTideHigh()
+                onTurnStart: () => this.game.activePlayer.isTideHigh()
             },
             gameAction: ability.actions.gainAmber(() => ({
                 target: this.game.activePlayer

--- a/server/game/cards/05-DT/PrimalRelic.js
+++ b/server/game/cards/05-DT/PrimalRelic.js
@@ -20,7 +20,7 @@ class PrimalRelic extends Card {
         });
         this.reaction({
             when: {
-                onBeginRound: () => true
+                onTurnStart: () => true
             },
             gameAction: ability.actions.removeAmber({ all: true }),
             condition: (context) =>

--- a/server/game/cards/05-DT/Ransom.js
+++ b/server/game/cards/05-DT/Ransom.js
@@ -8,7 +8,7 @@ class Ransom extends Card {
                 ability.effects.cardCannot('use'),
                 ability.effects.gainAbility('reaction', {
                     when: {
-                        onBeginRound: (_event, context) =>
+                        onTurnStart: (_event, context) =>
                             context.player === context.game.activePlayer
                     },
                     condition: (context) => context.player.amber >= 2,

--- a/server/game/cards/05-DT/Science.js
+++ b/server/game/cards/05-DT/Science.js
@@ -4,7 +4,7 @@ class Science extends Card {
     // Play: For the remainder of the turn, after you play another action card, gain 1A .
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onCardPlayed: (event, context) =>
                         event.player === context.player &&

--- a/server/game/cards/05-DT/StaticCharge.js
+++ b/server/game/cards/05-DT/StaticCharge.js
@@ -6,7 +6,7 @@ class StaticCharge extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reaction', {
                 when: {
-                    onBeginRound: (_event, context) => context.player === context.game.activePlayer
+                    onTurnStart: (_event, context) => context.player === context.game.activePlayer
                 },
                 gameAction: ability.actions.dealDamage((context) => ({
                     amount: 2,

--- a/server/game/cards/05-DT/TideWarp.js
+++ b/server/game/cards/05-DT/TideWarp.js
@@ -5,7 +5,7 @@ class TideWarp extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.raiseTide((context) => ({
                 target: context.player.isTideHigh() ? context.player.opponent : context.player

--- a/server/game/cards/05-DT/TrialByWater.js
+++ b/server/game/cards/05-DT/TrialByWater.js
@@ -8,7 +8,7 @@ class TrialByWater extends Card {
             effectAlert: true,
             gameAction: [
                 ability.actions.resetTide(),
-                ability.actions.untilNextTurn({
+                ability.actions.untilPlayerNextTurnStart({
                     targetController: 'any',
                     effect: ability.effects.playerCannot('raiseTide')
                 })

--- a/server/game/cards/05-DT/Whirlpool.js
+++ b/server/game/cards/05-DT/Whirlpool.js
@@ -5,7 +5,7 @@ class Whirlpool extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => !!context.game.activePlayer.opponent
+                onTurnEnd: (event, context) => !!context.game.activePlayer.opponent
             },
             gameAction: [
                 ability.actions.cardLastingEffect((context) => ({

--- a/server/game/cards/06-WoE/CurseOfForgetfulness.js
+++ b/server/game/cards/06-WoE/CurseOfForgetfulness.js
@@ -13,7 +13,7 @@ class CurseOfForgetfulness extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.purge((context) => ({
                 target: context.player.discard[0]

--- a/server/game/cards/06-WoE/ExtrematodeInfection.js
+++ b/server/game/cards/06-WoE/ExtrematodeInfection.js
@@ -15,7 +15,7 @@ class ExtrematodeInfection extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (event, context) => context.player === this.game.activePlayer
+                onTurnStart: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.removeHatchCounter(() => ({
                 target: this

--- a/server/game/cards/06-WoE/FeatsOfStrength.js
+++ b/server/game/cards/06-WoE/FeatsOfStrength.js
@@ -7,7 +7,7 @@ class FeatsOfStrength extends Card {
         this.play({
             effect:
                 'make a token creature each time an enemy creature is destroyed in a fight for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardDestroyed: (event) =>
                         event.clone.type === 'creature' &&

--- a/server/game/cards/06-WoE/Freelancer.js
+++ b/server/game/cards/06-WoE/Freelancer.js
@@ -8,7 +8,7 @@ class Freelancer extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reaction', {
                 when: {
-                    onBeginRound: () => true
+                    onTurnStart: () => true
                 },
                 gameAction: ability.actions.cardLastingEffect((context) => ({
                     duration: 'lastingEffect',

--- a/server/game/cards/06-WoE/GezrahiBlacksmith.js
+++ b/server/game/cards/06-WoE/GezrahiBlacksmith.js
@@ -6,7 +6,7 @@ class GezrahiBlacksmith extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: () => true
+                onTurnStart: () => true
             },
             useEventPlayer: true,
             targets: {

--- a/server/game/cards/06-WoE/GreenAeronaut.js
+++ b/server/game/cards/06-WoE/GreenAeronaut.js
@@ -10,7 +10,7 @@ class GreenAeronaut extends Card {
                 controller: 'self',
                 cardCondition: (card) => card.name === 'Nautilixian',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilEndOfRound',
+                    duration: 'untilPlayerTurnEnd',
                     effect: ability.effects.addKeyword({ 'splash-attack': 3 })
                 })
             }

--- a/server/game/cards/06-WoE/Grondal.js
+++ b/server/game/cards/06-WoE/Grondal.js
@@ -11,7 +11,7 @@ class Grondal extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             target: {
                 mode: 'mostStat',

--- a/server/game/cards/06-WoE/KelpingHands.js
+++ b/server/game/cards/06-WoE/KelpingHands.js
@@ -8,7 +8,7 @@ class KelpingHands extends Card {
                 ability.actions.destroy((context) => ({
                     target: context.source
                 })),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     match: (card) => card.type === 'creature',
                     effect: ability.effects.addKeyword({
                         poison: 1

--- a/server/game/cards/06-WoE/Knightapult.js
+++ b/server/game/cards/06-WoE/Knightapult.js
@@ -11,7 +11,7 @@ class Knightapult extends Card {
                         onCardEntersPlay: (event) =>
                             event.card.type === 'creature' &&
                             event.context.game.activePlayer === event.card.controller,
-                        onRoundEnded: () => true
+                        onTurnEnd: () => true
                     },
                     multipleTrigger: false,
                     effect: [ability.effects.enterPlayAnywhere(), ability.effects.entersPlayReady()]

--- a/server/game/cards/06-WoE/MagistrateCrispus.js
+++ b/server/game/cards/06-WoE/MagistrateCrispus.js
@@ -6,7 +6,7 @@ class MagistrateCrispus extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.sequentialCardLastingEffect((context) => ({
                 forEach: context.game.cardsInPlay.filter(

--- a/server/game/cards/06-WoE/MirrorShell.js
+++ b/server/game/cards/06-WoE/MirrorShell.js
@@ -15,7 +15,7 @@ class MirrorShell extends Card {
             effect: ability.effects.gainAbility('fight', {
                 reap: true,
                 effect: 'make all friendly token creatures a copy of {0}',
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     controller: 'self',
                     match: (card) => card.isToken(),
                     effect: ability.effects.copyCard(context.source)

--- a/server/game/cards/06-WoE/Molluscaller.js
+++ b/server/game/cards/06-WoE/Molluscaller.js
@@ -7,7 +7,7 @@ class Molluscaller extends Card {
         this.reap({
             effect:
                 'cause all friendly Strange Shells to gain 3 power and lose their abilities for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.name === 'Strange Shell',
                 effect: [ability.effects.blank(), ability.effects.modifyPower(3)]
             })

--- a/server/game/cards/06-WoE/NirborFlamewing.js
+++ b/server/game/cards/06-WoE/NirborFlamewing.js
@@ -8,14 +8,14 @@ class NirborFlamewing extends Card {
     //
     // Destroyed: Make a token creature.
     setupCardAbilities(ability) {
-        this.leftPlaySinceStartOfRound = false;
+        this.leftPlaySinceStartOfTurn = false;
 
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onBeginRound', 'onCardLeavesPlay', 'onCardEntersPlay']);
+        this.tracker.register(['onTurnStart', 'onCardLeavesPlay', 'onCardEntersPlay']);
 
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             optional: true,
             location: 'discard',
@@ -35,7 +35,7 @@ class NirborFlamewing extends Card {
             }
         });
 
-        // If Nirbor enters the discard pile during the `onBeginRound`
+        // If Nirbor enters the discard pile during the `onTurnStart`
         // window (e.g., because another Nirbor Flamewing destroyed it, or
         // General Order 24, or something else that destroys creatures at the
         // "start of your turn", we can loop it back into play again by
@@ -43,14 +43,14 @@ class NirborFlamewing extends Card {
         //
         // It gets to have one instance of its resurrection ability
         // each time it re-enters the discard pile. (So, for instance, you
-        // shouldn't be able to pop a ward during `onBeginRound` and then
+        // shouldn't be able to pop a ward during `onTurnStart` and then
         // kill the same creature during `onFinalizeBeginRound` in order to
         // get resurrected.)  So each time it leaves play, it gets the ability,
         // and each time it re-enters play, it loses it again.
         this.interrupt({
             when: {
                 onFinalizeBeginRound: (_, context) =>
-                    context.player === this.game.activePlayer && this.leftPlaySinceStartOfRound
+                    context.player === this.game.activePlayer && this.leftPlaySinceStartOfTurn
             },
             optional: true,
             location: 'discard',
@@ -82,19 +82,19 @@ class NirborFlamewing extends Card {
         });
     }
 
-    onBeginRound() {
-        this.leftPlaySinceStartOfRound = false;
+    onTurnStart() {
+        this.leftPlaySinceStartOfTurn = false;
     }
 
     onCardLeavesPlay(event) {
         if (event.card === this) {
-            this.leftPlaySinceStartOfRound = true;
+            this.leftPlaySinceStartOfTurn = true;
         }
     }
 
     onCardEntersPlay(event) {
         if (event.card === this) {
-            this.leftPlaySinceStartOfRound = false;
+            this.leftPlaySinceStartOfTurn = false;
         }
     }
 }

--- a/server/game/cards/06-WoE/PhalanxLeader.js
+++ b/server/game/cards/06-WoE/PhalanxLeader.js
@@ -12,7 +12,7 @@ class PhalanxLeader extends Card {
 
         this.fight({
             reap: true,
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 controller: 'self',
                 match: (card) =>
                     context.player.creaturesInPlay.indexOf(card) <

--- a/server/game/cards/06-WoE/PressGang.js
+++ b/server/game/cards/06-WoE/PressGang.js
@@ -12,7 +12,7 @@ class PressGang extends Card {
         }
 
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onCardDestroyed', 'onBeginRound']);
+        this.tracker.register(['onCardDestroyed', 'onTurnStart']);
 
         this.play({
             gameAction: ability.actions.sequential([
@@ -41,7 +41,7 @@ class PressGang extends Card {
         }
     }
 
-    onBeginRound() {
+    onTurnStart() {
         this.creaturesDestroyed[this.game.activePlayer.uuid] = 0;
         if (this.game.activePlayer.opponent) {
             this.creaturesDestroyed[this.game.activePlayer.opponent.uuid] = 0;

--- a/server/game/cards/06-WoE/PrimordialVault.js
+++ b/server/game/cards/06-WoE/PrimordialVault.js
@@ -9,7 +9,7 @@ class PrimordialVault extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.player === this.game.activePlayer &&
                     !!context.player.tokenCard &&
                     context.player.tokenCard.name === 'Cultist'

--- a/server/game/cards/06-WoE/RedAeronaut.js
+++ b/server/game/cards/06-WoE/RedAeronaut.js
@@ -26,7 +26,7 @@ class RedAeronaut extends Card {
                 controller: 'self',
                 cardCondition: (card) => card.name === 'Nautilixian',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilEndOfRound',
+                    duration: 'untilPlayerTurnEnd',
                     effect: ability.effects.modifyPower(5)
                 })
             }

--- a/server/game/cards/06-WoE/SV3Lander.js
+++ b/server/game/cards/06-WoE/SV3Lander.js
@@ -13,7 +13,7 @@ class SV3Lander extends Card {
         this.omni({
             gameAction: [
                 ability.actions.sacrifice(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse(
                         (card) => card.type === 'creature' && card.isToken()
                     )

--- a/server/game/cards/06-WoE/SibylWaimare.js
+++ b/server/game/cards/06-WoE/SibylWaimare.js
@@ -6,7 +6,7 @@ class SibylWaimare extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.player.opponent === this.game.activePlayer &&
                     context.player.opponent.deck.length > 0
             },

--- a/server/game/cards/06-WoE/StaffUp.js
+++ b/server/game/cards/06-WoE/StaffUp.js
@@ -5,7 +5,7 @@ class StaffUp extends Card {
     // would be added to your pool, make that many token creatures instead.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onModifyAmber: (event, context) =>
                         event.player === context.player && event.amount > 0 && !event.loseAmber

--- a/server/game/cards/06-WoE/TheGrandGord.js
+++ b/server/game/cards/06-WoE/TheGrandGord.js
@@ -7,7 +7,7 @@ class TheGrandGord extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => {
+                onTurnStart: (_, context) => {
                     if (context.player !== this.game.activePlayer) {
                         return false;
                     }

--- a/server/game/cards/06-WoE/ThePromisedBlade.js
+++ b/server/game/cards/06-WoE/ThePromisedBlade.js
@@ -7,7 +7,7 @@ class ThePromisedBlade extends Card {
     setupCardAbilities(ability) {
         this.movedThisRound = false;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded']);
+        this.tracker.register(['onTurnEnd']);
 
         this.omni({
             target: {
@@ -22,7 +22,7 @@ class ThePromisedBlade extends Card {
         // Even creature count, active player chooses
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     !!context.source.controller.opponent &&
                     !this.movedThisRound &&
                     context.source.controller.creaturesInPlay.length ===
@@ -64,7 +64,7 @@ class ThePromisedBlade extends Card {
         // Uneven creature count, automatic
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     !!context.source.controller.opponent &&
                     !this.movedThisRound &&
                     context.source.controller.creaturesInPlay.length >
@@ -81,7 +81,7 @@ class ThePromisedBlade extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.movedThisRound = false;
     }
 }

--- a/server/game/cards/07-GR/AncestralTimekeeper.js
+++ b/server/game/cards/07-GR/AncestralTimekeeper.js
@@ -8,7 +8,7 @@ class AncestralTimekeeper extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addTimeCounter((context) => ({
                 target: context.source.controller.creaturesInPlay.filter((c) => c.hasTrait('clock'))
@@ -20,7 +20,7 @@ class AncestralTimekeeper extends Card {
                 })),
                 then: {
                     message: '{0} uses {1} to take another turn after this one',
-                    gameAction: ability.actions.forRemainderOfTurn({
+                    gameAction: ability.actions.untilPlayerTurnEnd({
                         effect: ability.effects.anotherTurn()
                     })
                 }

--- a/server/game/cards/07-GR/BrawlingGrounds.js
+++ b/server/game/cards/07-GR/BrawlingGrounds.js
@@ -8,7 +8,7 @@ class BrawlingGrounds extends Card {
         this.omni({
             effect:
                 'make the controller of each creature destroyed in a fight this turn discard a card at random for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onCardDestroyed: (event) =>
                         event.clone.type === 'creature' &&

--- a/server/game/cards/07-GR/Chronometer.js
+++ b/server/game/cards/07-GR/Chronometer.js
@@ -7,7 +7,7 @@ class Chronometer extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addTimeCounter((context) => ({
                 target: context.source.controller.creaturesInPlay.filter((c) => c.hasTrait('clock'))

--- a/server/game/cards/07-GR/CorporalBridger.js
+++ b/server/game/cards/07-GR/CorporalBridger.js
@@ -8,7 +8,7 @@ class CorporalBridger extends Card {
             fight: true,
             reap: true,
             effect: 'allow them to use one non staralliance creature this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canUseNonHouseCreature('staralliance')
             })
         });

--- a/server/game/cards/07-GR/CurseOfConfusion.js
+++ b/server/game/cards/07-GR/CurseOfConfusion.js
@@ -8,7 +8,7 @@ class CurseOfConfusion extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.exhaust((context) => ({
                 target: context.player.creaturesInPlay.filter((card) =>

--- a/server/game/cards/07-GR/CurseOfCowardice.js
+++ b/server/game/cards/07-GR/CurseOfCowardice.js
@@ -10,11 +10,11 @@ class CurseOfCowardice extends Card {
     setupCardAbilities(ability) {
         this.fights = 0;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onFight', 'onRoundEnded']);
+        this.tracker.register(['onFight', 'onTurnEnd']);
 
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.loseAmber((context) => ({
                 target: context.player,
@@ -33,7 +33,7 @@ class CurseOfCowardice extends Card {
         this.fights++;
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.fights = 0;
     }
 }

--- a/server/game/cards/07-GR/CurseOfDisappearances.js
+++ b/server/game/cards/07-GR/CurseOfDisappearances.js
@@ -9,7 +9,7 @@ class CurseOfDisappearances extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             condition: (context) => !!context.player.opponent,
             gameAction: ability.actions.archive((context) => ({

--- a/server/game/cards/07-GR/CurseOfFertility.js
+++ b/server/game/cards/07-GR/CurseOfFertility.js
@@ -8,7 +8,7 @@ class CurseOfFertility extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) =>
+                onTurnEnd: (_, context) =>
                     context.player === this.game.activePlayer &&
                     !!context.player.opponent &&
                     this.game.cardsPlayed.filter((card) => card.type === 'creature').length === 0

--- a/server/game/cards/07-GR/CurseOfObstinacy.js
+++ b/server/game/cards/07-GR/CurseOfObstinacy.js
@@ -8,7 +8,7 @@ class CurseOfObstinacy extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.stun((context) => ({
                 target: context.player.creaturesInPlay.filter(

--- a/server/game/cards/07-GR/DarkMemento.js
+++ b/server/game/cards/07-GR/DarkMemento.js
@@ -9,7 +9,7 @@ class DarkMemento extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.player === this.game.activePlayer && !context.player.isHaunted()
             },
             condition: (context) => context.player.deck.length > 0,

--- a/server/game/cards/07-GR/Dredge.js
+++ b/server/game/cards/07-GR/Dredge.js
@@ -8,7 +8,7 @@ class Dredge extends Card {
         this.play({
             effect:
                 "give each friendly creature 'Reap: Return a card from your discard pile to the top of your deck' for the remainder of the turn",
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('reap', {
                     target: {

--- a/server/game/cards/07-GR/EkwirresFulcrum.js
+++ b/server/game/cards/07-GR/EkwirresFulcrum.js
@@ -6,7 +6,7 @@ class EkwirresFulcrum extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: () => true
+                onTurnEnd: () => true
             },
             useEventPlayer: true,
             optional: true,

--- a/server/game/cards/07-GR/HauntedHouse.js
+++ b/server/game/cards/07-GR/HauntedHouse.js
@@ -8,7 +8,7 @@ class HauntedHouse extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.player === this.game.activePlayer &&
                     context.player.deck.length > 0 &&
                     !context.player.isHaunted()

--- a/server/game/cards/07-GR/Infiltrator.js
+++ b/server/game/cards/07-GR/Infiltrator.js
@@ -7,7 +7,7 @@ class Infiltrator extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.destroy((context) => ({
                 target: context.source.neighbors

--- a/server/game/cards/07-GR/LoyaltyImplants.js
+++ b/server/game/cards/07-GR/LoyaltyImplants.js
@@ -8,7 +8,7 @@ class LoyaltyImplants extends Card {
             effect: 'destroy {0} and use friendly Mars creatures this turn',
             gameAction: [
                 ability.actions.destroy(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canUse(
                         (card) => card.hasHouse('mars') && card.type === 'creature'
                     )

--- a/server/game/cards/07-GR/MissileOfficerMyers.js
+++ b/server/game/cards/07-GR/MissileOfficerMyers.js
@@ -21,7 +21,7 @@ class MissileOfficerMyers extends Card {
 
         this.scrap({
             effect: 'play 1 card that is not of the active house during their turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 effect: ability.effects.canPlayNonHouse(context.player.activeHouse)
             }))
         });

--- a/server/game/cards/07-GR/ModularExoskeleton.js
+++ b/server/game/cards/07-GR/ModularExoskeleton.js
@@ -12,7 +12,7 @@ class ModularExoskeleton extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             optional: true,
             location: 'discard',

--- a/server/game/cards/07-GR/MultiDimensionalRescue.js
+++ b/server/game/cards/07-GR/MultiDimensionalRescue.js
@@ -38,7 +38,7 @@ class MultiDimensionalRescue extends Card {
             effectArgs: (context) => [Object.values(context.targets)],
             then: {
                 alwaysTriggers: true,
-                gameAction: ability.actions.forRemainderOfTurn({
+                gameAction: ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.canPlayNonHouse('staralliance')
                 }),
                 then: {

--- a/server/game/cards/07-GR/PlagueWind.js
+++ b/server/game/cards/07-GR/PlagueWind.js
@@ -5,7 +5,7 @@ class PlagueWind extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'give each non-Mars creatures -3 power until the end of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'any',
                 match: (card) => !card.hasHouse('mars'),
                 effect: ability.effects.modifyPower(-3)

--- a/server/game/cards/07-GR/Plan10.js
+++ b/server/game/cards/07-GR/Plan10.js
@@ -16,7 +16,7 @@ class Plan10 extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: () => true
+                onTurnEnd: () => true
             },
             useEventPlayer: true,
             target: {

--- a/server/game/cards/07-GR/PrototypeHarness.js
+++ b/server/game/cards/07-GR/PrototypeHarness.js
@@ -9,7 +9,7 @@ class PrototypeHarness extends Card {
                 ability.effects.modifyPower(6),
                 ability.effects.gainAbility('reaction', {
                     when: {
-                        onBeginRound: (_event, context) =>
+                        onTurnStart: (_event, context) =>
                             context.player === context.game.activePlayer
                     },
                     gameAction: ability.actions.dealDamage((context) => ({

--- a/server/game/cards/07-GR/RaiderOfThePeaks.js
+++ b/server/game/cards/07-GR/RaiderOfThePeaks.js
@@ -6,7 +6,7 @@ class RaiderOfThePeaks extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             target: {
                 mode: 'mostStat',

--- a/server/game/cards/07-GR/ReplicativeGrowth.js
+++ b/server/game/cards/07-GR/ReplicativeGrowth.js
@@ -8,7 +8,7 @@ class ReplicativeGrowth extends Card {
         this.play({
             effect:
                 "give each friendly creature 'Reap: Move 1 amber from this creature to your pool' for the remainder of the turn",
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('reap', {
                     gameAction: ability.actions.removeAmber(),

--- a/server/game/cards/07-GR/Rotfeast.js
+++ b/server/game/cards/07-GR/Rotfeast.js
@@ -7,7 +7,7 @@ class Rotfeast extends Card {
         this.play({
             effect:
                 'gain 1 amber each time a creature is dealt damage for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onDamageApplied: (event) => event.amount > 0
                 },

--- a/server/game/cards/07-GR/SingingScythe.js
+++ b/server/game/cards/07-GR/SingingScythe.js
@@ -21,9 +21,9 @@ class SingingScythe extends Card {
         // choice.
         this.reaction({
             when: {
-                onBeginRound: (event, context) =>
+                onTurnStart: (event, context) =>
                     event.player === context.player && context.player.isHaunted(),
-                onPhaseEnded: (event, context) =>
+                onPhaseEnd: (event, context) =>
                     event.phase === 'draw' &&
                     this.game.activePlayer === context.player &&
                     context.player.isHaunted()

--- a/server/game/cards/07-GR/TachyonManifold.js
+++ b/server/game/cards/07-GR/TachyonManifold.js
@@ -8,7 +8,7 @@ class TachyonManifold extends Card {
             effect: 'take another turn after this one and purge {0}',
             effectAlert: true,
             gameAction: [
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     effect: ability.effects.anotherTurn()
                 }),
                 ability.actions.conditional((context) => ({

--- a/server/game/cards/07-GR/TheBodySnatchers.js
+++ b/server/game/cards/07-GR/TheBodySnatchers.js
@@ -8,7 +8,7 @@ class TheBodySnatchers extends Card {
         this.play({
             effect:
                 "give each enemy creature 'Destroyed: Fully heal this creature and give control of it to your opponent instead' for the remainder of the turn",
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('destroyed', {

--- a/server/game/cards/07-GR/TickTock.js
+++ b/server/game/cards/07-GR/TickTock.js
@@ -8,7 +8,7 @@ class TickTock extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addTimeCounter((context) => ({
                 target: context.source.controller.creaturesInPlay.filter((c) => c.hasTrait('clock'))

--- a/server/game/cards/08-AS/AerialPedlar.js
+++ b/server/game/cards/08-AS/AerialPedlar.js
@@ -17,7 +17,7 @@ class AerialPedlar extends Card {
                         duration: 'lastingEffect',
                         effect: ability.effects.takeControl(context.player)
                     })),
-                    ability.actions.forRemainderOfTurn((context) => ({
+                    ability.actions.untilPlayerTurnEnd((context) => ({
                         effect: ability.effects.canUse(
                             (card) => context.target && context.target.includes(card)
                         )

--- a/server/game/cards/08-AS/ArticulatedRen.js
+++ b/server/game/cards/08-AS/ArticulatedRen.js
@@ -6,7 +6,7 @@ class ArticulatedRen extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             target: {
                 optional: true,

--- a/server/game/cards/08-AS/AtomicDestabilizer.js
+++ b/server/game/cards/08-AS/AtomicDestabilizer.js
@@ -7,7 +7,7 @@ class AtomicDestabilizer extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('interrupt', {
                 when: {
-                    onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                    onTurnEnd: (_, context) => context.player === this.game.activePlayer
                 },
                 gameAction: ability.actions.capture({
                     amount: 1

--- a/server/game/cards/08-AS/Beehemoth.js
+++ b/server/game/cards/08-AS/Beehemoth.js
@@ -8,7 +8,7 @@ class Beehemoth extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             target: {
                 cardType: 'creature',

--- a/server/game/cards/08-AS/CmdPrompt.js
+++ b/server/game/cards/08-AS/CmdPrompt.js
@@ -5,7 +5,7 @@ class CmdPrompt extends Card {
     setupCardAbilities(ability) {
         this.reap({
             effect: 'allow them to play one non-Logos card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayNonHouse('logos')
             })
         });

--- a/server/game/cards/08-AS/ContractExecution.js
+++ b/server/game/cards/08-AS/ContractExecution.js
@@ -7,7 +7,7 @@ class ContractExecution extends Card {
         this.play({
             effect:
                 'deal 2 damage to a creature after playing a creature for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player &&

--- a/server/game/cards/08-AS/Doppelganger.js
+++ b/server/game/cards/08-AS/Doppelganger.js
@@ -7,7 +7,7 @@ class Doppelganger extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             // The card doesn't say this ability it optional, but 2
             // next to each other leads to an infinite loop that can't

--- a/server/game/cards/08-AS/EldestBatchminder.js
+++ b/server/game/cards/08-AS/EldestBatchminder.js
@@ -6,7 +6,7 @@ class EldestBatchminder extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.addPowerCounter((context) => ({
                 target: context.game.creaturesInPlay.filter(

--- a/server/game/cards/08-AS/ImprovisedAviation.js
+++ b/server/game/cards/08-AS/ImprovisedAviation.js
@@ -13,7 +13,7 @@ class ImprovisedAviation extends Card {
                         onCardEntersPlay: (event) =>
                             event.card.type === 'creature' &&
                             event.context.game.activePlayer === event.card.controller,
-                        onRoundEnded: () => true
+                        onTurnEnd: () => true
                     },
                     multipleTrigger: false,
                     effect: [
@@ -25,7 +25,7 @@ class ImprovisedAviation extends Card {
                         // is entering play, and let it last for the rest of
                         // the round.
                         ability.effects.entersPlayWithEffect({
-                            duration: 'untilEndOfRound',
+                            duration: 'untilPlayerTurnEnd',
                             builder: () =>
                                 ability.effects.gainAbility('fight', {
                                     target: {

--- a/server/game/cards/08-AS/Incensed.js
+++ b/server/game/cards/08-AS/Incensed.js
@@ -7,7 +7,7 @@ class Incensed extends Card {
         this.play({
             effect:
                 "give each friendly creature 'After Fight: Gain 1 amber' for the remainder of the turn",
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.gainAbility('fight', {
                     gameAction: ability.actions.gainAmber()

--- a/server/game/cards/08-AS/LateralThrusters.js
+++ b/server/game/cards/08-AS/LateralThrusters.js
@@ -7,7 +7,7 @@ class LateralThrusters extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reaction', {
                 when: {
-                    onBeginRound: (_event, context) => context.player === context.game.activePlayer
+                    onTurnStart: (_event, context) => context.player === context.game.activePlayer
                 },
                 gameAction: ability.actions.rearrangeBattleline((context) => ({
                     player: context.player

--- a/server/game/cards/08-AS/MalifiDragon.js
+++ b/server/game/cards/08-AS/MalifiDragon.js
@@ -5,7 +5,7 @@ class MalifiDragon extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer && context.player.amber <= 4
             },
             gameAction: ability.actions.gainAmber({ amount: 2 })

--- a/server/game/cards/08-AS/Phantasmaquid.js
+++ b/server/game/cards/08-AS/Phantasmaquid.js
@@ -24,7 +24,7 @@ class Phantasmaquid extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             condition: (context) =>
                 !context.player.opponent || context.player.opponent.creaturesInPlay.length === 0,

--- a/server/game/cards/08-AS/Screeyan.js
+++ b/server/game/cards/08-AS/Screeyan.js
@@ -7,7 +7,7 @@ class Screeyan extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.player === this.game.activePlayer && context.player.opponent
             },
             gameAction: ability.actions.discard((context) => ({

--- a/server/game/cards/08-AS/TorpefyingHarpoon.js
+++ b/server/game/cards/08-AS/TorpefyingHarpoon.js
@@ -7,7 +7,7 @@ class TorpefyingHarpoon extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('interrupt', {
                 when: {
-                    onRoundEnded: (_event, context) =>
+                    onTurnEnd: (_event, context) =>
                         context.player === context.game.activePlayer && !context.source.isOnFlank()
                 },
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/08-AS/TyrannusAquilae.js
+++ b/server/game/cards/08-AS/TyrannusAquilae.js
@@ -6,7 +6,7 @@ class TyrannusAquilae extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: () => true
+                onTurnEnd: () => true
             },
             gameAction: ability.actions.capture()
         });

--- a/server/game/cards/08-AS/VoidShields.js
+++ b/server/game/cards/08-AS/VoidShields.js
@@ -6,7 +6,7 @@ class VoidShields extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('interrupt', {
                 when: {
-                    onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                    onTurnEnd: (_, context) => context.player === this.game.activePlayer
                 },
                 gameAction: ability.actions.ward()
             })

--- a/server/game/cards/09-ToC/BeyondAllDarkness.js
+++ b/server/game/cards/09-ToC/BeyondAllDarkness.js
@@ -7,7 +7,7 @@ class BeyondAllDarkness extends Card {
         this.play({
             effect:
                 'make a token creature when a creature is destroyed for the remained of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onCardDestroyed: (event) => event.clone.type === 'creature'
                 },

--- a/server/game/cards/09-ToC/NiffleSanctuary.js
+++ b/server/game/cards/09-ToC/NiffleSanctuary.js
@@ -20,7 +20,7 @@ class NiffleSanctuary extends Card {
                 alwaysTriggers: true,
                 message:
                     '{0} uses {1} to make each friendly Niffle Brute gain "After Fight: Gain 1 amber" for the rest of the turn',
-                gameAction: ability.actions.forRemainderOfTurn({
+                gameAction: ability.actions.untilPlayerTurnEnd({
                     targetController: 'current',
                     match: (card) => card.name === 'Niffle Brute',
                     effect: ability.effects.gainAbility('fight', {

--- a/server/game/cards/09-ToC/SneakyFeats.js
+++ b/server/game/cards/09-ToC/SneakyFeats.js
@@ -7,7 +7,7 @@ class SneakyFeats extends Card {
     setupCardAbilities(ability) {
         this.activePlayerStoleAmber = false;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onStealAmber', { 'onRoundEnded:preResolution': 'onRoundEnded' }]);
+        this.tracker.register(['onStealAmber', { 'onTurnEnd:preResolution': 'onTurnEnd' }]);
 
         this.play({
             gameAction: ability.actions.makeTokenCreature(),
@@ -30,7 +30,7 @@ class SneakyFeats extends Card {
         }
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.activePlayerStoleAmber = false;
     }
 }

--- a/server/game/cards/09-ToC/Unbinding.js
+++ b/server/game/cards/09-ToC/Unbinding.js
@@ -7,7 +7,7 @@ class Unbinding extends Card {
     setupCardAbilities(ability) {
         this.creatureDestroyedControllerUuid = {};
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onCardDestroyed']);
+        this.tracker.register(['onTurnEnd', 'onCardDestroyed']);
 
         this.play({
             gameAction: ability.actions.sequential([
@@ -29,7 +29,7 @@ class Unbinding extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creatureDestroyedControllerUuid = {};
     }
 

--- a/server/game/cards/10-MoMu/J43G3RV.js
+++ b/server/game/cards/10-MoMu/J43G3RV.js
@@ -15,7 +15,7 @@ class J43G3RV extends GiganticCard {
 
         this.reap({
             effect: 'allow them to reap with up to 2 non staralliance card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: [
                     ability.effects.canReapNonHouse('staralliance'),
                     ability.effects.canReapNonHouse('staralliance')
@@ -25,7 +25,7 @@ class J43G3RV extends GiganticCard {
 
         this.fight({
             effect: 'allow them to fight with up to 2 non staralliance card this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: [
                     ability.effects.canFightNonHouse('staralliance'),
                     ability.effects.canFightNonHouse('staralliance')

--- a/server/game/cards/11-VM25/TheConstant.js
+++ b/server/game/cards/11-VM25/TheConstant.js
@@ -14,7 +14,7 @@ class TheConstant extends Card {
 
         this.reaction({
             when: {
-                onBeginRound: (event, context) => context.player === this.game.activePlayer
+                onTurnStart: (event, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.removeTimeCounter((context) => ({
                 target: context.source

--- a/server/game/cards/11-VM25/ThermalDepletion.js
+++ b/server/game/cards/11-VM25/ThermalDepletion.js
@@ -5,7 +5,7 @@ class ThermalDepletion extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'prevent creatures from readying until the start of their next turn',
-            gameAction: ability.actions.untilNextTurn({
+            gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'any',
                 effect: ability.effects.cardCannot('ready')
             })

--- a/server/game/cards/11-VM25/TreokTheWise.js
+++ b/server/game/cards/11-VM25/TreokTheWise.js
@@ -7,7 +7,7 @@ class TreokTheWise extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.cardLastingEffect({
-                    duration: 'untilNextTurn',
+                    duration: 'untilPlayerNextTurnStart',
                     effect: ability.effects.addKeyword({ invulnerable: 1 })
                 })
             },

--- a/server/game/cards/12-PV/Atrocity.js
+++ b/server/game/cards/12-PV/Atrocity.js
@@ -7,7 +7,7 @@ class Atrocity extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) =>
+                onTurnStart: (_, context) =>
                     context.source.controller.opponent === context.game.activePlayer
             },
             gameAction: [
@@ -30,7 +30,7 @@ class Atrocity extends Card {
             ],
             then: {
                 alwaysTriggers: true,
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     targetController: 'opponent',
                     effect: ability.effects.restrictHouseChoice(
                         context.preThenEvents.length > 1 && context.preThenEvents[0].card

--- a/server/game/cards/12-PV/Azrael.js
+++ b/server/game/cards/12-PV/Azrael.js
@@ -5,7 +5,7 @@ class Azrael extends Card {
     setupCardAbilities(ability) {
         this.reap({
             effect: 'allow each friendly creature to fight until the end of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canFight(() => true)
             })
         });

--- a/server/game/cards/12-PV/BadOmen.js
+++ b/server/game/cards/12-PV/BadOmen.js
@@ -5,7 +5,7 @@ class BadOmen extends Card {
     setupCardAbilities(ability) {
         this.prophecyInterrupt({
             when: {
-                onRoundEnded: (_, context) =>
+                onTurnEnd: (_, context) =>
                     this.game.activePlayer === context.source.controller.opponent &&
                     this.game.activePlayer.amber === 6
             },

--- a/server/game/cards/12-PV/BanditCulver.js
+++ b/server/game/cards/12-PV/BanditCulver.js
@@ -7,7 +7,7 @@ class BanditCulver extends Card {
     setupCardAbilities(ability) {
         this.shadowsCardDiscarded = undefined;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onBeginRound', 'onCardDiscarded']);
+        this.tracker.register(['onTurnStart', 'onCardDiscarded']);
 
         this.reaction({
             when: {
@@ -30,7 +30,7 @@ class BanditCulver extends Card {
         }
     }
 
-    onBeginRound() {
+    onTurnStart() {
         this.shadowsCardDiscarded = undefined;
     }
 }

--- a/server/game/cards/12-PV/BrassKlein.js
+++ b/server/game/cards/12-PV/BrassKlein.js
@@ -16,7 +16,7 @@ class BrassKlein extends Card {
         });
 
         this.fate({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 effect: ability.effects.cardCannot('fight')
             })

--- a/server/game/cards/12-PV/CosmicRecompense.js
+++ b/server/game/cards/12-PV/CosmicRecompense.js
@@ -49,7 +49,7 @@ class CosmicRecompense extends Card {
 
         this.fate({
             effect: 'prevent playing, using, or discarding cards for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 effect: [
                     ability.effects.playerCannot('play'),

--- a/server/game/cards/12-PV/CrystallineHarvest.js
+++ b/server/game/cards/12-PV/CrystallineHarvest.js
@@ -5,7 +5,7 @@ class CrystallineHarvest extends Card {
     // Fate: For the remainder of the turn, lose 1 amber each time you play an action card.
     setupCardAbilities(ability) {
         this.play({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onCardPlayed: (event, context) =>
                         event.player === context.player && event.card.type === 'action'
@@ -15,7 +15,7 @@ class CrystallineHarvest extends Card {
         });
 
         this.fate({
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onCardPlayed: (event, context) =>
                         event.player === context.game.activePlayer && event.card.type === 'action'

--- a/server/game/cards/12-PV/EnviousVenomite.js
+++ b/server/game/cards/12-PV/EnviousVenomite.js
@@ -12,7 +12,7 @@ class EnviousVenomite extends Card {
         });
 
         this.fate({
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 match: (card) =>
                     card.type === 'creature' && card.controller !== context.game.activePlayer,
                 effect: ability.effects.addKeyword({

--- a/server/game/cards/12-PV/EvasiveManeuvers.js
+++ b/server/game/cards/12-PV/EvasiveManeuvers.js
@@ -6,7 +6,7 @@ class EvasiveManeuvers extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'prevent friendly creatures from taking damage for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'current',
                 effect: ability.effects.cardCannot('damage')
             })

--- a/server/game/cards/12-PV/ExoticPivot.js
+++ b/server/game/cards/12-PV/ExoticPivot.js
@@ -18,7 +18,7 @@ class ExoticPivot extends Card {
 
         this.fate({
             effect: 'prevent creatures from being played this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 effect: ability.effects.playerCannot(
                     'play',

--- a/server/game/cards/12-PV/Flarie.js
+++ b/server/game/cards/12-PV/Flarie.js
@@ -5,7 +5,7 @@ class Flarie extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onBeginRound: (_, context) => context.player === this.game.activePlayer
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
             gameAction: ability.actions.gainAmber()
         });

--- a/server/game/cards/12-PV/GarnetSquire.js
+++ b/server/game/cards/12-PV/GarnetSquire.js
@@ -6,7 +6,7 @@ class GarnetSquire extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) => context.player === this.game.activePlayer
+                onTurnEnd: (_, context) => context.player === this.game.activePlayer
             },
             condition: (context) => context.source.tokens.damage > 0,
             gameAction: ability.actions.heal({ amount: 1 }),

--- a/server/game/cards/12-PV/GonePearShaped.js
+++ b/server/game/cards/12-PV/GonePearShaped.js
@@ -15,7 +15,7 @@ class GonePearShaped extends Card {
 
         this.fate({
             effect: 'prevent creatures from reaping for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 effect: ability.effects.cardCannot('reap')
             })

--- a/server/game/cards/12-PV/HeadsIWin.js
+++ b/server/game/cards/12-PV/HeadsIWin.js
@@ -6,7 +6,7 @@ class HeadsIWin extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) =>
+                onTurnEnd: (_, context) =>
                     context.player === this.game.activePlayer && context.source.activeProphecy
             },
             location: 'any',

--- a/server/game/cards/12-PV/PoisedStrike.js
+++ b/server/game/cards/12-PV/PoisedStrike.js
@@ -13,7 +13,7 @@ class PoisedStrike extends Card {
         });
 
         this.fate({
-            gameAction: ability.actions.forRemainderOfTurn(() => ({
+            gameAction: ability.actions.untilPlayerTurnEnd(() => ({
                 targetController: 'player',
                 effect: ability.effects.doesNotReady()
             }))

--- a/server/game/cards/12-PV/PubliusScipio.js
+++ b/server/game/cards/12-PV/PubliusScipio.js
@@ -6,7 +6,7 @@ class PubliusScipio extends Card {
     setupCardAbilities(ability) {
         this.fate({
             effect: 'deal 4 damage to neighbors of friendly creatures used this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 when: {
                     onUseCard: (event, context) =>
                         event.card.type === 'creature' &&

--- a/server/game/cards/12-PV/RackOfRedemption.js
+++ b/server/game/cards/12-PV/RackOfRedemption.js
@@ -6,7 +6,7 @@ class RackOfRedemption extends Card {
     setupCardAbilities(ability) {
         this.mutantDestroyed = undefined;
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onBeginRound', 'onCardDestroyed']);
+        this.tracker.register(['onTurnStart', 'onCardDestroyed']);
 
         this.reaction({
             when: {
@@ -31,7 +31,7 @@ class RackOfRedemption extends Card {
         });
     }
 
-    onBeginRound() {
+    onTurnStart() {
         this.mutantDestroyed = undefined;
     }
 

--- a/server/game/cards/12-PV/SignsPointToYes.js
+++ b/server/game/cards/12-PV/SignsPointToYes.js
@@ -5,7 +5,7 @@ class SignsPointToYes extends Card {
     setupCardAbilities(ability) {
         this.prophecyInterrupt({
             when: {
-                onRoundEnded: (_, context) =>
+                onTurnEnd: (_, context) =>
                     this.game.activePlayer === context.source.controller.opponent &&
                     this.game.activePlayer.amber >= this.game.activePlayer.getCurrentKeyCost()
             },

--- a/server/game/cards/12-PV/StarsAligned.js
+++ b/server/game/cards/12-PV/StarsAligned.js
@@ -5,7 +5,7 @@ class StarsAligned extends Card {
     setupCardAbilities(ability) {
         this.prophecyReaction({
             when: {
-                onBeginRound: (event, context) =>
+                onTurnStart: (event, context) =>
                     context.game.activePlayer === context.source.controller.opponent &&
                     context.game
                         .getPlayers()

--- a/server/game/cards/12-PV/StrategicFeint.js
+++ b/server/game/cards/12-PV/StrategicFeint.js
@@ -22,7 +22,7 @@ class StrategicFeint extends Card {
             })),
             then: {
                 condition: (context) => !!context.preThenEvent.card,
-                gameAction: ability.actions.forRemainderOfTurn((context) => ({
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                     targetController: 'opponent',
                     effect: ability.effects.playerCannot(
                         'play',

--- a/server/game/cards/12-PV/TailsYouLose.js
+++ b/server/game/cards/12-PV/TailsYouLose.js
@@ -6,7 +6,7 @@ class TailsYouLose extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (_, context) =>
+                onTurnEnd: (_, context) =>
                     context.player === this.game.activePlayer && context.source.activeProphecy
             },
             location: 'any',

--- a/server/game/cards/12-PV/TheEarlyBird.js
+++ b/server/game/cards/12-PV/TheEarlyBird.js
@@ -5,7 +5,7 @@ class TheEarlyBird extends Card {
     setupCardAbilities(ability) {
         this.prophecyInterrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.game.activePlayer === context.source.controller.opponent &&
                     context.game.activePlayer.amber > context.source.controller.amber
             },

--- a/server/game/cards/12-PV/TheEndIsNigh.js
+++ b/server/game/cards/12-PV/TheEndIsNigh.js
@@ -7,7 +7,7 @@ class TheEndIsNigh extends Card {
         this.creaturesDestroyed = [];
 
         this.tracker = new EventRegistrar(this.game, this);
-        this.tracker.register(['onRoundEnded', 'onCardDestroyed']);
+        this.tracker.register(['onTurnEnd', 'onCardDestroyed']);
 
         this.prophecyReaction({
             when: {
@@ -21,7 +21,7 @@ class TheEndIsNigh extends Card {
         });
     }
 
-    onRoundEnded() {
+    onTurnEnd() {
         this.creaturesDestroyed = [];
     }
 

--- a/server/game/cards/12-PV/TheMist.js
+++ b/server/game/cards/12-PV/TheMist.js
@@ -6,7 +6,7 @@ class TheMist extends Card {
         this.omni({
             gameAction: [
                 ability.actions.destroy(),
-                ability.actions.forRemainderOfTurn({
+                ability.actions.untilPlayerTurnEnd({
                     targetController: 'any',
                     effect: ability.effects.addTrait('mutant')
                 })

--- a/server/game/cards/12-PV/TheSecondMouse.js
+++ b/server/game/cards/12-PV/TheSecondMouse.js
@@ -5,7 +5,7 @@ class TheSecondMouse extends Card {
     setupCardAbilities(ability) {
         this.prophecyInterrupt({
             when: {
-                onRoundEnded: (event, context) =>
+                onTurnEnd: (event, context) =>
                     context.game.activePlayer === context.source.controller.opponent &&
                     context.game.activePlayer.amber < context.source.controller.amber
             },

--- a/server/game/cards/12-PV/UnityPrism.js
+++ b/server/game/cards/12-PV/UnityPrism.js
@@ -8,7 +8,7 @@ class UnityPrism extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'allow playing up to 4 cards from any house this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: [
                     ability.effects.canPlay((context) => {
                         return context.game.cardsPlayedThisPhase.length < 4;

--- a/server/game/cards/13-CC/Badger.js
+++ b/server/game/cards/13-CC/Badger.js
@@ -7,7 +7,7 @@ class Badger extends Card {
             reap: true,
             effect:
                 'deal 3 damage to an enemy creature after playing a Brobnar creature for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 when: {
                     onCardPlayed: (event) =>
                         event.player === context.player &&

--- a/server/game/cards/13-CC/DoomDevice.js
+++ b/server/game/cards/13-CC/DoomDevice.js
@@ -5,7 +5,7 @@ class DoomDevice extends Card {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onRoundEnded: (event, context) => context.player === this.game.activePlayer
+                onTurnEnd: (event, context) => context.player === this.game.activePlayer
             },
             condition: (context) =>
                 context.game.cardsInPlay.length +

--- a/server/game/cards/13-CC/InciteViolence.js
+++ b/server/game/cards/13-CC/InciteViolence.js
@@ -5,7 +5,7 @@ class InciteViolence extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'give each friendly creature splash-attack 1 for the remainder of the turn',
-            gameAction: ability.actions.forRemainderOfTurn((context) => ({
+            gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
                 target: context.player.creaturesInPlay,
                 effect: ability.effects.addKeyword({ 'splash-attack': 1 })
             }))

--- a/server/game/cards/13-CC/KathaTheWise.js
+++ b/server/game/cards/13-CC/KathaTheWise.js
@@ -5,7 +5,7 @@ class KathaTheWise extends Card {
     setupCardAbilities(ability) {
         this.omni({
             effect: 'allow them to play one Untamed creature this turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 effect: ability.effects.canPlayHouse({
                     house: 'untamed',
                     condition: (card) => card.type === 'creature' && card.location === 'hand'

--- a/server/game/cards/13-CC/RottingMist.js
+++ b/server/game/cards/13-CC/RottingMist.js
@@ -5,7 +5,7 @@ class RottingMist extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'give each enemy creature -1 power until the end of the turn',
-            gameAction: ability.actions.forRemainderOfTurn({
+            gameAction: ability.actions.untilPlayerTurnEnd({
                 targetController: 'opponent',
                 match: (card) => card.type === 'creature',
                 effect: ability.effects.modifyPower(-1)

--- a/server/game/cards/13-CC/SonicWaver.js
+++ b/server/game/cards/13-CC/SonicWaver.js
@@ -21,7 +21,7 @@ class SonicWaver extends Card {
 
         this.interrupt({
             when: {
-                onRoundEnded: () => true
+                onTurnEnd: () => true
             },
             condition: (context) => !context.game.creaturesInPlay.some((card) => card.stunned),
             gameAction: ability.actions.purge((context) => ({

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -139,7 +139,7 @@ class Game extends EventEmitter {
 
     /**
      * Adds a message to in-game chat with a graphical icon
-     * @param {String} one of: 'endofround', 'success', 'info', 'danger', 'warning'
+     * @param {String} one of: 'endofturn', 'success', 'info', 'danger', 'warning'
      * @param {String} message to display (can include {i} references to args)
      * @param {Array} args to match the references in @string
      */
@@ -893,7 +893,7 @@ class Game extends EventEmitter {
      * @returns {undefined}
      */
     beginRound() {
-        this.raiseEvent('onBeginRound', { player: this.activePlayer });
+        this.raiseEvent('onTurnStart', { player: this.activePlayer });
         this.activePlayer.beginRound();
         this.queueStep(new SimpleStep(this, () => this.finalizeBeginRound(0)));
         this.queueStep(new KeyPhase(this));
@@ -1311,7 +1311,7 @@ class Game extends EventEmitter {
     }
 
     raiseEndRoundEvent() {
-        this.raiseEvent('onRoundEnded', { player: this.activePlayer }, () => {
+        this.raiseEvent('onTurnEnd', { player: this.activePlayer }, () => {
             this.endRound();
         });
     }
@@ -1344,7 +1344,7 @@ class Game extends EventEmitter {
             .map((player) => `${player.name}: ${player.amber} amber (${this.playerKeys(player)})`)
             .join(' ');
 
-        this.addAlert('endofround', `End of turn ${this.round}`);
+        this.addAlert('endofturn', `End of turn ${this.round}`);
 
         if (
             !this.activePlayer.opponent ||
@@ -1354,7 +1354,7 @@ class Game extends EventEmitter {
         }
 
         this.addMessage(playerResources);
-        this.addAlert('startofround', `Turn ${this.round} - {0}`, this.activePlayer);
+        this.addAlert('startofturn', `Turn ${this.round} - {0}`, this.activePlayer);
         this.checkForTimeExpired();
     }
 

--- a/server/game/gamesteps/phase.js
+++ b/server/game/gamesteps/phase.js
@@ -24,7 +24,7 @@ class Phase extends BaseStepWithPipeline {
             this.game.currentPhase = this.name;
             if (this.name !== 'setup') {
                 this.game.addAlert(
-                    'endofround',
+                    'endofturn',
                     '{0} phase - {1}',
                     this.name.charAt(0).toUpperCase() + this.name.slice(1),
                     this.game.activePlayer
@@ -38,7 +38,7 @@ class Phase extends BaseStepWithPipeline {
     }
 
     endPhase() {
-        this.game.raiseEvent('onPhaseEnded', { phase: this.name }, () => {
+        this.game.raiseEvent('onPhaseEnd', { phase: this.name }, () => {
             this.game.resetThingsThisPhase();
         });
         this.game.currentPhase = '';

--- a/server/game/gamesteps/setup/setupphase.js
+++ b/server/game/gamesteps/setup/setupphase.js
@@ -59,7 +59,7 @@ class SetupPhase extends Phase {
             .draw({ amount: 1 })
             .resolve(this.game.activePlayer, this.game.getFrameworkContext());
         this.game.actions
-            .forRemainderOfTurn({
+            .untilPlayerTurnEnd({
                 condition: () =>
                     !!this.game.cardsUsed.length ||
                     !!this.game.cardsPlayed.length ||

--- a/server/game/gamesteps/triggeredabilitywindowtitles.js
+++ b/server/game/gamesteps/triggeredabilitywindowtitles.js
@@ -10,7 +10,7 @@ const EventToTitleFunc = {
             : ' leaving play'),
     onCharacterEntersPlay: (event) => event.card.name + ' entering play',
     onCardPlayed: (event) => event.card.name + ' being played',
-    onPhaseEnded: (event) => event.phase + ' phase ending',
+    onPhaseEnd: (event) => event.phase + ' phase ending',
     onPhaseStarted: (event) => event.phase + ' phase starting'
 };
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -12,7 +12,7 @@ const TriggeredAbilityContext = require('./TriggeredAbilityContext.js');
  *           trigger the reaction when that event is fired. For example, to
  *           trigger only at the end of the challenge phase, you would do:
  *           when: {
- *               onPhaseEnded: event => event.phase === 'conflict'
+ *               onPhaseEnd: event => event.phase === 'conflict'
  *           }
  *           Multiple events may be specified for cards that have multiple
  *           possible triggers for the same reaction.

--- a/server/scripts/generatecards/Ability.njk
+++ b/server/scripts/generatecards/Ability.njk
@@ -15,7 +15,7 @@ this.persistentEffect({
 });
     {%- endif -%}
 {%- elif ability.name == 'reaction' -%}
-this.{{'interrupt' if ['onRoundEnded'].includes(ability.trigger.trigger) else 'reaction'}}({
+this.{{'interrupt' if ['onTurnEnd'].includes(ability.trigger.trigger) else 'reaction'}}({
     {{formatReaction(ability, refs) | indent(4)}}
 });
 {%- elif ability.name == 'keywords' -%}
@@ -57,7 +57,7 @@ match: (card{{", context" if c.includes("context") }}) => {{c}},
 effect: {{formatEffectArray(ability.effects, refs) }}
 {%- endmacro -%}
 
-{# Sorts out effects that may be targetted or untargeted, sequential or interdependent. 
+{# Sorts out effects that may be targetted or untargeted, sequential or interdependent.
 
  The rule regarding resolving one sentence at a time, except for damage and replacement effects etc. is not implemented yet - and many existing cards don't follow it anyway. In particular, this doesn't generate any unconditional "thens" using alwaysTriggers #}
 {%- macro formatActions(actions, refs) -%}
@@ -179,7 +179,7 @@ ability.actions.sequential([
     {{formatSingleAction(action, refs) | indent(4)}}{{"," if not loop.last }}
         {%- endfor %}
 ])
-    {%- elif ['forRemainderOfTurn', 'lastingEffect'].includes(effect.name) -%}
+    {%- elif ['untilPlayerTurnEnd', 'lastingEffect'].includes(effect.name) -%}
         {%- if effect.durationEffect.name == "reaction" or not effect.durationEffect.target or effect.durationEffect.target.mode == 'all' -%}
 ability.actions.{{effect.name}}({{formatParams(effect, refs, allowContext=false)}})
         {%- else -%}
@@ -206,16 +206,16 @@ ability.effects.gainAbility('reaction', {
 })
         {%- endif -%}
     {%- elif effect.name == 'terminalCondition' -%}
-ability.effects.terminalCondition({ 
-    {{formatActions(effect.actions, refs) | indent(4)}} 
+ability.effects.terminalCondition({
+    {{formatActions(effect.actions, refs) | indent(4)}}
 })
     {%- elif effect.name == 'gainKeywords' -%}
-ability.effects.addKeyword({ 
+ability.effects.addKeyword({
         {%- for keyword in effect.keywords %}
     {{keyword.name}}: {{keyword.count|default(1, true)}}{{"," if not loop.last }}
         {%- endfor %}
 })
-    {%- elif ['forRemainderOfTurn', 'lastingEffect'].includes(effect.name) -%}
+    {%- elif ['untilPlayerTurnEnd', 'lastingEffect'].includes(effect.name) -%}
         {%- if effect.durationEffect.name == "reaction" or not effect.durationEffect.target -%}
 ability.actions.{{effect.name}}({{formatParams(effect, refs, allowContext=false)}})
         {%- else -%}

--- a/test/server/cards/07-GR/SingingScythe.spec.js
+++ b/test/server/cards/07-GR/SingingScythe.spec.js
@@ -32,7 +32,7 @@ describe('Singing Scythe', function () {
             expect(this.player1).toHavePrompt('Choose a card to play, discard or use');
         });
 
-        it('allows it to come back to hand when haunted at end of the round', function () {
+        it('allows it to come back to hand when haunted at end of the turn', function () {
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();
             this.player1.clickCard(this.singingScythe);
@@ -40,7 +40,7 @@ describe('Singing Scythe', function () {
             this.player2.clickPrompt('staralliance');
         });
 
-        it('can choose not to come back to hand when haunted at end of the round', function () {
+        it('can choose not to come back to hand when haunted at end of the turn', function () {
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();
             this.player1.clickPrompt('Done');
@@ -48,7 +48,7 @@ describe('Singing Scythe', function () {
             this.player2.clickPrompt('staralliance');
         });
 
-        it('can not come back to hand when not haunted at end of the round', function () {
+        it('can not come back to hand when not haunted at end of the turn', function () {
             this.player1.player.discard = [];
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();
@@ -56,7 +56,7 @@ describe('Singing Scythe', function () {
             this.player2.clickPrompt('staralliance');
         });
 
-        it('allows it to come back to hand when haunted at start of the round', function () {
+        it('allows it to come back to hand when haunted at start of the turn', function () {
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();
             this.player1.clickPrompt('Done');
@@ -67,7 +67,7 @@ describe('Singing Scythe', function () {
             this.player1.clickPrompt('geistoid');
         });
 
-        it('can choose not to come back to hand when haunted at start of the round', function () {
+        it('can choose not to come back to hand when haunted at start of the turn', function () {
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();
             this.player1.clickPrompt('Done');
@@ -78,7 +78,7 @@ describe('Singing Scythe', function () {
             this.player1.clickPrompt('geistoid');
         });
 
-        it('can not come back to hand when not haunted at start of the round', function () {
+        it('can not come back to hand when not haunted at start of the turn', function () {
             this.player1.player.discard = [];
             this.player1.scrap(this.singingScythe);
             this.player1.endTurn();


### PR DESCRIPTION
- refactor: rename round to turn
- refactor: a few other related namings
- refactor: a couple import reorderings from auto-import (eslint? prettier?) 

```
- old: onBeginRound
- new: onTurnStart

- old: onRoundEnded
- new: onTurnEnd

- old: untilEndOfRound
- old: forRemainderOfTurn
- new: untilPlayerTurnEnd

- old: (didn't exist before)
- new: duringOpponentNextTurn

- old: untilNextTurn
- new: untilPlayerNextTurnStart

- old: untilEndOfMyNextTurn
- new: untilPlayerNextTurnEnd

- old: onPhaseEnded
- new: onPhaseEnd

- old: untilEndOfPhase
- new: untilPhaseEnd

- old: perRound
- new: perTurn

JSX/CSS:
- old: endofround
- new: endofturn

- old: startofround
- new: endofround

- old: match-round
- new: match-turn
```