### PR TITLE
fix: Lord Golgotha and Smite

### DIFF
--- a/server/game/cards/02-AoA/Smite.js
+++ b/server/game/cards/02-AoA/Smite.js
@@ -1,77 +1,45 @@
 const Card = require('../../Card.js');
-const { EVENTS } = require('../../Events/types.js');
-const FightGameAction = require('../../GameActions/FightGameAction');
-const AbilityResolver = require('../../gamesteps/abilityresolver');
-const SimpleStep = require('../../gamesteps/simplestep');
-
-class SmiteAbilityResolver extends AbilityResolver {
-    // Play: Ready and fight with a friendly creature. Deal 2D to the attacked creatures neighbors.
-    initialise() {
-        this.pipeline.initialise([
-            new SimpleStep(this.game, () => this.createSnapshot()),
-            new SimpleStep(this.game, () => this.payCosts()),
-            new SimpleStep(this.game, () => this.resolveTargets()),
-            new SimpleStep(this.game, () => this.getNeighbors()),
-            new SimpleStep(this.game, () => this.initiateAbility()),
-            new SimpleStep(this.game, () => this.executeHandler()),
-            new SimpleStep(this.game, () => this.raiseResolvedEvent()),
-            new SimpleStep(this.game, () => this.damageNeighbors())
-        ]);
-    }
-
-    getNeighbors() {
-        if (this.cancelled) {
-            return;
-        }
-
-        if (!this.context.target) {
-            return;
-        }
-
-        this.neighbors = this.context.target.neighbors;
-    }
-
-    damageNeighbors() {
-        if (this.cancelled || !this.neighbors) {
-            return;
-        }
-
-        this.game.actions.dealDamage({ amount: 2 }).resolve(this.neighbors, this.context);
-    }
-}
-
-class SmiteFightAction extends FightGameAction {
-    getEvent(card, context) {
-        return super.createEvent(EVENTS.onInitiateFight, { card, context }, () => {
-            let newContext;
-            if (card.stunned) {
-                let removeStunAction = card
-                    .getActions()
-                    .find((action) => action.title === "Remove this creature's stun");
-                newContext = removeStunAction.createContext(context.player);
-            } else {
-                let fightAction = card.getFightAction();
-                newContext = fightAction.createContext(context.player);
-            }
-
-            newContext.canCancel = false;
-            context.game.queueStep(new SmiteAbilityResolver(context.game, newContext));
-        });
-    }
-}
 
 class Smite extends Card {
+    // Play: Ready and fight with a friendly creature. Deal 2D to the attacked creature's neighbors.
     setupCardAbilities(ability) {
         this.play({
             target: {
                 cardType: 'creature',
                 controller: 'self',
-                gameAction: ability.actions.sequential([
-                    ability.actions.ready(),
-                    new SmiteFightAction()
-                ])
+                gameAction: ability.actions.ready()
             },
-            effect: 'ready and fight with {0}'
+            effect: 'ready and fight with {0}, dealing 2 damage to its neighbors',
+            then: (preThenContext) => {
+                // Register a one-time listener to capture the fight target
+                const fightListener = (event) => {
+                    if (event.attacker === preThenContext.target) {
+                        this.smiteTarget = event.attackerTarget;
+                        preThenContext.game.removeListener('onFight', fightListener);
+                    }
+                };
+                preThenContext.game.on('onFight', fightListener);
+
+                return {
+                    gameAction: ability.actions.fight({
+                        target: preThenContext.target
+                    }),
+                    then: {
+                        alwaysTriggers: true,
+                        gameAction: ability.actions.dealDamage(() => {
+                            const target = this.smiteTarget;
+                            const neighbors =
+                                target?.location === 'play area'
+                                    ? target.neighbors
+                                    : target?.neighborsBeforeLeavingPlay || [];
+                            return {
+                                amount: 2,
+                                target: neighbors
+                            };
+                        })
+                    }
+                };
+            }
         });
     }
 }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -508,6 +508,13 @@ class Player extends GameObject {
         }
 
         let oldTopOfDeck = card.owner.deck[0];
