### PR TITLE
feat: Add powerCounters() getter

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -1021,6 +1021,10 @@ class Card extends EffectSource {
         this.tokens.amber = amber;
     }
 
+    get powerCounters() {
+        return this.hasToken('power') ? this.tokens.power : 0;
+    }
+
     get enraged() {
         return this.hasToken('enrage');
     }

--- a/server/game/cards/04-MM/Chonkers.js
+++ b/server/game/cards/04-MM/Chonkers.js
@@ -12,7 +12,7 @@ class Chonkers extends Card {
             },
             gameAction: [
                 ability.actions.addPowerCounter((context) => ({
-                    amount: context.source.tokens.power
+                    amount: context.source.powerCounters
                 }))
             ]
         });

--- a/server/game/cards/05-DT/GeneticDrift.js
+++ b/server/game/cards/05-DT/GeneticDrift.js
@@ -11,7 +11,7 @@ class GeneticDrift extends Card {
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.addPowerCounter((context) => ({
-                    target: context.game.creaturesInPlay.filter((card) => !!card.tokens.power)
+                    target: context.game.creaturesInPlay.filter((card) => card.powerCounters)
                 }))
             }
         });

--- a/server/game/cards/12-PV/ChonkEvermore.js
+++ b/server/game/cards/12-PV/ChonkEvermore.js
@@ -26,12 +26,12 @@ class ChonkEvermore extends Card {
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.addPowerCounter((context) => ({
-                    target: context.game.creaturesInPlay.filter((card) => !!card.tokens.power),
+                    target: context.game.creaturesInPlay.filter((card) => card.powerCounters),
                     multiplier: 2
                 })),
                 message: '{0} uses {1} to double the number of +1 power counters on {3}',
                 messageArgs: (context) => [
-                    context.game.creaturesInPlay.filter((card) => !!card.tokens.power)
+                    context.game.creaturesInPlay.filter((card) => card.powerCounters)
                 ]
             }
         });

