### PR TITLE
Changes when swap boolean is set for rematch

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1209,10 +1209,20 @@ class Game extends EventEmitter {
         player.socket = undefined;
     }
 
-    rematch() {
+    /**
+     * @param {boolean} swapDecks If true, swap decks in the rematch from what
+     * they were this game. Note that if the current game was a rematch with
+     * swapped decks, swapping for the 2nd rematch puts them back to where they
+     * were originally.
+     */
+    rematch(swapDecks = false) {
         if (!this.finishedAt) {
             this.finishedAt = new Date();
             this.winReason = 'rematch';
+        }
+
+        if (swapDecks) {
+            this.swap = !this.swap;
         }
 
         this.router.rematch(this);

--- a/server/game/gamesteps/GameWonPrompt.js
+++ b/server/game/gamesteps/GameWonPrompt.js
@@ -61,8 +61,7 @@ class GameWonPrompt extends AllPlayerPrompt {
         }
 
         if (arg === 'rematch-swap') {
-            this.game.swap = !this.game.swap;
-            this.game.queueStep(new RematchPrompt(this.game, player));
+            this.game.queueStep(new RematchPrompt(this.game, player, true));
 
             return true;
         }

--- a/server/game/gamesteps/RematchPrompt.js
+++ b/server/game/gamesteps/RematchPrompt.js
@@ -1,12 +1,16 @@
 const AllPlayerPrompt = require('./allplayerprompt');
 
 class RematchPrompt extends AllPlayerPrompt {
-    constructor(game, requestingPlayer) {
+    /**
+     * @param {boolean} swap If true, request is for a rematch with swapped
+     * decks from how they were this game.
+     */
+    constructor(game, requestingPlayer, swap = false) {
         super(game);
 
         this.requestingPlayer = requestingPlayer;
         this.completedPlayers = new Set([requestingPlayer]);
-        this.swap = game.swap;
+        this.swap = swap;
         this.cancelled = false;
     }
 
@@ -58,7 +62,7 @@ class RematchPrompt extends AllPlayerPrompt {
             return;
         }
 
-        this.game.rematch();
+        this.game.rematch(this.swap);
         this.game.addAlert(
             'danger',
             '{0} uses /rematch to reset the game and start a rematch',


### PR DESCRIPTION
Fixes #4666

Because the 2nd player has to okay the rematch, this waits to actually modify the `game.swap` field until that confirmation is made.

Prevents a bug where the `swap` boolean was modified before the 2nd player confirmed, leading to incorrect decks if they declined the swap but then offered their own rematch.