### PR TITLE
Corrects ID for Tomes Gigantica in frontend / importing

### DIFF
--- a/client/archonMaker.js
+++ b/client/archonMaker.js
@@ -72,7 +72,7 @@ const gigantic2s = [
 ];
 
 // The MV API doesn't provide proper per-house images for these cards.
-const houselessCards = ['build-your-champion', 'digging-up-the-monster', 'tomes-gigantic'];
+const houselessCards = ['build-your-champion', 'digging-up-the-monster', 'tomes-gigantica'];
 
 export const loadImage = (url) => {
     return new Promise((resolve) => {

--- a/server/scripts/fetchdata/CardImport.js
+++ b/server/scripts/fetchdata/CardImport.js
@@ -104,7 +104,7 @@ class CardImport {
             874: {
                 'build-your-champion': true,
                 'digging-up-the-monster': true,
-                'tomes-gigantic': true
+                'tomes-gigantica': true
             },
             886: {
                 'avenging-aura': true,

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -895,7 +895,7 @@ class DeckService {
                 'dark-æmber-vault': true,
                 'build-your-champion': true,
                 'digging-up-the-monster': true,
-                'tomes-gigantic': true
+                'tomes-gigantica': true
             },
             886: {
                 'avenging-aura': true,


### PR DESCRIPTION
Fixes #4696

Card should be `tomes-gigantica` but was refered to as `tomes-gigantic`. This prevented the frontend from rendering a version with the correct house icon.



Before:

<img width="698" height="559" alt="Screenshot 2025-12-14 at 10 12 37 AM" src="https://github.com/user-attachments/assets/9b8864aa-c9c4-4878-be6d-0fd8ca218964" />

After:

<img width="615" height="556" alt="Screenshot 2025-12-14 at 10 12 29 AM" src="https://github.com/user-attachments/assets/d8382e7b-b059-48d5-a930-e09d40f31d35" />
