### PR TITLE
feat: update messaging for Scout Pete, Explorer, Future Booster, and …

### DIFF
--- a/server/game/cards/04-MM/ScoutPete.js
+++ b/server/game/cards/04-MM/ScoutPete.js
@@ -16,7 +16,12 @@ class ScoutPete extends Card {
                     handlers: [() => []]
                 }
             })),
-            message: 'Choose to keep or discard top of deck.'
+            effect: 'look at the top card of their deck',
+            then: {
+                alwaysTriggers: true,
+                condition: (context) => !context.preThenEvent || context.preThenEvent.cancelled,
+                message: '{0} uses {1} to leave it on top of their deck'
+            }
         });
     }
 }

--- a/server/game/cards/06-WoE/Explorer.js
+++ b/server/game/cards/06-WoE/Explorer.js
@@ -14,7 +14,12 @@ class Explorer extends Card {
                     handlers: [() => []]
                 }
             })),
-            message: 'Choose to keep or discard top of deck.'
+            effect: 'look at the top card of their deck',
+            then: {
+                alwaysTriggers: true,
+                condition: (context) => !context.preThenEvent || context.preThenEvent.cancelled,
+                message: '{0} uses {1} to leave it on top of their deck'
+            }
         });
     }
 }

--- a/server/game/cards/06-WoE/FutureBooster.js
+++ b/server/game/cards/06-WoE/FutureBooster.js
@@ -15,7 +15,16 @@ class FutureBooster extends Card {
                     handlers: [() => []]
                 }
             })),
-            effect: 'choose to keep top of deck or move to bottom of deck.'
+            effect: 'look at the top card of their deck',
+            then: {
+                alwaysTriggers: true,
+                message: '{0} uses {1} to {3}',
+                messageArgs: (context) => [
+                    context.preThenEvent && !context.preThenEvent.cancelled
+                        ? 'move it to the bottom of their deck'
+                        : 'leave it on top of their deck'
+                ]
+            }
         });
     }
 }

--- a/server/game/cards/12-PV/BondsmanBelvan.js
+++ b/server/game/cards/12-PV/BondsmanBelvan.js
@@ -6,7 +6,7 @@ class BondsmanBelvan extends Card {
     setupCardAbilities(ability) {
         this.fight({
             reap: true,
-            effect: "look at the top card of their opponent's deck and may discard it",
+            effect: "look at the top card of their opponent's deck",
             condition: (context) =>
                 context.player.opponent && context.player.opponent.deck.length > 0,
             gameAction: ability.actions.discard((context) => ({
@@ -17,7 +17,12 @@ class BondsmanBelvan extends Card {
                     handlers: [() => []],
                     cards: [context.player.opponent ? context.player.opponent.deck[0] : undefined]
                 }
-            }))
+            })),
+            then: {
+                alwaysTriggers: true,
+                condition: (context) => !context.preThenEvent || context.preThenEvent.cancelled,
+                message: "{0} uses {1} to leave it on top of their opponent's deck"
+            }
         });
 
         this.fate({


### PR DESCRIPTION
feat: update messaging for Scout Pete, Explorer, Future Booster, and Bondsman Belvan

Fixes #3444

Scout Pete:
```
2026-01-16 18:46:39 player1 plays Scout Pete
2026-01-16 18:46:39 player1 uses Scout Pete to look at the top card of their deck
2026-01-16 18:46:39 player1 uses Scout Pete to discard Troll

2026-01-16 18:46:39 player1 plays Scout Pete
2026-01-16 18:46:39 player1 uses Scout Pete to look at the top card of their deck
2026-01-16 18:46:39 player1 uses Scout Pete to leave it on top of their deck
```

Explorer:
```
2026-01-16 18:47:19 player1 uses Explorer to reap with Explorer
2026-01-16 18:47:19 player1 uses Explorer to look at the top card of their deck
2026-01-16 18:47:19 player1 uses Explorer to discard Troll

2026-01-16 18:47:19 player1 uses Explorer to reap with Explorer
2026-01-16 18:47:19 player1 uses Explorer to look at the top card of their deck
2026-01-16 18:47:19 player1 uses Explorer to leave it on top of their deck
```

Future Booster:
```
2026-01-16 18:47:51 player1 uses Future Booster to look at the top card of their deck
2026-01-16 18:47:51 player1 uses Future Booster to move it to the bottom of their deck

2026-01-16 18:47:51 player1 uses Future Booster to look at the top card of their deck
2026-01-16 18:47:51 player1 uses Future Booster to leave it on top of their deck
```

Bondsman Belvan:
```
2026-01-16 18:48:31 player1 uses Bondsman Belvan to reap with Bondsman Belvan
2026-01-16 18:48:31 player1 uses Bondsman Belvan to look at the top card of their opponent's deck
2026-01-16 18:48:31 player1 uses Bondsman Belvan to discard Hunting Witch

2026-01-16 18:48:31 player1 uses Bondsman Belvan to reap with Bondsman Belvan
2026-01-16 18:48:31 player1 uses Bondsman Belvan to look at the top card of their opponent's deck
2026-01-16 18:48:31 player1 uses Bondsman Belvan to leave it on top of their opponent's deck
```