### PR TITLE
fix: combat pheromones handles leaves play

### DIFF
--- a/server/game/cards/01-Core/CombatPheromones.js
+++ b/server/game/cards/01-Core/CombatPheromones.js
@@ -9,8 +9,16 @@ class CombatPheromones extends Card {
                 numCards: 2,
                 controller: 'self',
                 cardCondition: (card) => card.hasHouse('mars'),
-                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
-                    effect: ability.effects.canUse((card) => context.target.includes(card))
+                gameAction: ability.actions.sequentialForEach((context) => ({
+                    forEach: context.target,
+                    action: (targetCard) =>
+                        ability.actions.lastingEffect({
+                            until: {
+                                onTurnEnd: () => true,
+                                onCardLeavesPlay: (event) => event.card === targetCard
+                            },
+                            effect: ability.effects.canUse((card) => card === targetCard)
+                        })
                 }))
             },
             effect: 'sacrifice {1} and allow them to use {0} this turn',

--- a/test/server/cards/01-Core/CombatPheromones.spec.js
+++ b/test/server/cards/01-Core/CombatPheromones.spec.js
@@ -36,5 +36,59 @@ describe('Combat Pheromones', function () {
             this.player1.clickCard(this.crystalHive);
             expect(this.player1).toHavePrompt('Crystal Hive');
         });
+
+        it('should last until the end of the turn', function () {
+            this.player1.clickCard(this.combatPheromones);
+            this.player1.clickPrompt("Use this card's Omni ability");
+            this.player1.clickCard(this.mindwarper);
+            this.player1.clickPrompt('Done');
+            this.player1.reap(this.mindwarper);
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.endTurn();
+            this.player1.clickPrompt('Sanctum');
+            this.player1.clickCard(this.mindwarper);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Combat Pheromones with destroyed and returned cards', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    inPlay: ['combat-pheromones', 'dr-xyloxxzlphrex', 'ixxyxli-fixfinger']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+        });
+
+        it('should not allow using a card that was destroyed and returned to play', function () {
+            // Use Combat Pheromones to allow using Dr. Xyloxxzlphrex and Ixxyxli Fixfinger
+            this.player1.clickCard(this.combatPheromones);
+            this.player1.clickPrompt("Use this card's Omni ability");
+            this.player1.clickCard(this.drXyloxxzlphrex);
+            this.player1.clickCard(this.ixxyxliFixfinger);
+            this.player1.clickPrompt('Done');
+
+            // Destroy Fixfinger
+            this.player1.fightWith(this.ixxyxliFixfinger, this.troll);
+            expect(this.ixxyxliFixfinger.location).toBe('discard');
+
+            // Reap with Dr. Xyloxxzlphrex to bring back Fixfinger
+            this.player1.reap(this.drXyloxxzlphrex);
+            this.player1.clickCard(this.ixxyxliFixfinger);
+            this.player1.clickPrompt('Left');
+            expect(this.ixxyxliFixfinger.location).toBe('play area');
+            expect(this.ixxyxliFixfinger.exhausted).toBe(false);
+
+            // Fixfinger should NOT be usable via Combat Pheromones anymore
+            // because it's a new creature instance
+            this.player1.clickCard(this.ixxyxliFixfinger);
+            expect(this.player1).not.toHavePrompt('Ixxyxli Fixfinger');
+            expect(this.player1).isReadyToTakeAction();
+        });
     });
 });


### PR DESCRIPTION
fix: combat pheromones handles leaves play - fixes #3923

Changed to a sequential action for each selected card so that an until condition for end of turn and leaves play can be set individually per card.