+
+        // Snapshot neighbors before removing from battleline - needed for cards like Smite
+        // that reference "neighbors of the attacked creature" after it's destroyed
+        if (card.location === 'play area' && card.type === 'creature') {
+            card.neighborsBeforeLeavingPlay = card.neighbors?.slice() || [];
+        }
+
         this.removeCardFromPile(card);
         let location = card.location;
         targetPile = this.getSourceList(targetLocation);

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -370,6 +370,16 @@ class PlayerInteractionWrapper {
         return card;
     }
 
+    /**
+     * Makes a card a maverick of the specified house
+     * @param {DrawCard} card - the card to make a maverick
+     * @param {String} house - the house to maverick the card into
+     */
+    makeMaverick(card, house) {
+        card.maverick = true;
+        card.printedHouse = house;
+    }
+
     hasPlayCreaturePrompt(menuTitle, creatureName) {
         var currentPrompt = this.currentPrompt();
         return (

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -376,7 +376,7 @@ class PlayerInteractionWrapper {
      * @param {String} house - the house to maverick the card into
      */
     makeMaverick(card, house) {
-        card.maverick = true;
+        card.maverick = house;
         card.printedHouse = house;
     }
 

--- a/test/server/cards/02-AoA/Smite.spec.js
+++ b/test/server/cards/02-AoA/Smite.spec.js
@@ -119,4 +119,80 @@ describe('Smite', function () {
             this.player1.endTurn();
         });
     });
+
+    describe('Smite with before fight abilities', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    hand: ['smite'],
+                    inPlay: ['lord-golgotha']
+                },
+                player2: {
+                    inPlay: ['prescriptive-grammarbot', 'daughter', 'infomorph']
+                }
+            });
+        });
+
+        it('should target neighbors of attacked creature', function () {
+            this.player1.play(this.smite);
+            this.player1.clickCard(this.lordGolgotha);
+
+            // Fight Infomorph
+            this.player1.clickCard(this.infomorph);
+
+            // Golgotha's before fight ability kills Daughter
+            expect(this.daughter.location).toBe('discard');
+
+            // Fight destroys Infomorph
+            expect(this.infomorph.location).toBe('discard');
+
+            // Smite deals 2 damage to creatures who were Infomorph's neighbors
+            // immediately before it left play
+            expect(this.prescriptiveGrammarbot.damage).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Smite with after fight abilities', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    hand: ['smite', 'bigger-guns-for-everyone'],
+                    inPlay: ['impzilla']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'murmook', 'troll', 'mighty-tiger']
+                }
+            });
+            this.player1.makeMaverick(this.biggerGunsForEveryone, 'sanctum');
+        });
+
+        it('should target neighbors of attacked creature', function () {
+            this.player1.playUpgrade(this.biggerGunsForEveryone, this.impzilla);
+            this.player1.play(this.smite);
+            this.player1.clickCard(this.impzilla);
+
+            // Fight Troll
+            this.player1.clickCard(this.troll);
+
+            // Bigger Guns deals 5 damage to murmook
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toHavePromptButton('Bigger Guns for Everyone');
+            expect(this.player1).toHavePromptButton('Impzilla');
+            this.player1.clickPrompt(this.biggerGunsForEveryone.name);
+            this.player1.clickCard(this.murmook);
+            expect(this.murmook.location).toBe('discard');
+
+            // Impzilla's ability destroys Troll
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+
+            // Smite deals 2 damage to Troll's neighbors immediately before it left play
+            expect(this.flaxia.damage).toBe(2);
+            expect(this.mightyTiger.damage).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
fix: Lord Golgotha and Smite - fixes #1946 

Tried to simplify smite, but it was surprisingly difficult and a seemingly unique card. Due to the ready and fight part, it doesn't seem like the fight target is available in the preThenContext.