--- a/server/game/cards/12-PV/Nectarcyte.js
+++ b/server/game/cards/12-PV/Nectarcyte.js
@@ -16,7 +16,7 @@ class Nectarcyte extends Card {
                     options: (context) =>
                         [
                             ...Array.from(
-                                { length: context.source.tokens.power + 1 },
+                                { length: context.source.powerCounters + 1 },
                                 (v, k) => k
                             ).keys()
                         ].map((option) => ({ name: option, value: option }))

--- a/test/server/cards/01-Core/EaterOfTheDead.spec.js
+++ b/test/server/cards/01-Core/EaterOfTheDead.spec.js
@@ -23,7 +23,7 @@ describe('Eater of the Dead', function () {
             expect(this.player1).not.toBeAbleToSelect(this.handOfDis);
             this.player1.clickCard(this.batdrone);
             expect(this.batdrone.location).toBe('purged');
-            expect(this.eaterOfTheDead.tokens.power).toBe(1);
+            expect(this.eaterOfTheDead.powerCounters).toBe(1);
             expect(this.eaterOfTheDead.power).toBe(5);
         });
 
@@ -36,7 +36,7 @@ describe('Eater of the Dead', function () {
             expect(this.player1).not.toBeAbleToSelect(this.handOfDis);
             this.player1.clickCard(this.pitlord);
             expect(this.pitlord.location).toBe('purged');
-            expect(this.eaterOfTheDead.tokens.power).toBe(1);
+            expect(this.eaterOfTheDead.powerCounters).toBe(1);
             expect(this.eaterOfTheDead.power).toBe(5);
         });
 

--- a/test/server/cards/01-Core/MartianHounds.spec.js
+++ b/test/server/cards/01-Core/MartianHounds.spec.js
@@ -28,7 +28,7 @@ describe('Martian Hounds', function () {
             this.player1.play(this.martianHounds);
             expect(this.player1).toHavePrompt('Martian Hounds');
             this.player1.clickCard(this.tunk);
-            expect(this.tunk.tokens.power).toBe(4);
+            expect(this.tunk.powerCounters).toBe(4);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -38,7 +38,7 @@ describe('Martian Hounds', function () {
             this.player1.play(this.martianHounds);
             expect(this.player1).toHavePrompt('Martian Hounds');
             this.player1.clickCard(this.batdrone);
-            expect(this.batdrone.tokens.power).toBe(4);
+            expect(this.batdrone.powerCounters).toBe(4);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/01-Core/Mugwump.spec.js
+++ b/test/server/cards/01-Core/Mugwump.spec.js
@@ -17,7 +17,7 @@ describe('Mugwump', function () {
             this.player1.fightWith(this.mugwump, this.docBookton);
             expect(this.docBookton.location).toBe('discard');
             expect(this.mugwump.tokens.damage).toBeUndefined();
-            expect(this.mugwump.tokens.power).toBe(1);
+            expect(this.mugwump.powerCounters).toBe(1);
             this.player1.endTurn();
         });
 
@@ -25,7 +25,7 @@ describe('Mugwump', function () {
             this.player1.fightWith(this.mugwump, this.badPenny);
             expect(this.badPenny.location).toBe('hand');
             expect(this.mugwump.tokens.damage).toBeUndefined();
-            expect(this.mugwump.tokens.power).toBe(1);
+            expect(this.mugwump.powerCounters).toBe(1);
             this.player1.endTurn();
         });
 
@@ -35,7 +35,7 @@ describe('Mugwump', function () {
             expect(this.docBookton.location).toBe('play area');
             expect(this.docBookton.warded).toBe(false);
             expect(this.mugwump.tokens.damage).toBe(5);
-            expect(this.mugwump.tokens.power).toBeUndefined();
+            expect(this.mugwump.powerCounters).toBe(0);
             this.player1.endTurn();
         });
 
@@ -52,7 +52,7 @@ describe('Mugwump', function () {
             this.player2.fightWith(this.docBookton, this.mugwump);
             expect(this.docBookton.location).toBe('discard');
             expect(this.mugwump.tokens.damage).toBeUndefined();
-            expect(this.mugwump.tokens.power).toBe(1);
+            expect(this.mugwump.powerCounters).toBe(1);
             this.player2.endTurn();
         });
 

--- a/test/server/cards/01-Core/ZyzzixTheMany.spec.js
+++ b/test/server/cards/01-Core/ZyzzixTheMany.spec.js
@@ -22,7 +22,7 @@ describe('Zyzzix the Many', function () {
             expect(this.player1).not.toBeAbleToSelect(this.squawker);
             this.player1.clickCard(this.zorg);
             expect(this.zorg.location).toBe('archives');
-            expect(this.zyzzixTheMany.tokens.power).toBe(3);
+            expect(this.zyzzixTheMany.powerCounters).toBe(3);
             expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
@@ -33,7 +33,7 @@ describe('Zyzzix the Many', function () {
             this.player1.clickCard(this.zyzzixTheMany);
             this.player1.clickCard(this.zorg);
             expect(this.zorg.location).toBe('archives');
-            expect(this.zyzzixTheMany.tokens.power).toBe(3);
+            expect(this.zyzzixTheMany.powerCounters).toBe(3);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -42,7 +42,7 @@ describe('Zyzzix the Many', function () {
             expect(this.player1).toHavePrompt('Any reactions?');
             this.player1.clickPrompt('Done');
             expect(this.zorg.location).toBe('hand');
-            expect(this.zyzzixTheMany.tokens.power).toBeUndefined();
+            expect(this.zyzzixTheMany.powerCounters).toBe(0);
             expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
@@ -51,12 +51,12 @@ describe('Zyzzix the Many', function () {
             this.player1.reap(this.zyzzixTheMany);
             this.player1.clickCard(this.zyzzixTheMany);
             this.player1.clickCard(this.zorg);
-            expect(this.zyzzixTheMany.tokens.power).toBe(3);
+            expect(this.zyzzixTheMany.powerCounters).toBe(3);
             this.zyzzixTheMany.exhausted = false;
             this.player1.reap(this.zyzzixTheMany);
             this.player1.clickCard(this.zyzzixTheMany);
             this.player1.clickCard(this.mindwarper);
-            expect(this.zyzzixTheMany.tokens.power).toBe(6);
+            expect(this.zyzzixTheMany.powerCounters).toBe(6);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/02-AoA/CybergiantRig.spec.js
+++ b/test/server/cards/02-AoA/CybergiantRig.spec.js
@@ -25,7 +25,7 @@ describe('Cybergiant Rig', function () {
 
             it('should fully heal the creature and add power tokens', function () {
                 expect(this.groggins.tokens.damage).toBeUndefined();
-                expect(this.groggins.tokens.power).toBe(6);
+                expect(this.groggins.powerCounters).toBe(6);
             });
 
             describe('at the end of own turn', function () {
@@ -34,7 +34,7 @@ describe('Cybergiant Rig', function () {
                 });
 
                 it('should remove 1 power token', function () {
-                    expect(this.groggins.tokens.power).toBe(5);
+                    expect(this.groggins.powerCounters).toBe(5);
                 });
 
                 describe("at the end of opponent's turn", function () {
@@ -44,7 +44,7 @@ describe('Cybergiant Rig', function () {
                     });
 
                     it('should not remove 1 power token', function () {
-                        expect(this.groggins.tokens.power).toBe(5);
+                        expect(this.groggins.powerCounters).toBe(5);
                     });
 
                     describe('at the end of own turn again', function () {
@@ -54,7 +54,7 @@ describe('Cybergiant Rig', function () {
                         });
 
                         it('should remove another power token', function () {
-                            expect(this.groggins.tokens.power).toBe(4);
+                            expect(this.groggins.powerCounters).toBe(4);
                         });
                     });
                 });
@@ -68,7 +68,7 @@ describe('Cybergiant Rig', function () {
 
             it('should fully heal the creature and add power tokens', function () {
                 expect(this.troll.tokens.damage).toBeUndefined();
-                expect(this.troll.tokens.power).toBe(3);
+                expect(this.troll.powerCounters).toBe(3);
             });
 
             describe('at the end of own turn', function () {
@@ -77,7 +77,7 @@ describe('Cybergiant Rig', function () {
                 });
 
                 it('should not remove 1 power token', function () {
-                    expect(this.troll.tokens.power).toBe(3);
+                    expect(this.troll.powerCounters).toBe(3);
                 });
 
                 describe("at the end of opponent's turn", function () {
@@ -87,7 +87,7 @@ describe('Cybergiant Rig', function () {
                     });
 
                     it('should remove 1 power token', function () {
-                        expect(this.troll.tokens.power).toBe(2);
+                        expect(this.troll.powerCounters).toBe(2);
                     });
                 });
             });

--- a/test/server/cards/02-AoA/ShardOfStrength.spec.js
+++ b/test/server/cards/02-AoA/ShardOfStrength.spec.js
@@ -30,7 +30,7 @@ describe('Shard of Strength', function () {
             expect(this.player1).not.toBeAbleToSelect(this.mother);
             this.player1.clickCard(this.cowfyne);
 
-            expect(this.cowfyne.tokens.power).toBe(3);
+            expect(this.cowfyne.powerCounters).toBe(3);
         });
 
         it('should work properly when Remote Accessed', function () {
@@ -45,7 +45,7 @@ describe('Shard of Strength', function () {
             expect(this.player2).toBeAbleToSelect(this.archimedes);
             expect(this.player2).toBeAbleToSelect(this.mother);
             this.player2.clickCard(this.mother);
-            expect(this.mother.tokens.power).toBe(2);
+            expect(this.mother.powerCounters).toBe(2);
         });
 
         it('should work properly when Borrowed', function () {
@@ -60,7 +60,7 @@ describe('Shard of Strength', function () {
             expect(this.player2).toBeAbleToSelect(this.archimedes);
             expect(this.player2).toBeAbleToSelect(this.mother);
             this.player2.clickCard(this.mother);
-            expect(this.mother.tokens.power).toBe(2);
+            expect(this.mother.powerCounters).toBe(2);
         });
 
         describe('when there are no friendly creatures in play', function () {

--- a/test/server/cards/03-WC/AlakasBrew.spec.js
+++ b/test/server/cards/03-WC/AlakasBrew.spec.js
@@ -22,7 +22,7 @@ describe('Alakas Brew', function () {
             expect(this.player1).toBeAbleToSelect(this.mightyTiger);
             expect(this.player1).toBeAbleToSelect(this.huntingWitch);
             this.player1.clickCard(this.ancientBear);
-            expect(this.ancientBear.tokens.power).toBe(2);
+            expect(this.ancientBear.powerCounters).toBe(2);
         });
     });
 });

--- a/test/server/cards/03-WC/FavorOfRex.spec.js
+++ b/test/server/cards/03-WC/FavorOfRex.spec.js
@@ -42,7 +42,7 @@ describe('Favor of Rex', function () {
             this.player1.clickCard(this.witchOfTheWilds);
             expect(this.player1.amber).toBe(11);
             expect(this.player2.amber).toBe(4);
-            expect(this.chotaHazri.tokens.power).toBeUndefined();
+            expect(this.chotaHazri.powerCounters).toBe(0);
             expect(this.charette.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
@@ -100,10 +100,10 @@ describe('Favor of Rex', function () {
             this.player1.play(this.favorOfRex);
             expect(this.player1).toHavePrompt('Choose a creature');
             this.player1.clickCard(this.bumblebird);
-            expect(this.witchOfTheWilds.tokens.power).toBe(2);
-            expect(this.chotaHazri.tokens.power).toBe(2);
-            expect(this.bumblebird.tokens.power).toBeUndefined();
-            expect(this.flaxia.tokens.power).toBeUndefined();
+            expect(this.witchOfTheWilds.powerCounters).toBe(2);
+            expect(this.chotaHazri.powerCounters).toBe(2);
+            expect(this.bumblebird.powerCounters).toBe(0);
+            expect(this.flaxia.powerCounters).toBe(0);
         });
     });
 });

--- a/test/server/cards/03-WC/Gravelguts.spec.js
+++ b/test/server/cards/03-WC/Gravelguts.spec.js
@@ -18,7 +18,7 @@ describe('Gravelguts', function () {
             this.player1.fightWith(this.gravelguts, this.silvertooth);
             expect(this.silvertooth.location).toBe('discard');
             expect(this.gravelguts.tokens.damage).toBe(2);
-            expect(this.gravelguts.tokens.power).toBe(2);
+            expect(this.gravelguts.powerCounters).toBe(2);
         });
 
         it('should gain 2 +1 power counters when it destroys defending a creature during a fight', function () {
@@ -27,7 +27,7 @@ describe('Gravelguts', function () {
             this.player2.fightWith(this.silvertooth, this.gravelguts);
             expect(this.silvertooth.location).toBe('discard');
             expect(this.gravelguts.tokens.damage).toBe(2);
-            expect(this.gravelguts.tokens.power).toBe(2);
+            expect(this.gravelguts.powerCounters).toBe(2);
         });
     });
 });

--- a/test/server/cards/03-WC/GreaterOxtet.spec.js
+++ b/test/server/cards/03-WC/GreaterOxtet.spec.js
@@ -38,7 +38,7 @@ describe('Greater Oxtet', function () {
                 });
 
                 it('two power counters are added to greater oxtet', function () {
-                    expect(this.greaterOxtet.tokens.power).toBe(2);
+                    expect(this.greaterOxtet.powerCounters).toBe(2);
                 });
             });
         });
@@ -51,7 +51,7 @@ describe('Greater Oxtet', function () {
 
             it('no power counters are added to greater oxtet', function () {
                 expect(this.player1).toHavePrompt('Waiting for opponent');
-                expect(this.greaterOxtet.tokens.power).toBe(undefined);
+                expect(this.greaterOxtet.powerCounters).toBe(0);
             });
         });
     });

--- a/test/server/cards/03-WC/Irestaff.spec.js
+++ b/test/server/cards/03-WC/Irestaff.spec.js
@@ -20,7 +20,7 @@ describe('Irestaff', function () {
             expect(this.player1).toBeAbleToSelect(this.umbra);
             this.player1.clickCard(this.troll);
             expect(this.troll.power).toBe(9);
-            expect(this.troll.tokens.power).toBe(1);
+            expect(this.troll.powerCounters).toBe(1);
             expect(this.troll.tokens.enrage).toBe(1);
             this.player1.clickCard(this.troll);
             expect(this.player1).not.toHavePromptButton('Reap with this creature');

--- a/test/server/cards/03-WC/SelfBolsteringAutomata.spec.js
+++ b/test/server/cards/03-WC/SelfBolsteringAutomata.spec.js
@@ -29,7 +29,7 @@ describe('Self-Bolstering Automata', function () {
                 });
 
                 it('should not gain 2 +1 power counters, since it was exhausted by fighting', function () {
-                    expect(this.selfBolsteringAutomata.tokens.power).toBeUndefined();
+                    expect(this.selfBolsteringAutomata.powerCounters).toBe(0);
                 });
             });
         });
@@ -62,7 +62,7 @@ describe('Self-Bolstering Automata', function () {
                 expect(this.selfBolsteringAutomata.location).toBe('play area');
                 expect(this.selfBolsteringAutomata.exhausted).toBe(true);
                 expect(this.player1.player.cardsInPlay[1]).toBe(this.selfBolsteringAutomata);
-                expect(this.selfBolsteringAutomata.tokens.power).toBe(2);
+                expect(this.selfBolsteringAutomata.powerCounters).toBe(2);
             });
         });
 

--- a/test/server/cards/03-WC/Skoll.spec.js
+++ b/test/server/cards/03-WC/Skoll.spec.js
@@ -16,7 +16,7 @@ describe('Sköll', function () {
             this.player1.fightWith(this.sköll, this.nexus);
             this.player1.clickCard(this.troll);
             expect(this.nexus.location).toBe('discard');
-            expect(this.troll.tokens.power).toBe(1);
+            expect(this.troll.powerCounters).toBe(1);
             this.player1.endTurn();
         });
 
@@ -24,7 +24,7 @@ describe('Sköll', function () {
             this.player1.fightWith(this.sköll, this.valdr);
             expect(this.valdr.location).toBe('discard');
             expect(this.sköll.location).toBe('discard');
-            expect(this.troll.tokens.power).toBe(undefined);
+            expect(this.troll.powerCounters).toBe(0);
             this.player1.endTurn();
         });
     });

--- a/test/server/cards/03-WC/TheFittest.spec.js
+++ b/test/server/cards/03-WC/TheFittest.spec.js
@@ -14,12 +14,12 @@ describe('The Fittest', function () {
         });
         it('should give all friendly creatures a +1 power counter', function () {
             this.player1.play(this.theFittest);
-            expect(this.dustPixie.tokens.power).toBe(1);
-            expect(this.rustgnawer.tokens.power).toBe(1);
-            expect(this.snufflegator.tokens.power).toBe(1);
-            expect(this.duskwitch.tokens.power).toBe(1);
-            expect(this.mightyTiger.tokens.power).toBe(undefined);
-            expect(this.grabberJammer.tokens.power).toBe(undefined);
+            expect(this.dustPixie.powerCounters).toBe(1);
+            expect(this.rustgnawer.powerCounters).toBe(1);
+            expect(this.snufflegator.powerCounters).toBe(1);
+            expect(this.duskwitch.powerCounters).toBe(1);
+            expect(this.mightyTiger.powerCounters).toBe(0);
+            expect(this.grabberJammer.powerCounters).toBe(0);
         });
     });
 });

--- a/test/server/cards/04-MM/Chonkers.spec.js
+++ b/test/server/cards/04-MM/Chonkers.spec.js
@@ -16,7 +16,7 @@ describe('Chonkers', function () {
 
         it('should have 1 power counter after play', function () {
             this.player1.playCreature(this.chonkers);
-            expect(this.chonkers.tokens.power).toBe(1);
+            expect(this.chonkers.powerCounters).toBe(1);
         });
     });
 
@@ -37,7 +37,7 @@ describe('Chonkers', function () {
         it('should double chonkers power counters when attacking', function () {
             this.chonkers.tokens.power = 3;
             this.player1.fightWith(this.chonkers, this.grovekeeper);
-            expect(this.chonkers.tokens.power).toBe(6);
+            expect(this.chonkers.powerCounters).toBe(6);
         });
 
         it('should double chonkers power counters when defending', function () {
@@ -45,7 +45,7 @@ describe('Chonkers', function () {
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');
             this.player2.fightWith(this.grovekeeper, this.chonkers);
-            expect(this.chonkers.tokens.power).toBe(6);
+            expect(this.chonkers.powerCounters).toBe(6);
         });
     });
 });

--- a/test/server/cards/04-MM/Floomf.spec.js
+++ b/test/server/cards/04-MM/Floomf.spec.js
@@ -24,7 +24,7 @@ describe('Floomf', function () {
             expect(this.player1).toBeAbleToSelect(this.niffleQueen);
 
             this.player1.clickCard(this.niffleQueen);
-            expect(this.niffleQueen.tokens.power).toBe(2);
+            expect(this.niffleQueen.powerCounters).toBe(2);
         });
     });
 });

