### PR TITLE
fix: Fixes CopyCard’s handling of copying underlying card (#3529)

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -34,6 +34,19 @@ class Card extends EffectSource {
         this.tokens = {};
         this.gigantic = false;
 
+        /**
+         * Abilities that this card has.
+         *
+         * **IMPORTANT NOTE:** These arrays will include the _sum_ of abilities
+         * put on the card. Specifically, if a card is copying another card (for
+         * example, it’s face-down as a token creature), these arrays will have
+         * both the original card’s effects and the token creature’s effects.
+         *
+         * You in general will want to look at the
+         * actions/reactions/persistentEffects properties instead, as those will
+         * reflect what is actually active in the game, since they are sensitive
+         * both to text box blanking effects as well as copy card effects.
+         */
         this.abilities = {
             actions: [],
             reactions: [],

--- a/server/game/Effects/Values/CopyCard.js
+++ b/server/game/Effects/Values/CopyCard.js
@@ -1,11 +1,44 @@
 const EffectValue = require('./EffectValue');
 const GainAbility = require('./GainAbility');
 
+/**
+ * Makes the target of this effect a copy of the value of this effect. Used for
+ * tokens, Mirror Shell, and Mimic Gel. This doesn’t modify the card data
+ * itself, but {@link Card} has code that looks for 'copyCard' effects at
+ * appropriate places.
+ *
+ * **WARNING:** This does not un-listen any reactions or persistent effects that
+ * the underlying card had in this location.
+ *
+ * As of PV/CC, this limitation is mitigated by the following:
+ *
+ * - TriggeredAbility#eventHandler takes care of ignoring reactions that are not
+ *   currently in their card’s `reactions` property, which is dynamic and
+ *   sensitive to CopyCard.
+ * - Token creatures in general are only made from the deck or (in the case of
+ *   Sidekick) the hand, so the original card’s 'play area' abilities don’t get
+ *   registered in the first place.
+ * - Gĕzdrutyŏ the Arcane, the only card that _becomes_ a token creature from
+ *   being in play, only has an action, not persistent effects, and the code
+ *   that displays the list of available actions when selecting it is sensitive
+ *   to CopyCard.
+ * - Mimic Gel’s persistent effect only applies to being played, so that it is
+ *   still around when it’s in play isn’t relevant.
+ */
 class CopyCard extends EffectValue {
-    constructor(card, cascadeEffects = true) {
+    /**
+     * @param {Card} card Card to copy the effects from.
+     * @param {boolean} copyOriginalCard If true, copies the underlying, printed
+     * abilities on the card. Otherwise if the card is already copying
+     * something, this would copy those abilities. Necessary for flipping token
+     * creatures to their face-up side, since we need to copy those abilities,
+     * not the token abilities.
+     */
+    constructor(card, copyOriginalCard = false) {
         super(card);
         this.abilitiesForTargets = {};
-        if (cascadeEffects && card.anyEffect('copyCard')) {
+
+        if (card.anyEffect('copyCard') && !copyOriginalCard) {
             this.value = card.mostRecentEffect('copyCard');
             this.actions = this.value.actions.map(
                 (action) => new GainAbility('action', action, true)
@@ -17,15 +50,39 @@ class CopyCard extends EffectValue {
                 (properties) => new GainAbility('persistentEffect', properties)
             );
         } else {
-            this.actions = card.abilities.actions.map(
-                (action) => new GainAbility('action', action, true)
-            );
-            this.reactions = card.abilities.reactions.map(
-                (ability) => new GainAbility(ability.abilityType, ability, true)
-            );
-            this.persistentEffects = card.abilities.persistentEffects.map(
-                (properties) => new GainAbility('persistentEffect', properties)
-            );
+            // There’s not an easy way to just get the original printed
+            // actions/reactions of a card, ignoring any copyCard effects. What
+            // we have to do is collect any CopyCard effects on the card, gather
+            // the abilities that they’re adding, and filter those out. The
+            // remaining abilities are the ones the card had initially.
+
+            const allExistingCopyEffects = card.effects
+                .filter((effect) => effect.type === 'copyCard')
+                .map((staticEffect) => staticEffect.value)
+                // abilitesForTargets objects have
+                // actions/reactions/persistentEffects properties with array
+                // values.
+                .map(
+                    (/** @type CopyCard */ effectValue) =>
+                        effectValue.abilitiesForTargets[card.uuid] || {}
+                )
+                // flatmap down to the TriggeredAbility / other ability objects
+                .flatMap((state) => [].concat(...Object.values(state)));
+
+            // We explicitly want to use _e.g._ card.abilities.actions here,
+            // rather than card.actions, since the latter is wired in to copy
+            // card effects as well as text box blanking effects, which we do
+            // _not_ want to respect for this “copy.”
+
+            this.actions = card.abilities.actions
+                .filter((effect) => !allExistingCopyEffects.includes(effect))
+                .map((action) => new GainAbility('action', action, true));
+            this.reactions = card.abilities.reactions
+                .filter((effect) => !allExistingCopyEffects.includes(effect))
+                .map((ability) => new GainAbility(ability.abilityType, ability, true));
+            this.persistentEffects = card.abilities.persistentEffects
+                .filter((effect) => !allExistingCopyEffects.includes(effect))
+                .map((properties) => new GainAbility('persistentEffect', properties));
         }
     }
 

--- a/server/game/GameActions/FlipAction.js
+++ b/server/game/GameActions/FlipAction.js
@@ -66,7 +66,7 @@ class FlipAction extends CardGameAction {
                                 context.game.effects.changeType('creature'),
                                 context.game.effects.copyCard(
                                     card.isToken() ? card : card.owner.tokenCard,
-                                    false
+                                    true
                                 )
                             ]
                         })

--- a/server/game/GameActions/MakeTokenCreatureAction.js
+++ b/server/game/GameActions/MakeTokenCreatureAction.js
@@ -54,7 +54,7 @@ class MakeTokenCreatureAction extends CardGameAction {
                             effect: [
                                 context.game.effects.flipToken(),
                                 context.game.effects.changeType('creature'),
-                                context.game.effects.copyCard(event.player.tokenCard, false)
+                                context.game.effects.copyCard(event.player.tokenCard, true)
                             ]
                         }),
                         context.game.actions.putIntoPlay({

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -51,8 +51,8 @@ const Effects = {
     changeHouse: (house) => EffectBuilder.card.static('changeHouse', house),
     changeType: (type) => EffectBuilder.card.static('changeType', type),
     consideredAsFlank: () => EffectBuilder.card.static('consideredAsFlank'),
-    copyCard: (card, cascadeEffects = true) =>
-        EffectBuilder.card.static('copyCard', new CopyCard(card, cascadeEffects)),
+    copyCard: (card, copyOriginalCard = false) =>
+        EffectBuilder.card.static('copyCard', new CopyCard(card, copyOriginalCard)),
     customDetachedCard: (properties) => EffectBuilder.card.detached('customEffect', properties),
     doesNotReady: () => EffectBuilder.card.static('doesNotReady'),
     enterPlayAnywhere: () => EffectBuilder.card.static('enterPlayAnywhere'),

--- a/test/server/cards/06-WoE/MirrorShell.spec.js
+++ b/test/server/cards/06-WoE/MirrorShell.spec.js
@@ -5,9 +5,9 @@ describe('Mirror Shell', function () {
                 player1: {
                     amber: 1,
                     house: 'staralliance',
-                    token: 'grunt',
-                    inPlay: ['questor-jarta', 'first-officer-frane', 'grunt:clone-home'],
-                    hand: ['mirror-shell', 'legionary-trainer']
+                    token: 'rebel',
+                    inPlay: ['questor-jarta', 'first-officer-frane', 'rebel:collector-boren'],
+                    hand: ['mirror-shell', 'legionary-trainer', 'temporal-purge']
                 },
                 player2: {
                     amber: 4,
@@ -26,15 +26,55 @@ describe('Mirror Shell', function () {
         it('turns tokens into copy of a creature', function () {
             this.player1.playUpgrade(this.mirrorShell, this.firstOfficerFrane);
             this.player1.clickPrompt('Right');
+
+            // Reaping with First Officer Frane triggers Mirror Shell to copy it
+            // to our token creatures.
+            this.player1.reap(this.firstOfficerFrane);
+            this.player1.clickPrompt('First Officer Frane');
+
+            // Frane also has its own reap effect for a friendly creature to
+            // capture 1A.
+            this.player1.clickCard(this.questorJarta);
+            expect(this.questorJarta.amber).toBe(1);
+            expect(this.player2.amber).toBe(3);
+
+            // Reaping with the Rebel, which is now a copy of Frane.
+            this.player1.reap(this.rebel);
+            expect(this.player1).toHavePrompt('First Officer Frane');
+            this.player1.clickCard(this.questorJarta);
+
+            // The reap effect triggered will be the Frane effect (capture), not
+            // Rebel’s effect (damage).
+            expect(this.questorJarta.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+            expect(this.questorJarta.tokens.damage).toBe(undefined);
+
+            // No more effects to resolve.
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('the copying goes away if the creatures un-tokenize', function () {
+            this.player1.playUpgrade(this.mirrorShell, this.firstOfficerFrane);
+            this.player1.clickPrompt('Right');
+
+            // Mirror Shell goes off (as well as Frane’s After Reap: effect to
+            // capture.) Our Rebel is now a First Officer Frane.
             this.player1.reap(this.firstOfficerFrane);
             this.player1.clickPrompt('First Officer Frane');
             this.player1.clickCard(this.questorJarta);
             expect(this.questorJarta.amber).toBe(1);
             expect(this.player2.amber).toBe(3);
-            this.player1.reap(this.grunt);
-            this.player1.clickCard(this.questorJarta);
-            expect(this.questorJarta.amber).toBe(2);
-            expect(this.player2.amber).toBe(2);
+
+            // Temporal Purge to flip our tokens, so the Rebel goes to being a
+            // Collector Boren and should no longer be copying Frane.
+            this.player1.play(this.temporalPurge);
+            expect(this.rebel.name).toBe('Collector Boren');
+
+            this.player1.reap(this.rebel);
+
+            // Collector Boren doesn’t have any Reap effects, so we should be
+            // back to the main loop without any effects to resolve.
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('works in a non staralliance house', function () {
@@ -48,15 +88,15 @@ describe('Mirror Shell', function () {
             this.player1.reap(this.questorJarta);
             this.player1.clickPrompt('Questor Jarta');
             this.player1.clickCard(this.questorJarta);
-            this.player1.reap(this.grunt);
-            this.player1.clickCard(this.grunt);
+            this.player1.reap(this.rebel);
+            this.player1.clickCard(this.rebel);
             expect(this.player1.amber).toBe(5);
 
             this.player1.playCreature(this.legionaryTrainer);
             this.player1.clickPrompt('Right');
-            let grunt2 = this.player1.player.creaturesInPlay[5];
-            this.player1.reap(grunt2);
-            this.player1.clickCard(grunt2);
+            let rebel2 = this.player1.player.creaturesInPlay[5];
+            this.player1.reap(rebel2);
+            this.player1.clickCard(rebel2);
             expect(this.player1.amber).toBe(7);
         });
     });

--- a/test/server/cards/06-WoE/TemporalPurge.spec.js
+++ b/test/server/cards/06-WoE/TemporalPurge.spec.js
@@ -8,7 +8,7 @@ describe('Temporal Purge', function () {
                     amber: 1,
                     inPlay: [
                         'stealthster',
-                        'scholar:helper-bot',
+                        'scholar:collector-boren',
                         'senator-shrix',
                         'scholar:foggify'
                     ],
@@ -46,7 +46,7 @@ describe('Temporal Purge', function () {
 
             expect(p1c0.name).toBe('Stealthster');
             expect(p1c0.location).toBe('play area');
-            expect(p1c1.name).toBe('Helper Bot');
+            expect(p1c1.name).toBe('Collector Boren');
             expect(p1c1.location).toBe('play area');
             expect(p1c2.name).toBe('Senator Shrix');
             expect(p1c2.location).toBe('play area');
@@ -59,6 +59,32 @@ describe('Temporal Purge', function () {
             expect(p2c1.location).toBe('play area');
             expect(p2c2.name).toBe('Malison');
             expect(p2c2.location).toBe('play area');
+        });
+
+        /**
+         * Regression test for https://github.com/keyteki/keyteki/issues/3529
+         */
+        it('should remove after reap effects the token had', function () {
+            let collectorBoren = this.player1.inPlay[1];
+            expect(collectorBoren.name).toBe('Scholar');
+
+            this.player1.play(this.temporalPurge);
+
+            expect(collectorBoren.name).toBe('Collector Boren');
+            expect(collectorBoren.location).toBe('play area');
+
+            // Temporal Purge flipped our Scholar over to its Collector Boren
+            // side, so it should no longer have any abilities from Scholar.
+
+            expect(this.player1.hand.length).toBe(0);
+            expect(this.player1.amber).toBe(2);
+
+            this.player1.reap(collectorBoren);
+
+            // Scholar’s After Reap effect is to draw a card. We want to assert
+            // that we gained an æmber from the reap but did _not_ draw a card.
+            expect(this.player1.hand.length).toBe(0);
+            expect(this.player1.amber).toBe(3);
         });
 
         /**


### PR DESCRIPTION
Fixes #3529

This handles the case where cards flipped face-up by Temporal Purge were maintaining abilities from their token side. Flipping face-up is done by doing a CopyCard to overwrite the CopyCard that gave the card the token abilities. The bug in the previous implementation was that the source for the “original card” was `Card.abilities`, which was including both the original card’s abilities as well as those added by the previous CopyCard.

This adjusts that logic to explicitly filter out any abilities that came from CopyCard effects.

Adds test to Temporal Purge, as well as to Mirror Shell to capture that the behavior is correct through 2 layers of copying.

Also renames `cascadeEffects` to `copyOriginalCard` for clarity, inverting its value (so to copy the original you pass `true` rather than `false`).