--- a/test/server/cards/04-MM/GrowthSurge.spec.js
+++ b/test/server/cards/04-MM/GrowthSurge.spec.js
@@ -41,7 +41,7 @@ describe('Growth Surge', function () {
             expect(this.player1).toBeAbleToSelect(this.titanMechanic);
             expect(this.player1).toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.troll);
-            expect(this.troll.tokens.power).toBe(3);
+            expect(this.troll.powerCounters).toBe(3);
             expect(this.player1).isReadyToTakeAction();
         });
     });
@@ -69,8 +69,8 @@ describe('Growth Surge', function () {
             expect(this.player1).toBeAbleToSelect(this.krump);
             expect(this.player1).toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.troll);
-            expect(this.troll.tokens.power).toBe(3);
-            expect(this.krump.tokens.power).toBe(2);
+            expect(this.troll.powerCounters).toBe(3);
+            expect(this.krump.powerCounters).toBe(2);
             expect(this.player1).isReadyToTakeAction();
         });
     });
@@ -102,11 +102,11 @@ describe('Growth Surge', function () {
             expect(this.player1).not.toBeAbleToSelect(this.krump);
             expect(this.player1).not.toBeAbleToSelect(this.redlock);
             this.player1.clickCard(this.troll);
-            expect(this.troll.tokens.power).toBe(3);
-            expect(this.groggins.tokens.power).toBe(2);
-            expect(this.krump.tokens.power).toBe(1);
-            expect(this.redlock.tokens.power).toBeUndefined();
-            expect(this.lamindra.tokens.power).toBeUndefined();
+            expect(this.troll.powerCounters).toBe(3);
+            expect(this.groggins.powerCounters).toBe(2);
+            expect(this.krump.powerCounters).toBe(1);
+            expect(this.redlock.powerCounters).toBe(0);
+            expect(this.lamindra.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -130,11 +130,11 @@ describe('Growth Surge', function () {
             expect(this.player1).not.toBeAbleToSelect(this.groggins);
             expect(this.player1).not.toBeAbleToSelect(this.redlock);
             this.player1.clickCard(this.troll);
-            expect(this.groggins.tokens.power).toBe(3);
-            expect(this.troll.tokens.power).toBe(2);
-            expect(this.krump.tokens.power).toBeUndefined();
-            expect(this.redlock.tokens.power).toBeUndefined();
-            expect(this.lamindra.tokens.power).toBeUndefined();
+            expect(this.groggins.powerCounters).toBe(3);
+            expect(this.troll.powerCounters).toBe(2);
+            expect(this.krump.powerCounters).toBe(0);
+            expect(this.redlock.powerCounters).toBe(0);
+            expect(this.lamindra.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -158,11 +158,11 @@ describe('Growth Surge', function () {
             expect(this.player1).not.toBeAbleToSelect(this.groggins);
             expect(this.player1).not.toBeAbleToSelect(this.redlock);
             this.player1.clickCard(this.krump);
-            expect(this.groggins.tokens.power).toBe(3);
-            expect(this.krump.tokens.power).toBe(2);
-            expect(this.redlock.tokens.power).toBe(1);
-            expect(this.troll.tokens.power).toBeUndefined();
-            expect(this.lamindra.tokens.power).toBeUndefined();
+            expect(this.groggins.powerCounters).toBe(3);
+            expect(this.krump.powerCounters).toBe(2);
+            expect(this.redlock.powerCounters).toBe(1);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.lamindra.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/04-MM/RapidEvolution.spec.js
+++ b/test/server/cards/04-MM/RapidEvolution.spec.js
@@ -20,8 +20,8 @@ describe('Rapid Evolution', function () {
             expect(this.player1).toBeAbleToSelect(this.flaxia);
             expect(this.player1).toBeAbleToSelect(this.odoacThePatrician);
             this.player1.clickCard(this.flaxia);
-            expect(this.flaxia.tokens.power).toBe(5);
-            expect(this.odoacThePatrician.tokens.power).toBeUndefined();
+            expect(this.flaxia.powerCounters).toBe(5);
+            expect(this.odoacThePatrician.powerCounters).toBe(0);
         });
     });
 });

--- a/test/server/cards/04-MM/Skixuno.spec.js
+++ b/test/server/cards/04-MM/Skixuno.spec.js
@@ -17,7 +17,7 @@ describe('Skixuno', function () {
             this.player1.play(this.skixuno);
 
             expect(this.skixuno.location).toBe('play area');
-            expect(this.skixuno.tokens.power).toBe(3);
+            expect(this.skixuno.powerCounters).toBe(3);
 
             expect(this.emberImp.location).toBe('discard');
             expect(this.rotgrub.location).toBe('discard');
@@ -29,7 +29,7 @@ describe('Skixuno', function () {
             this.player1.play(this.skixuno);
 
             expect(this.skixuno.location).toBe('play area');
-            expect(this.skixuno.tokens.power).toBe(2);
+            expect(this.skixuno.powerCounters).toBe(2);
 
             expect(this.rotgrub.location).toBe('play area');
             expect(this.emberImp.location).toBe('discard');
@@ -65,7 +65,7 @@ describe('Skixuno', function () {
             expect(this.player2).toHavePrompt('House Choice');
 
             expect(this.skixuno.location).toBe('play area');
-            expect(this.skixuno.tokens.power).toBe(2);
+            expect(this.skixuno.powerCounters).toBe(2);
 
             expect(this.pitlord.location).toBe('discard');
             expect(this.emberImp.location).toBe('discard');

--- a/test/server/cards/05-DT/5c077.spec.js
+++ b/test/server/cards/05-DT/5c077.spec.js
@@ -37,7 +37,7 @@ describe('5C077', function () {
                 it('should add +1 power counter', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(4);
+                    expect(this['5c077'].powerCounters).toBe(4);
                     expect(this['5c077'].power).toBe(6);
                     this.player1.endTurn();
                 });
@@ -51,7 +51,7 @@ describe('5C077', function () {
                 it('should descrease power counters', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(2);
+                    expect(this['5c077'].powerCounters).toBe(2);
                     expect(this['5c077'].power).toBe(4);
                     this.player1.endTurn();
                 });
@@ -65,7 +65,7 @@ describe('5C077', function () {
                 it('should descrease power counters', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(3);
+                    expect(this['5c077'].powerCounters).toBe(3);
                     expect(this['5c077'].power).toBe(5);
                     this.player1.endTurn();
                 });
@@ -92,7 +92,7 @@ describe('5C077', function () {
                 it('should add +1 power counter', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(4);
+                    expect(this['5c077'].powerCounters).toBe(4);
                     expect(this['5c077'].power).toBe(6);
                     this.player1.endTurn();
                 });
@@ -106,7 +106,7 @@ describe('5C077', function () {
                 it('should descrease power counters', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(2);
+                    expect(this['5c077'].powerCounters).toBe(2);
                     expect(this['5c077'].power).toBe(4);
                     this.player1.endTurn();
                 });
@@ -120,7 +120,7 @@ describe('5C077', function () {
                 it('should descrease power counters', function () {
                     expect(this.player1.amber).toBe(2);
                     expect(this['5c077'].exhausted).toBe(true);
-                    expect(this['5c077'].tokens.power).toBe(3);
+                    expect(this['5c077'].powerCounters).toBe(3);
                     expect(this['5c077'].power).toBe(5);
                     this.player1.endTurn();
                 });
@@ -199,7 +199,7 @@ describe('5C077', function () {
                         });
 
                         it('should add +1 power counters', function () {
-                            expect(this['5c077'].tokens.power).toBe(1);
+                            expect(this['5c077'].powerCounters).toBe(1);
                             expect(this['5c077'].power).toBe(3);
                             expect(this.player1).isReadyToTakeAction();
                         });
@@ -225,7 +225,7 @@ describe('5C077', function () {
                                 });
 
                                 it('should remove its power counters', function () {
-                                    expect(this['5c077'].tokens.power).toBeUndefined();
+                                    expect(this['5c077'].powerCounters).toBe(0);
                                     expect(this['5c077'].power).toBe(2);
                                     expect(this.player1).isReadyToTakeAction();
                                 });

--- a/test/server/cards/05-DT/5c077EvilTwin.spec.js
+++ b/test/server/cards/05-DT/5c077EvilTwin.spec.js
@@ -33,7 +33,7 @@ describe('5C077 Evil Twin', function () {
                 });
 
                 it('should add +1 power counter', function () {
-                    expect(this['5c077EvilTwin'].tokens.power).toBe(4);
+                    expect(this['5c077EvilTwin'].powerCounters).toBe(4);
                     expect(this['5c077EvilTwin'].power).toBe(6);
                 });
             });
@@ -44,7 +44,7 @@ describe('5C077 Evil Twin', function () {
                 });
 
                 it('should descrease power counters', function () {
-                    expect(this['5c077EvilTwin'].tokens.power).toBe(2);
+                    expect(this['5c077EvilTwin'].powerCounters).toBe(2);
                     expect(this['5c077EvilTwin'].power).toBe(4);
                 });
             });
@@ -55,7 +55,7 @@ describe('5C077 Evil Twin', function () {
                 });
 
                 it('should descrease power counters', function () {
-                    expect(this['5c077EvilTwin'].tokens.power).toBe(3);
+                    expect(this['5c077EvilTwin'].powerCounters).toBe(3);
                     expect(this['5c077EvilTwin'].power).toBe(5);
                 });
             });
@@ -122,7 +122,7 @@ describe('5C077 Evil Twin', function () {
                     });
 
                     it('should add +1 power counters', function () {
-                        expect(this['5c077EvilTwin'].tokens.power).toBe(1);
+                        expect(this['5c077EvilTwin'].powerCounters).toBe(1);
                         expect(this['5c077EvilTwin'].power).toBe(3);
                         expect(this.player1).isReadyToTakeAction();
                     });

--- a/test/server/cards/05-DT/AmberfinShark.spec.js
+++ b/test/server/cards/05-DT/AmberfinShark.spec.js
@@ -20,7 +20,7 @@ describe('Æmberfin Shark', function () {
             });
 
             it('should have 3 power counters', function () {
-                expect(this.æmberfinShark.tokens.power).toBe(3);
+                expect(this.æmberfinShark.powerCounters).toBe(3);
             });
 
             describe('at the end of player 1 turn', function () {
@@ -29,7 +29,7 @@ describe('Æmberfin Shark', function () {
                 });
 
                 it('should have 2 power counters and make each player gain 1 amber', function () {
-                    expect(this.æmberfinShark.tokens.power).toBe(2);
+                    expect(this.æmberfinShark.powerCounters).toBe(2);
                     expect(this.player1.amber).toBe(2);
                     expect(this.player2.amber).toBe(3);
                 });
@@ -41,7 +41,7 @@ describe('Æmberfin Shark', function () {
                     });
 
                     it('should continue with 2 power counters and players do not gain amber', function () {
-                        expect(this.æmberfinShark.tokens.power).toBe(2);
+                        expect(this.æmberfinShark.powerCounters).toBe(2);
                         expect(this.player1.amber).toBe(2);
                         expect(this.player2.amber).toBe(3);
                     });
@@ -57,7 +57,7 @@ describe('Æmberfin Shark', function () {
                         });
 
                         it('should have no power counters and players gained 2 ambers each', function () {
-                            expect(this.æmberfinShark.tokens.power).toBeUndefined();
+                            expect(this.æmberfinShark.powerCounters).toBe(0);
                             expect(this.player1.amber).toBe(4);
                             expect(this.player2.amber).toBe(5);
                         });
@@ -75,7 +75,7 @@ describe('Æmberfin Shark', function () {
                             });
 
                             it('should have no power counters and players will not gain amber', function () {
-                                expect(this.æmberfinShark.tokens.power).toBeUndefined();
+                                expect(this.æmberfinShark.powerCounters).toBe(0);
                                 expect(this.player1.amber).toBe(4);
                                 expect(this.player2.amber).toBe(5);
                             });

--- a/test/server/cards/05-DT/AmberfinSharkEvilTwin.spec.js
+++ b/test/server/cards/05-DT/AmberfinSharkEvilTwin.spec.js
@@ -24,7 +24,7 @@ describe('Amberfin Shark Evil Twin', function () {
             this.player1.endTurn();
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(0);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBeUndefined();
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(0);
         });
 
         it('should cause player 1 to lose one A and gain 1 power', function () {
@@ -35,7 +35,7 @@ describe('Amberfin Shark Evil Twin', function () {
             this.player1.endTurn();
             expect(this.player1.amber).toBe(1);
             expect(this.player2.amber).toBe(0);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBe(1);
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(1);
         });
 
         it('should cause player 2 to lose one A and gain 1 power', function () {
@@ -46,7 +46,7 @@ describe('Amberfin Shark Evil Twin', function () {
             this.player1.endTurn();
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(1);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBe(1);
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(1);
         });
 
         it('should cause both players 1 to lose one A and gain 2 power', function () {
@@ -57,7 +57,7 @@ describe('Amberfin Shark Evil Twin', function () {
             this.player1.endTurn();
             expect(this.player1.amber).toBe(1);
             expect(this.player2.amber).toBe(1);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBe(2);
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(2);
         });
 
         it('should only trigger at the end of the controllers turn', function () {
@@ -68,13 +68,13 @@ describe('Amberfin Shark Evil Twin', function () {
             this.player1.endTurn();
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(2);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBe(2);
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(2);
 
             this.player2.clickPrompt('untamed');
             this.player2.endTurn();
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(2);
-            expect(this.æmberfinSharkEvilTwin.tokens.power).toBe(2);
+            expect(this.æmberfinSharkEvilTwin.powerCounters).toBe(2);
         });
     });
 });

--- a/test/server/cards/05-DT/Ambermancy.spec.js
+++ b/test/server/cards/05-DT/Ambermancy.spec.js
@@ -26,7 +26,7 @@ describe('Ambermancy', function () {
             this.flaxia.addToken('power');
             this.flaxia.addToken('power');
             this.flaxia.addToken('power');
-            expect(this.flaxia.tokens.power).toBe(4);
+            expect(this.flaxia.powerCounters).toBe(4);
             this.player1.play(this.æmbermancy);
             this.player1.clickCard(this.flaxia);
             expect(this.player1).toHavePromptButton('0');
@@ -35,7 +35,7 @@ describe('Ambermancy', function () {
             expect(this.player1).toHavePromptButton('3');
             expect(this.player1).not.toHavePromptButton('4');
             this.player1.clickPrompt('0');
-            expect(this.flaxia.tokens.power).toBe(4);
+            expect(this.flaxia.powerCounters).toBe(4);
         });
 
         it('should remove the number of tokens requested and give aember for that number', function () {
@@ -43,11 +43,11 @@ describe('Ambermancy', function () {
             this.flaxia.addToken('power');
             this.flaxia.addToken('power');
             this.flaxia.addToken('power');
-            expect(this.flaxia.tokens.power).toBe(4);
+            expect(this.flaxia.powerCounters).toBe(4);
             this.player1.play(this.æmbermancy);
             this.player1.clickCard(this.flaxia);
             this.player1.clickPrompt('2');
-            expect(this.flaxia.tokens.power).toBe(2);
+            expect(this.flaxia.powerCounters).toBe(2);
             expect(this.player1.amber).toBe(4); // start at 1, 1 for æmbermancy, 2 from effect
         });
     });

--- a/test/server/cards/05-DT/ComOfficerGross.spec.js
+++ b/test/server/cards/05-DT/ComOfficerGross.spec.js
@@ -72,10 +72,10 @@ describe('Com. Officer Gross', function () {
                     });
 
                     it('should add +1 power counter to creatures among them', function () {
-                        expect(this.comOfficerGross.tokens.power).toBeUndefined();
-                        expect(this.armsmasterMolina.tokens.power).toBe(1);
-                        expect(this.tantadlin.tokens.power).toBe(1);
-                        expect(this.comOfficerHings1.tokens.power).toBeUndefined();
+                        expect(this.comOfficerGross.powerCounters).toBe(0);
+                        expect(this.armsmasterMolina.powerCounters).toBe(1);
+                        expect(this.tantadlin.powerCounters).toBe(1);
+                        expect(this.comOfficerHings1.powerCounters).toBe(0);
                     });
                 });
 
@@ -100,11 +100,11 @@ describe('Com. Officer Gross', function () {
                     });
 
                     it('should add +1 power counter to creatures among them', function () {
-                        expect(this.comOfficerGross.tokens.power).toBeUndefined();
-                        expect(this.armsmasterMolina.tokens.power).toBe(1);
-                        expect(this.tantadlin.tokens.power).toBe(1);
-                        expect(this.comOfficerHings1.tokens.power).toBe(1);
-                        expect(this.comOfficerHings2.tokens.power).toBeUndefined();
+                        expect(this.comOfficerGross.powerCounters).toBe(0);
+                        expect(this.armsmasterMolina.powerCounters).toBe(1);
+                        expect(this.tantadlin.powerCounters).toBe(1);
+                        expect(this.comOfficerHings1.powerCounters).toBe(1);
+                        expect(this.comOfficerHings2.powerCounters).toBe(0);
                     });
                 });
 
@@ -121,10 +121,10 @@ describe('Com. Officer Gross', function () {
                     });
 
                     it('should add +1 power counter to creatures among them', function () {
-                        expect(this.comOfficerGross.tokens.power).toBeUndefined();
-                        expect(this.armsmasterMolina.tokens.power).toBe(1);
-                        expect(this.tantadlin.tokens.power).toBe(1);
-                        expect(this.comOfficerHings1.tokens.power).toBeUndefined();
+                        expect(this.comOfficerGross.powerCounters).toBe(0);
+                        expect(this.armsmasterMolina.powerCounters).toBe(1);
+                        expect(this.tantadlin.powerCounters).toBe(1);
+                        expect(this.comOfficerHings1.powerCounters).toBe(0);
                     });
                 });
             });

--- a/test/server/cards/05-DT/GeneticDrift.spec.js
+++ b/test/server/cards/05-DT/GeneticDrift.spec.js
@@ -32,10 +32,10 @@ describe('Genetic Drift', function () {
             });
 
             it('should give this creature a +1 power token and +1 power token to exch creature with power tokens', function () {
-                expect(this.flaxia.tokens.power).toBe(3);
-                expect(this.bumblebird.tokens.power).toBe(2);
-                expect(this.gub.tokens.power).toBe(2);
-                expect(this.krump.tokens.power).toBeUndefined();
+                expect(this.flaxia.powerCounters).toBe(3);
+                expect(this.bumblebird.powerCounters).toBe(2);
+                expect(this.gub.powerCounters).toBe(2);
+                expect(this.krump.powerCounters).toBe(0);
             });
         });
     });

--- a/test/server/cards/05-DT/Mookling.spec.js
+++ b/test/server/cards/05-DT/Mookling.spec.js
@@ -36,7 +36,7 @@ describe('Mookling', function () {
 
         it('should make player2 key more expensive because of extra power token on Mookling', function () {
             this.mookling.addToken('power');
-            expect(this.mookling.tokens.power).toBe(1);
+            expect(this.mookling.powerCounters).toBe(1);
             this.player2.amber = 10;
             expect(this.player2.amber).toBe(10);
             this.player1.endTurn();

--- a/test/server/cards/05-DT/MooklingEvilTwin.spec.js
+++ b/test/server/cards/05-DT/MooklingEvilTwin.spec.js
@@ -39,21 +39,21 @@ describe('Mookling Evil Twin', function () {
             this.player2.clickPrompt('untamed');
             this.player2.endTurn();
             this.player1.forgeKey('Red');
-            expect(this.mooklingEvilTwin.tokens.power).toBeUndefined();
+            expect(this.mooklingEvilTwin.powerCounters).toBe(0);
         });
 
         it('should gain power when opponent forges', function () {
-            expect(this.mooklingEvilTwin.tokens.power).toBeUndefined();
+            expect(this.mooklingEvilTwin.powerCounters).toBe(0);
             this.player2.amber = 7;
             expect(this.player2.amber).toBe(7);
             this.player1.endTurn();
             this.player2.forgeKey('Red');
             expect(this.player2.amber).toBe(1);
-            expect(this.mooklingEvilTwin.tokens.power).toBe(6);
+            expect(this.mooklingEvilTwin.powerCounters).toBe(6);
         });
 
         it('should gain less power if the key is less expensive', function () {
-            expect(this.mooklingEvilTwin.tokens.power).toBeUndefined();
+            expect(this.mooklingEvilTwin.powerCounters).toBe(0);
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');
             this.player2.endTurn();
@@ -65,18 +65,18 @@ describe('Mookling Evil Twin', function () {
             this.player1.endTurn();
             this.player2.forgeKey('Red');
             expect(this.player2.amber).toBe(0);
-            expect(this.mooklingEvilTwin.tokens.power).toBe(5);
+            expect(this.mooklingEvilTwin.powerCounters).toBe(5);
         });
 
         it('should gain extra power if the key is more expensive', function () {
-            expect(this.mooklingEvilTwin.tokens.power).toBeUndefined();
+            expect(this.mooklingEvilTwin.powerCounters).toBe(0);
             this.player1.play(this.murmook);
             this.player2.amber = 7;
             expect(this.player2.amber).toBe(7);
             this.player1.endTurn();
             this.player2.forgeKey('Red');
             expect(this.player2.amber).toBe(0);
-            expect(this.mooklingEvilTwin.tokens.power).toBe(7);
+            expect(this.mooklingEvilTwin.powerCounters).toBe(7);
         });
     });
 });

--- a/test/server/cards/05-DT/PrimalRelic.spec.js
+++ b/test/server/cards/05-DT/PrimalRelic.spec.js
@@ -32,9 +32,9 @@ describe('Primal Relic', function () {
             this.player1.clickCard(this.flaxia);
             this.player1.clickPrompt('Done');
 
-            expect(this.dustPixie.tokens.power).toBe(1);
-            expect(this.krump.tokens.power).toBe(1);
-            expect(this.flaxia.tokens.power).toBe(1);
+            expect(this.dustPixie.powerCounters).toBe(1);
+            expect(this.krump.powerCounters).toBe(1);
+            expect(this.flaxia.powerCounters).toBe(1);
 
             this.player1.endTurn();
         });

--- a/test/server/cards/05-DT/ReapOrSow.spec.js
+++ b/test/server/cards/05-DT/ReapOrSow.spec.js
@@ -95,8 +95,8 @@ describe('Reap Or Sow', function () {
             this.player1.clickCard(this.dustPixie);
             this.player1.clickCard(this.dustPixie);
             this.player1.clickCard(this.troll);
-            expect(this.dustPixie.tokens.power).toBe(2);
-            expect(this.troll.tokens.power).toBe(1);
+            expect(this.dustPixie.powerCounters).toBe(2);
+            expect(this.troll.powerCounters).toBe(1);
         });
 
         describe('and inky gloom is played', function () {

--- a/test/server/cards/05-DT/Sporegorger.spec.js
+++ b/test/server/cards/05-DT/Sporegorger.spec.js
@@ -17,9 +17,9 @@ describe('Sporegorger', function () {
         });
 
         it('should add power token on reap', function () {
-            expect(this.sporegorger.tokens.power).toBeUndefined();
+            expect(this.sporegorger.powerCounters).toBe(0);
             this.player1.reap(this.sporegorger);
-            expect(this.sporegorger.tokens.power).toBe(1);
+            expect(this.sporegorger.powerCounters).toBe(1);
         });
 
         it('should give choice to remove all tokens', function () {
@@ -31,13 +31,13 @@ describe('Sporegorger', function () {
         it('should leave tokens when player chooses to keep them', function () {
             this.player1.reap(this.sporegorger);
             this.player1.clickPrompt('No');
-            expect(this.sporegorger.tokens.power).toBe(1);
+            expect(this.sporegorger.powerCounters).toBe(1);
         });
 
         it('should remove tokens when player chooses loose them', function () {
             this.player1.reap(this.sporegorger);
             this.player1.clickPrompt('Yes');
-            expect(this.sporegorger.tokens.power).toBeUndefined();
+            expect(this.sporegorger.powerCounters).toBe(0);
         });
 
         it('should deal damage to all other creatures when reaping and removing all tokens', function () {
@@ -58,7 +58,7 @@ describe('Sporegorger', function () {
             this.player1.clickPrompt('untamed');
             this.player1.reap(this.sporegorger);
             this.player1.clickPrompt('Yes');
-            expect(this.sporegorger.tokens.power).toBeUndefined();
+            expect(this.sporegorger.powerCounters).toBe(0);
             expect(this.sporegorger.tokens.damage).toBeUndefined();
             expect(this.mother.tokens.damage).toBe(2);
             expect(this.krump.tokens.damage).toBe(2);

--- a/test/server/cards/05-DT/SporegorgerEvilTwin.spec.js
+++ b/test/server/cards/05-DT/SporegorgerEvilTwin.spec.js
@@ -24,10 +24,10 @@ describe('Sporegorger Evil Twin', function () {
 
             this.player1.play(this.sporegorgerEvilTwin);
 
-            expect(this.mother.tokens.power).toBeUndefined();
-            expect(this.urchin.tokens.power).toBeUndefined();
-            expect(this.krump.tokens.power).toBeUndefined();
-            expect(this.sporegorgerEvilTwin.tokens.power).toBe(4);
+            expect(this.mother.powerCounters).toBe(0);
+            expect(this.urchin.powerCounters).toBe(0);
+            expect(this.krump.powerCounters).toBe(0);
+            expect(this.sporegorgerEvilTwin.powerCounters).toBe(4);
         });
 
         it('should give choice to remove all tokens, and leave them if the user chooses to keep them', function () {
@@ -43,11 +43,11 @@ describe('Sporegorger Evil Twin', function () {
             this.player1.clickPrompt('untamed');
 
             this.player1.reap(this.sporegorgerEvilTwin);
-            expect(this.sporegorgerEvilTwin.tokens.power).toBe(4);
+            expect(this.sporegorgerEvilTwin.powerCounters).toBe(4);
             expect(this.player1).toHavePromptButton('Yes');
             expect(this.player1).toHavePromptButton('No');
             this.player1.clickPrompt('No');
-            expect(this.sporegorgerEvilTwin.tokens.power).toBe(4);
+            expect(this.sporegorgerEvilTwin.powerCounters).toBe(4);
         });
 
         it('deal damage to other cretures if player chooses to remove them', function () {
@@ -63,9 +63,9 @@ describe('Sporegorger Evil Twin', function () {
             this.player1.clickPrompt('untamed');
 
             this.player1.reap(this.sporegorgerEvilTwin);
-            expect(this.sporegorgerEvilTwin.tokens.power).toBe(4);
+            expect(this.sporegorgerEvilTwin.powerCounters).toBe(4);
             this.player1.clickPrompt('Yes');
-            expect(this.sporegorgerEvilTwin.tokens.power).toBeUndefined();
+            expect(this.sporegorgerEvilTwin.powerCounters).toBe(0);
             expect(this.sporegorgerEvilTwin.tokens.damage).toBeUndefined();
             expect(this.mother.tokens.damage).toBe(4);
             expect(this.krump.tokens.damage).toBe(4);

--- a/test/server/cards/05-DT/SwallowWhole.spec.js
+++ b/test/server/cards/05-DT/SwallowWhole.spec.js
@@ -43,9 +43,9 @@ describe('Swallow Whole', function () {
                 this.player1.clickCard(this.krump);
 
                 expect(this.senatorShrix.location).toBe('purged');
-                expect(this.krump.tokens.power).toBe(4);
-                expect(this.gub.tokens.power).toBeUndefined();
-                expect(this.shooler.tokens.power).toBeUndefined();
+                expect(this.krump.powerCounters).toBe(4);
+                expect(this.gub.powerCounters).toBe(0);
+                expect(this.shooler.powerCounters).toBe(0);
             });
 
             describe('there are two creatures with equal highest power', function () {
@@ -71,9 +71,9 @@ describe('Swallow Whole', function () {
                     this.player1.clickCard(this.shooler);
 
                     expect(this.krump.location).toBe('purged');
-                    expect(this.shooler.tokens.power).toBe(7);
-                    expect(this.gub.tokens.power).toBeUndefined();
-                    expect(this.senatorShrix.tokens.power).toBeUndefined();
+                    expect(this.shooler.powerCounters).toBe(7);
+                    expect(this.gub.powerCounters).toBe(0);
+                    expect(this.senatorShrix.powerCounters).toBe(0);
                 });
             });
         });

--- a/test/server/cards/05-DT/TalmageSteelheart.spec.js
+++ b/test/server/cards/05-DT/TalmageSteelheart.spec.js
@@ -20,7 +20,7 @@ describe('Talmage Steelheart', function () {
             });
 
             it('should gain +1 power counter', function () {
-                expect(this.talmageSteelheart.tokens.power).toBe(1);
+                expect(this.talmageSteelheart.powerCounters).toBe(1);
             });
         });
 
@@ -34,7 +34,7 @@ describe('Talmage Steelheart', function () {
             });
 
             it('should gain as much power counters', function () {
-                expect(this.talmageSteelheart.tokens.power).toBe(5);
+                expect(this.talmageSteelheart.powerCounters).toBe(5);
             });
         });
     });

--- a/test/server/cards/05-DT/TheMysticeti.spec.js
+++ b/test/server/cards/05-DT/TheMysticeti.spec.js
@@ -36,7 +36,7 @@ describe('The Mysticeti', function () {
                 expect(this.player1).not.toBeAbleToSelect(this.murkens);
                 expect(this.player1).isReadyToTakeAction();
                 expect(this.theMysticeti.type).toBe('artifact');
-                expect(this.theMysticeti.tokens.power).toBeUndefined();
+                expect(this.theMysticeti.powerCounters).toBe(0);
             });
         });
 
@@ -69,7 +69,7 @@ describe('The Mysticeti', function () {
 
                 expect(this.player1).isReadyToTakeAction();
                 expect(this.theMysticeti.type).toBe('artifact');
-                expect(this.theMysticeti.tokens.power).toBeUndefined();
+                expect(this.theMysticeti.powerCounters).toBe(0);
             });
         });
 
@@ -89,7 +89,7 @@ describe('The Mysticeti', function () {
 
                 expect(this.player1).isReadyToTakeAction();
                 expect(this.theMysticeti.type).toBe('artifact');
-                expect(this.theMysticeti.tokens.power).toBeUndefined();
+                expect(this.theMysticeti.powerCounters).toBe(0);
             });
 
             it('should be able to choose non-exhausted creatures and move it to battleline', function () {
@@ -114,7 +114,7 @@ describe('The Mysticeti', function () {
 
                 expect(this.player1).isReadyToTakeAction();
                 expect(this.theMysticeti.type).toBe('creature');
-                expect(this.theMysticeti.tokens.power).toBe(6);
+                expect(this.theMysticeti.powerCounters).toBe(6);
                 expect(this.theMysticeti.hasKeyword('taunt')).toBe(true);
             });
         });
@@ -140,7 +140,7 @@ describe('The Mysticeti', function () {
 
                 expect(this.player1).isReadyToTakeAction();
                 expect(this.theMysticeti.type).toBe('creature');
-                expect(this.theMysticeti.tokens.power).toBe(12);
+                expect(this.theMysticeti.powerCounters).toBe(12);
                 expect(this.theMysticeti.hasKeyword('taunt')).toBe(true);
             });
         });
@@ -158,7 +158,7 @@ describe('The Mysticeti', function () {
                 this.player2.clickCard(this.tantadlin);
                 this.player2.clickPrompt('Done');
                 expect(this.tantadlin.exhausted).toBe(true);
-                expect(this.theMysticeti.tokens.power).toBe(3);
+                expect(this.theMysticeti.powerCounters).toBe(3);
                 expect(this.theMysticeti.controller).toBe(this.player1.player);
                 expect(this.theMysticeti.exhausted).toBe(true);
                 expect(this.theMysticeti.type).toBe('artifact');

--- a/test/server/cards/08-AS/Beehemoth.spec.js
+++ b/test/server/cards/08-AS/Beehemoth.spec.js
@@ -24,7 +24,7 @@ describe('Beehemoth', function () {
             expect(this.player1).toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.flaxia);
             expect(this.flaxia.getPower()).toBe(5);
-            expect(this.flaxia.tokens.power).toBe(1);
+            expect(this.flaxia.powerCounters).toBe(1);
             this.player1.clickPrompt('brobnar');
         });
 
@@ -48,8 +48,8 @@ describe('Beehemoth', function () {
             this.player1.clickCard(this.flaxia);
             this.player1.clickPrompt('Left');
             expect(this.player1.amber).toBe(7);
-            expect(this.flaxia.tokens.power).toBe(undefined);
-            expect(this.huntingWitch.tokens.power).toBe(undefined);
+            expect(this.flaxia.powerCounters).toBe(0);
+            expect(this.huntingWitch.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -59,8 +59,8 @@ describe('Beehemoth', function () {
             this.player1.clickCard(this.flaxia);
             this.player1.clickPrompt('Left');
             expect(this.player1.amber).toBe(5);
-            expect(this.flaxia.tokens.power).toBe(undefined);
-            expect(this.huntingWitch.tokens.power).toBe(undefined);
+            expect(this.flaxia.powerCounters).toBe(0);
+            expect(this.huntingWitch.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 

--- a/test/server/cards/08-AS/CrimsonDax.spec.js
+++ b/test/server/cards/08-AS/CrimsonDax.spec.js
@@ -27,7 +27,7 @@ describe('Crimson Dax', function () {
             expect(this.player1).not.toBeAbleToSelect(this.thunderdell);
             expect(this.player1).not.toBeAbleToSelect(this.brikkNastee);
             this.player1.clickCard(this.drXyloxxzlphrex);
-            expect(this.drXyloxxzlphrex.tokens.power).toBe(3);
+            expect(this.drXyloxxzlphrex.powerCounters).toBe(3);
         });
 
         it('should allow the player to select 0 cards', function () {

--- a/test/server/cards/08-AS/DonorVox.spec.js
+++ b/test/server/cards/08-AS/DonorVox.spec.js
@@ -19,7 +19,7 @@ describe('Donor Vox', function () {
             expect(this.player1).not.toBeAbleToSelect(this.thunderdell);
             expect(this.player1).not.toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.drXyloxxzlphrex);
-            expect(this.drXyloxxzlphrex.tokens.power).toBe(2);
+            expect(this.drXyloxxzlphrex.powerCounters).toBe(2);
         });
     });
 });

--- a/test/server/cards/12-PV/ChonkEvermore.spec.js
+++ b/test/server/cards/12-PV/ChonkEvermore.spec.js
@@ -26,10 +26,10 @@ describe('Chonk Evermore', function () {
             this.player1.play(this.chonkEvermore);
             expect(this.player1).toHavePrompt('Chonk Evermore');
             this.player1.clickPrompt('Continue');
-            expect(this.emberImp.tokens.power).toBe(undefined);
-            expect(this.troll.tokens.power).toBe(undefined);
-            expect(this.krump.tokens.power).toBe(undefined);
-            expect(this.cpoZytar.tokens.power).toBe(6);
+            expect(this.emberImp.powerCounters).toBe(0);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.krump.powerCounters).toBe(0);
+            expect(this.cpoZytar.powerCounters).toBe(6);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -44,10 +44,10 @@ describe('Chonk Evermore', function () {
             this.player1.clickCard(this.emberImp);
             this.player1.clickCard(this.krump);
             this.player1.clickPrompt('Done');
-            expect(this.emberImp.tokens.power).toBe(2);
-            expect(this.krump.tokens.power).toBe(2);
-            expect(this.troll.tokens.power).toBe(undefined);
-            expect(this.cpoZytar.tokens.power).toBe(6);
+            expect(this.emberImp.powerCounters).toBe(2);
+            expect(this.krump.powerCounters).toBe(2);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.cpoZytar.powerCounters).toBe(6);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -63,10 +63,10 @@ describe('Chonk Evermore', function () {
             this.player1.clickCard(this.cpoZytar); // trying to select a third creature should do nothing
             expect(this.player1).toHavePromptButton('Done');
             this.player1.clickPrompt('Done');
-            expect(this.emberImp.tokens.power).toBe(2);
-            expect(this.troll.tokens.power).toBe(undefined);
-            expect(this.krump.tokens.power).toBe(2);
-            expect(this.cpoZytar.tokens.power).toBe(6);
+            expect(this.emberImp.powerCounters).toBe(2);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.krump.powerCounters).toBe(2);
+            expect(this.cpoZytar.powerCounters).toBe(6);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -75,10 +75,10 @@ describe('Chonk Evermore', function () {
             this.player1.endTurn();
             this.player2.clickPrompt('brobnar');
             this.player2.reap(this.krump);
-            expect(this.emberImp.tokens.power).toBe(2);
-            expect(this.troll.tokens.power).toBe(2);
-            expect(this.krump.tokens.power).toBe(undefined);
-            expect(this.cpoZytar.tokens.power).toBe(3);
+            expect(this.emberImp.powerCounters).toBe(2);
+            expect(this.troll.powerCounters).toBe(2);
+            expect(this.krump.powerCounters).toBe(0);
+            expect(this.cpoZytar.powerCounters).toBe(3);
             expect(this.chonkEvermore.location).toBe('discard');
             expect(this.player2).isReadyToTakeAction();
         });

--- a/test/server/manualmode/chatcommands.spec.js
+++ b/test/server/manualmode/chatcommands.spec.js
@@ -191,7 +191,7 @@ describe('Chat Commands', function () {
             expect(this.player1.executeCommand('/token power 5')).toBe(true);
             expect(this.player1).toBeAbleToSelect(this.niffleApe);
             this.player1.clickCard(this.niffleApe);
-            expect(this.niffleApe.tokens.power).toBe(5);
+            expect(this.niffleApe.powerCounters).toBe(5);
         });
     });
 

--- a/test/server/manualmode/menucommand.spec.js
+++ b/test/server/manualmode/menucommand.spec.js
@@ -101,16 +101,16 @@ describe('Menu Commands', function () {
         it('player 1 can add and remove power tokens from a creature', function () {
             this.player1.menuClick(this.niffleApe, 'addPower');
             this.player1.menuClick(this.niffleApe, 'addPower');
-            expect(this.niffleApe.tokens.power).toBe(2);
+            expect(this.niffleApe.powerCounters).toBe(2);
             this.player1.menuClick(this.niffleApe, 'remPower');
-            expect(this.niffleApe.tokens.power).toBe(1);
+            expect(this.niffleApe.powerCounters).toBe(1);
         });
 
         it('player 2 can add and remove power tokens from a creature', function () {
             this.player2.menuClick(this.batdrone, 'addPower');
-            expect(this.batdrone.tokens.power).toBe(1);
+            expect(this.batdrone.powerCounters).toBe(1);
             this.player2.menuClick(this.batdrone, 'remPower');
-            expect(this.niffleApe.tokens.power).toBeUndefined();
+            expect(this.niffleApe.powerCounters).toBe(0);
         });
     });
 


### PR DESCRIPTION
feat: Add powerCounters() getter - can now do `expect(this.mugwump.powerCounters).toBe(0);` instead of `expect(this.mugwump.tokens.power).toBeUndefined();`