### PR TITLE
fix: exterminate-exterminate selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,7 @@ Ask the user before proceeding when:
 -   Run all tests: `DEBUG_TEST=1 npm test`
 -   Run specific test file: `DEBUG_TEST=1 npm test -- test/server/cards/<Set>/<CardName>.spec.js`
 -   Run multiple test files: `DEBUG_TEST=1 npm test -- test/server/cards/<Set1>/<CardName1>.spec.js test/server/cards/<set2>/<CardName2>.spec.js`
--   Run tests matching a pattern: `DEBUG_TEST=1 npm test -- -t '<pattern>'`
-    -   The `-t` flag is short for `--testNamePattern`.
+-   Run tests matching a pattern: `DEBUG_TEST=1 npm test -- --testNamePattern '<pattern>'`
 
 ## Version Control
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Ask the user before proceeding when:
 -   Run all tests: `DEBUG_TEST=1 npm test`
 -   Run specific test file: `DEBUG_TEST=1 npm test -- test/server/cards/<Set>/<CardName>.spec.js`
 -   Run multiple test files: `DEBUG_TEST=1 npm test -- test/server/cards/<Set1>/<CardName1>.spec.js test/server/cards/<set2>/<CardName2>.spec.js`
--   Run tests matching a pattern: `DEBUG_TEST=1 npm test -- --filter='<pattern>'`
-    -   Using just the filter option is slower than running test files, so prefer using filters in combination with specifying test files.
+-   Run tests matching a pattern: `DEBUG_TEST=1 npm test -- -t '<pattern>'`
+    -   The `-t` flag is short for `--testNamePattern`.
 
 ## Version Control
 

--- a/docs/testing-cards.md
+++ b/docs/testing-cards.md
@@ -176,50 +176,50 @@ When writing tests, use creatures with minimal abilities to avoid unintended int
 
 **Recommended creatures by house:**
 
-| House        | Creature               | Notes                                            |
-| ------------ | ---------------------- | ------------------------------------------------ |
-| Brobnar      | `troll`                | 8 power, Reap: heal 3 damage                     |
-| Brobnar      | `groggins`             | 8 power, can only attack flank creatures         |
-| Brobnar      | `honored-battlemaster` | 4 power, Action:                                 |
-| Dis          | `pit-demon`            | 5 power, Action:                                 |
-| Dis          | `hystricog`            | 4 power, Action:                                 |
-| Dis          | `snarette`             | 4 power, captures at end of turn, Action:        |
-| Ekwidon      | `antiquities-dealer`   | 3 power, Action:                                 |
-| Ekwidon      | `gemcoat-vendor`       | 6 power, Action:                                 |
-| Ekwidon      | `pen-pal`              | 5 power, Action:                                 |
-| Geistoid     | `shadys`               | 5 power, Action:                                 |
-| Geistoid     | `helichopper`          | 5 power, +power if haunted, Action:              |
-| Geistoid     | `echofly`              | 2 power, 1 armor, Action:                        |
-| Logos        | `even-ivan`            | 4 power, Action:                                 |
-| Logos        | `odd-clawde`           | 5 power, Action:                                 |
-| Logos        | `novu-archaeologist`   | 4 power, Action:                                 |
-| Mars         | `yxlix-mesmerist`      | 5 power, Action:                                 |
-| Mars         | `green-aeronaut`       | 3 power, Action:                                 |
-| Mars         | `white-aeronaut`       | 3 power, Action:                                 |
-| Redemption   | `even-ivan`            | 4 power, Action:                                 |
-| Redemption   | `odd-clawde`           | 5 power, Action:                                 |
-| Redemption   | `dark-centurion`       | 5 power, Action:                                 |
-| Sanctum      | `abond-the-armorsmith` | 3 power, other creatures +1 armor, Action:       |
-| Sanctum      | `lady-maxena`          | 5 power, 2 armor, Play: stun, Action:            |
-| Sanctum      | `protectrix`           | 5 power, Reap: heal and protect creature         |
-| Saurian      | `dark-centurion`       | 5 power, Action:                                 |
-| Saurian      | `cornicen-octavia`     | 5 power, 1 armor, Action:                        |
-| Saurian      | `eclectic-ambrosius`   | 4 power, knowledge counters, Action:             |
+| House        | Creature               | Notes                                                            |
+| ------------ | ---------------------- | ---------------------------------------------------------------- |
+| Brobnar      | `troll`                | 8 power, Reap: heal 3 damage                                     |
+| Brobnar      | `groggins`             | 8 power, can only attack flank creatures                         |
+| Brobnar      | `honored-battlemaster` | 4 power, Action:                                                 |
+| Dis          | `pit-demon`            | 5 power, Action:                                                 |
+| Dis          | `hystricog`            | 4 power, Action:                                                 |
+| Dis          | `snarette`             | 4 power, captures at end of turn, Action:                        |
+| Ekwidon      | `antiquities-dealer`   | 3 power, Action:                                                 |
+| Ekwidon      | `gemcoat-vendor`       | 6 power, Action:                                                 |
+| Ekwidon      | `pen-pal`              | 5 power, Action:                                                 |
+| Geistoid     | `shadys`               | 5 power, Action:                                                 |
+| Geistoid     | `helichopper`          | 5 power, +power if haunted, Action:                              |
+| Geistoid     | `echofly`              | 2 power, 1 armor, Action:                                        |
+| Logos        | `even-ivan`            | 4 power, Action:                                                 |
+| Logos        | `odd-clawde`           | 5 power, Action:                                                 |
+| Logos        | `novu-archaeologist`   | 4 power, Action:                                                 |
+| Mars         | `yxlix-mesmerist`      | 5 power, Action:                                                 |
+| Mars         | `green-aeronaut`       | 3 power, Action:                                                 |
+| Mars         | `white-aeronaut`       | 3 power, Action:                                                 |
+| Redemption   | `even-ivan`            | 4 power, Action:                                                 |
+| Redemption   | `odd-clawde`           | 5 power, Action:                                                 |
+| Redemption   | `dark-centurion`       | 5 power, Action:                                                 |
+| Sanctum      | `abond-the-armorsmith` | 3 power, other creatures +1 armor, Action:                       |
+| Sanctum      | `lady-maxena`          | 5 power, 2 armor, Play: stun, Action:                            |
+| Sanctum      | `protectrix`           | 5 power, Reap: heal and protect creature                         |
+| Saurian      | `dark-centurion`       | 5 power, Action:                                                 |
+| Saurian      | `cornicen-octavia`     | 5 power, 1 armor, Action:                                        |
+| Saurian      | `eclectic-ambrosius`   | 4 power, knowledge counters, Action:                             |
 | Shadows      | `lamindra`             | 1 power, Elusive; good fight target for testing Fight: abilities |
-| Shadows      | `yantzee-gang`         | 5 power, Action:                                 |
-| Shadows      | `hobnobber`            | 3 power, Action:                                 |
-| Skyborn      | `redhawk`              | 3 power, Action:                                 |
-| Skyborn      | `bux-bastian`          | 3 power, Scrap: exalt enemy flank creature       |
-| Skyborn      | `scalawag-finn`        | 6 power, After Fight: heal 3                     |
-| StarAlliance | `ensign-el-samra`      | 3 power, Action:                                 |
-| StarAlliance | `crewman-jörg`         | 3 power, Action:                                 |
-| StarAlliance | `ambassador-liu`       | 4 power, Action:                                 |
-| Unfathomable | `flamegill-enforcer`   | 6 power, enrages on tide raise, Action:          |
-| Unfathomable | `rustmiser`            | 5 power, Reap: exhaust artifacts                 |
-| Unfathomable | `bubbles`              | 5 power, Play: return creature to deck           |
-| Untamed      | `mighty-tiger`         | 4 power, Play: deal 4 damage                     |
-| Untamed      | `witch-of-the-dawn`    | 3 power, Play: return creature from discard      |
-| Untamed      | `conclave-witch`       | 3 power, Action:                                 |
+| Shadows      | `yantzee-gang`         | 5 power, Action:                                                 |
+| Shadows      | `hobnobber`            | 3 power, Action:                                                 |
+| Skyborn      | `redhawk`              | 3 power, Action:                                                 |
+| Skyborn      | `bux-bastian`          | 3 power, Scrap: exalt enemy flank creature                       |
+| Skyborn      | `scalawag-finn`        | 6 power, After Fight: heal 3                                     |
+| StarAlliance | `ensign-el-samra`      | 3 power, Action:                                                 |
+| StarAlliance | `crewman-jörg`         | 3 power, Action:                                                 |
+| StarAlliance | `ambassador-liu`       | 4 power, Action:                                                 |
+| Unfathomable | `flamegill-enforcer`   | 6 power, enrages on tide raise, Action:                          |
+| Unfathomable | `rustmiser`            | 5 power, Reap: exhaust artifacts                                 |
+| Unfathomable | `bubbles`              | 5 power, Play: return creature to deck                           |
+| Untamed      | `mighty-tiger`         | 4 power, Play: deal 4 damage                                     |
+| Untamed      | `witch-of-the-dawn`    | 3 power, Play: return creature from discard                      |
+| Untamed      | `conclave-witch`       | 3 power, Action:                                                 |
 
 **Avoid** using creatures with abilities or keywords unless those abilities/keywords are being specifically tested. When using a creature with an ability or keyword, make sure to account for its effects in your test assertions:
 
@@ -696,8 +696,8 @@ DEBUG_TEST=1 npm test -- test/server/cards/PV/BadOmen.spec.js
 # Run multiple test files
 DEBUG_TEST=1 npm test -- test/server/cards/PV/BadOmen.spec.js test/server/cards/CotA/MightyTiger.spec.js
 
-# Run tests matching a pattern (slower - prefer specifying files)
-DEBUG_TEST=1 npm test -- --filter='Bad Omen'
+# Run tests matching a pattern
+DEBUG_TEST=1 npm test -- --testNamePattern 'Bad Omen'
 ```
 
 ## Testing UI changes

--- a/server/game/GameActions.js
+++ b/server/game/GameActions.js
@@ -166,6 +166,8 @@ const Actions = {
     sequentialForEach: (propertyFactory) =>
         new GameActions.SequentialForEachAction(propertyFactory),
     sequentialFight: (propertyFactory) => new GameActions.SequentialFightAction(propertyFactory),
+    sequentialPairedChoices: (propertyFactory) =>
+        new GameActions.SequentialPairedChoicesAction(propertyFactory),
     sequentialPlay: (propertyFactory) => new GameActions.SequentialPlayAction(propertyFactory),
     sequentialPutIntoPlay: (propertyFactory) =>
         new GameActions.SequentialPutIntoPlayAction(propertyFactory),

--- a/server/game/GameActions/SequentialPairedChoicesAction.js
+++ b/server/game/GameActions/SequentialPairedChoicesAction.js
@@ -8,28 +8,20 @@ const CardSelector = require('../CardSelector');
  * The specified action is performed on all targets simultaneously after all pairs are selected.
  *
  * Properties:
- * - sourceCardType: String | Array - card type(s) for sources (default: any)
  * - sourceCondition: Function (card, context) => boolean - condition for source cards
- * - sourceController: String - 'self', 'opponent', or 'any' (default: 'any')
  * - sourcePromptTitle: String - title for source selection prompt
  * - targetAction: Function (targets) => GameAction - factory function that creates the action to perform on all targets
- * - targetCardType: String | Array - card type(s) for targets (default: any)
  * - targetCondition: Function (card, sourceCard, context) => boolean - condition for targets based on source
- * - targetController: String - 'self', 'opponent', or 'any' (default: 'any')
  * - targetPromptTitle: String | Function(sourceCard) => String - title for target selection prompt
  * - pairMessage: String - message template for each pair, uses {0}=player, {1}=source, {2}=sourceCard, {3}=targetCard
  */
 class SequentialPairedChoicesAction extends GameAction {
     setDefaultProperties() {
         this.pairMessage = null;
-        this.sourceCardType = undefined;
         this.sourceCondition = () => true;
-        this.sourceController = 'any';
         this.sourcePromptTitle = 'Choose a card';
         this.targetAction = null;
-        this.targetCardType = undefined;
         this.targetCondition = () => true;
-        this.targetController = 'any';
         this.targetPromptTitle = 'Choose a card';
     }
 
@@ -41,8 +33,6 @@ class SequentialPairedChoicesAction extends GameAction {
     hasLegalTarget(context) {
         this.update(context);
         const sourceSelector = CardSelector.for({
-            cardType: this.sourceCardType,
-            controller: this.sourceController,
             cardCondition: (card) => this.sourceCondition(card, context)
         });
         return sourceSelector.hasEnoughTargets(context);
@@ -61,8 +51,6 @@ class SequentialPairedChoicesAction extends GameAction {
 
                 // Build initial source selector to count sources
                 const initialSourceSelector = CardSelector.for({
-                    cardType: this.sourceCardType,
-                    controller: this.sourceController,
                     cardCondition: (card) => this.sourceCondition(card, context)
                 });
                 const sources = initialSourceSelector.getAllLegalTargets(context);
@@ -72,8 +60,6 @@ class SequentialPairedChoicesAction extends GameAction {
                     context.game.queueSimpleStep(() => {
                         // Prompt for source selection
                         const sourceSelector = CardSelector.for({
-                            cardType: this.sourceCardType,
-                            controller: this.sourceController,
                             cardCondition: (card) =>
                                 this.sourceCondition(card, context) && !usedSources.includes(card)
                         });
@@ -96,8 +82,6 @@ class SequentialPairedChoicesAction extends GameAction {
                                         : this.targetPromptTitle;
 
                                 const targetSelector = CardSelector.for({
-                                    cardType: this.targetCardType,
-                                    controller: this.targetController,
                                     cardCondition: (card) =>
                                         this.targetCondition(card, sourceCard, context) &&
                                         !markedTargets.includes(card)

--- a/server/game/GameActions/SequentialPairedChoicesAction.js
+++ b/server/game/GameActions/SequentialPairedChoicesAction.js
@@ -9,7 +9,7 @@ const CardSelector = require('../CardSelector');
  *
  * Properties:
  * - sourceCondition: Function (card, context) => boolean - condition for source cards
- * - sourcePromptTitle: String - title for source selection prompt
+ * - sourcePromptTitle: String | Function(context) => String - title for source selection prompt
  * - targetAction: Function (targets) => GameAction - factory function that creates the action to perform on all targets
  * - targetCondition: Function (card, sourceCard, context) => boolean - condition for targets based on source
  * - targetPromptTitle: String | Function(sourceCard) => String - title for target selection prompt
@@ -68,8 +68,13 @@ class SequentialPairedChoicesAction extends GameAction {
                             return;
                         }
 
+                        const sourcePromptTitle =
+                            typeof this.sourcePromptTitle === 'function'
+                                ? this.sourcePromptTitle(context)
+                                : this.sourcePromptTitle;
+
                         context.game.promptForSelect(context.game.activePlayer, {
-                            activePromptTitle: this.sourcePromptTitle,
+                            activePromptTitle: sourcePromptTitle,
                             context: context,
                             selector: sourceSelector,
                             onSelect: (player, sourceCard) => {

--- a/server/game/GameActions/SequentialPairedChoicesAction.js
+++ b/server/game/GameActions/SequentialPairedChoicesAction.js
@@ -1,0 +1,149 @@
+const { EVENTS } = require('../Events/types');
+const GameAction = require('./GameAction');
+const CardSelector = require('../CardSelector');
+
+/**
+ * A game action that pairs cards from one group with cards from another group.
+ * For each source card, prompts to select a target card based on the source's properties.
+ * The specified action is performed on all targets simultaneously after all pairs are selected.
+ *
+ * Properties:
+ * - sourceCardType: String | Array - card type(s) for sources (default: any)
+ * - sourceCondition: Function (card, context) => boolean - condition for source cards
+ * - sourceController: String - 'self', 'opponent', or 'any' (default: 'any')
+ * - sourcePromptTitle: String - title for source selection prompt
+ * - targetAction: Function (targets) => GameAction - factory function that creates the action to perform on all targets
+ * - targetCardType: String | Array - card type(s) for targets (default: any)
+ * - targetCondition: Function (card, sourceCard, context) => boolean - condition for targets based on source
+ * - targetController: String - 'self', 'opponent', or 'any' (default: 'any')
+ * - targetPromptTitle: String | Function(sourceCard) => String - title for target selection prompt
+ * - pairMessage: String - message template for each pair, uses {0}=player, {1}=source, {2}=sourceCard, {3}=targetCard
+ */
+class SequentialPairedChoicesAction extends GameAction {
+    setDefaultProperties() {
+        this.pairMessage = null;
+        this.sourceCardType = undefined;
+        this.sourceCondition = () => true;
+        this.sourceController = 'any';
+        this.sourcePromptTitle = 'Choose a card';
+        this.targetAction = null;
+        this.targetCardType = undefined;
+        this.targetCondition = () => true;
+        this.targetController = 'any';
+        this.targetPromptTitle = 'Choose a card';
+    }
+
+    setup() {
+        super.setup();
+        this.effectMsg = 'pair cards';
+    }
+
+    hasLegalTarget(context) {
+        this.update(context);
+        const sourceSelector = CardSelector.for({
+            cardType: this.sourceCardType,
+            controller: this.sourceController,
+            cardCondition: (card) => this.sourceCondition(card, context)
+        });
+        return sourceSelector.hasEnoughTargets(context);
+    }
+
+    canAffect() {
+        return true;
+    }
+
+    getEventArray(context) {
+        return [
+            super.createEvent(EVENTS.unnamedEvent, {}, () => {
+                // Track used sources and marked targets
+                const usedSources = [];
+                const markedTargets = [];
+
+                // Build initial source selector to count sources
+                const initialSourceSelector = CardSelector.for({
+                    cardType: this.sourceCardType,
+                    controller: this.sourceController,
+                    cardCondition: (card) => this.sourceCondition(card, context)
+                });
+                const sources = initialSourceSelector.getAllLegalTargets(context);
+
+                // Queue prompts for each source
+                for (let i = 0; i < sources.length; i++) {
+                    context.game.queueSimpleStep(() => {
+                        // Prompt for source selection
+                        const sourceSelector = CardSelector.for({
+                            cardType: this.sourceCardType,
+                            controller: this.sourceController,
+                            cardCondition: (card) =>
+                                this.sourceCondition(card, context) && !usedSources.includes(card)
+                        });
+
+                        if (!sourceSelector.hasEnoughTargets(context)) {
+                            return;
+                        }
+
+                        context.game.promptForSelect(context.game.activePlayer, {
+                            activePromptTitle: this.sourcePromptTitle,
+                            context: context,
+                            selector: sourceSelector,
+                            onSelect: (player, sourceCard) => {
+                                usedSources.push(sourceCard);
+
+                                // Now prompt for target selection
+                                const targetPromptTitle =
+                                    typeof this.targetPromptTitle === 'function'
+                                        ? this.targetPromptTitle(sourceCard)
+                                        : this.targetPromptTitle;
+
+                                const targetSelector = CardSelector.for({
+                                    cardType: this.targetCardType,
+                                    controller: this.targetController,
+                                    cardCondition: (card) =>
+                                        this.targetCondition(card, sourceCard, context) &&
+                                        !markedTargets.includes(card)
+                                });
+
+                                if (!targetSelector.hasEnoughTargets(context)) {
+                                    // No valid targets for this source, continue
+                                    return true;
+                                }
+
+                                context.game.promptForSelect(context.game.activePlayer, {
+                                    activePromptTitle: targetPromptTitle,
+                                    context: context,
+                                    selector: targetSelector,
+                                    onSelect: (player, targetCard) => {
+                                        markedTargets.push(targetCard);
+                                        if (this.pairMessage) {
+                                            context.game.addMessage(
+                                                this.pairMessage,
+                                                player,
+                                                context.source,
+                                                sourceCard,
+                                                targetCard
+                                            );
+                                        }
+                                        return true;
+                                    }
+                                });
+
+                                return true;
+                            }
+                        });
+                    });
+                }
+
+                // After all selections, perform the action on all marked targets
+                context.game.queueSimpleStep(() => {
+                    if (markedTargets.length > 0 && this.targetAction) {
+                        const action = this.targetAction(markedTargets);
+                        action.update(context);
+                        context.game.openEventWindow(action.getEventArray(context));
+                    }
+                });
+            })
+        ];
+    }
+}
+
+module.exports = SequentialPairedChoicesAction;

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -78,6 +78,7 @@ module.exports = {
     SequentialForEachAction: require('./SequentialForEachAction'),
     SequentialFightAction: require('./SequentialFightAction'),
     SequentialMakeTokenCreatureAction: require('./SequentialMakeTokenCreatureAction'),
+    SequentialPairedChoicesAction: require('./SequentialPairedChoicesAction'),
     SequentialPlayAction: require('./SequentialPlayAction'),
     SequentialPutIntoPlayAction: require('./SequentialPutIntoPlayAction'),
     ShuffleDeckAction: require('./ShuffleDeckAction'),

--- a/server/game/cards/02-AoA/ExterminateExterminate.js
+++ b/server/game/cards/02-AoA/ExterminateExterminate.js
@@ -7,15 +7,16 @@ class ExterminateExterminate extends Card {
             effect: 'destroy a non-Mars creature for each Mars creature they control',
             gameAction: ability.actions.sequentialPairedChoices({
                 pairMessage: '{0} uses {1} to choose {2} and destroy {3}',
-                sourceCardType: 'creature',
-                sourceCondition: (card) => card.hasHouse('mars'),
-                sourceController: 'self',
+                sourceCondition: (card, context) =>
+                    card.type === 'creature' &&
+                    card.hasHouse('mars') &&
+                    card.controller === context.player,
                 sourcePromptTitle: 'Choose a friendly Mars creature',
                 targetAction: (targets) => ability.actions.destroy({ target: targets }),
-                targetCardType: 'creature',
                 targetCondition: (card, sourceCard) =>
-                    !card.hasHouse('mars') && card.power < sourceCard.power,
-                targetController: 'any',
+                    card.type === 'creature' &&
+                    !card.hasHouse('mars') &&
+                    card.power < sourceCard.power,
                 targetPromptTitle: (sourceCard) =>
                     `Choose a non-Mars creature with less than ${sourceCard.power} power to destroy`
             })

--- a/server/game/cards/02-AoA/ExterminateExterminate.js
+++ b/server/game/cards/02-AoA/ExterminateExterminate.js
@@ -17,7 +17,7 @@ class ExterminateExterminate extends Card {
                     !card.hasHouse('mars') && card.power < sourceCard.power,
                 targetController: 'any',
                 targetPromptTitle: (sourceCard) =>
-                    `${sourceCard.name} (${sourceCard.power} power) chosen - choose a non-Mars creature with less power to destroy`
+                    `Choose a non-Mars creature with less than ${sourceCard.power} power to destroy`
             })
         });
     }

--- a/server/game/cards/02-AoA/ExterminateExterminate.js
+++ b/server/game/cards/02-AoA/ExterminateExterminate.js
@@ -5,18 +5,20 @@ class ExterminateExterminate extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'destroy a non-Mars creature for each Mars creature they control',
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                forEach: context.player.creaturesInPlay.filter((card) => card.hasHouse('mars')),
-                action: (card) =>
-                    ability.actions.destroy({
-                        promptForSelect: {
-                            activePromptTitle: 'Choose a creature to destroy',
-                            cardType: 'creature',
-                            cardCondition: (c) => !c.hasHouse('mars') && c.power < card.power,
-                            context: context
-                        }
-                    })
-            }))
+            gameAction: ability.actions.sequentialPairedChoices({
+                pairMessage: '{0} uses {1} to choose {2} and destroy {3}',
+                sourceCardType: 'creature',
+                sourceCondition: (card) => card.hasHouse('mars'),
+                sourceController: 'self',
+                sourcePromptTitle: 'Choose a friendly Mars creature',
+                targetAction: (targets) => ability.actions.destroy({ target: targets }),
+                targetCardType: 'creature',
+                targetCondition: (card, sourceCard) =>
+                    !card.hasHouse('mars') && card.power < sourceCard.power,
+                targetController: 'any',
+                targetPromptTitle: (sourceCard) =>
+                    `${sourceCard.name} (${sourceCard.power} power) chosen - choose a non-Mars creature with less power to destroy`
+            })
         });
     }
 }

--- a/test/server/cards/02-AoA/ExterminateExterminate.spec.js
+++ b/test/server/cards/02-AoA/ExterminateExterminate.spec.js
@@ -5,30 +5,88 @@ describe('Exterminate!Exterminate!', function () {
                 player1: {
                     house: 'mars',
                     hand: ['exterminate-exterminate'],
-                    inPlay: ['the-terror', 'blypyp', 'zorg', 'yxilx-dominator']
+                    inPlay: ['blypyp', 'zorg', 'yxilx-dominator']
                 },
                 player2: {
-                    inPlay: ['commander-remiel', 'troll', 'sequis', 'yxilo-bolter']
+                    inPlay: ['commander-remiel', 'troll', 'sequis']
                 }
             });
         });
 
-        it('should prompt the player and destroy creatures correctly', function () {
+        it('should let the player choose which Mars creature to use', function () {
             this.player1.play(this.exterminateExterminate);
-            expect(this.player1).toHavePrompt('Exterminate! Exterminate!');
+            // First, select which Mars creature to use
+            expect(this.player1).toHavePrompt('Choose a friendly Mars creature');
+            expect(this.player1).toBeAbleToSelect(this.blypyp);
+            expect(this.player1).toBeAbleToSelect(this.zorg);
+            expect(this.player1).toBeAbleToSelect(this.yxilxDominator);
+            // Select zorg (power 7) first
+            this.player1.clickCard(this.zorg);
+
+            // Now select a creature with power < 7 to destroy
+            expect(this.player1).toHavePrompt(
+                'Zorg (7 power) chosen - choose a non-Mars creature with less power to destroy'
+            );
+            expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
+            expect(this.player1).toBeAbleToSelect(this.sequis); // power 4
+            expect(this.player1).not.toBeAbleToSelect(this.troll); // power 8
+            this.player1.clickCard(this.sequis);
+
+            // Select next Mars creature - zorg is no longer available
+            expect(this.player1).toHavePrompt('Choose a friendly Mars creature');
+            expect(this.player1).toBeAbleToSelect(this.blypyp);
+            expect(this.player1).not.toBeAbleToSelect(this.zorg); // already used
+            expect(this.player1).toBeAbleToSelect(this.yxilxDominator);
+            // Select yxilx-dominator (power 9)
+            this.player1.clickCard(this.yxilxDominator);
+
+            // Now select a creature with power < 9 to destroy
+            expect(this.player1).toHavePrompt(
+                'Yxilx Dominator (9 power) chosen - choose a non-Mars creature with less power to destroy'
+            );
+            expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
+            expect(this.player1).not.toBeAbleToSelect(this.sequis); // already marked
+            expect(this.player1).toBeAbleToSelect(this.troll); // power 8 < 9
+            this.player1.clickCard(this.troll);
+
+            // Select last Mars creature - only blypyp remains
+            expect(this.player1).toHavePrompt('Choose a friendly Mars creature');
+            expect(this.player1).toBeAbleToSelect(this.blypyp);
+            expect(this.player1).not.toBeAbleToSelect(this.zorg);
+            expect(this.player1).not.toBeAbleToSelect(this.yxilxDominator);
+            this.player1.clickCard(this.blypyp);
+
+            // blypyp has power 2, so only creatures with power < 2 would be valid
+            // commander-remiel has power 3, so no valid targets - skip to end
+            // All creatures are destroyed simultaneously at the end
+            expect(this.sequis.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.commanderRemiel.location).toBe('play area'); // not destroyed
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should not allow selecting the same target twice', function () {
+            this.player1.play(this.exterminateExterminate);
+            // Select yxilx-dominator (power 9)
+            this.player1.clickCard(this.yxilxDominator);
+            // Select troll (power 8)
+            this.player1.clickCard(this.troll);
+
+            // Select zorg (power 7)
+            this.player1.clickCard(this.zorg);
+            // Troll is already marked, so can't be selected again
+            expect(this.player1).not.toBeAbleToSelect(this.troll);
             expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
             expect(this.player1).toBeAbleToSelect(this.sequis);
-            expect(this.player1).not.toBeAbleToSelect(this.troll);
-            expect(this.player1).not.toBeAbleToSelect(this.yxiloBolter);
             this.player1.clickCard(this.sequis);
-            expect(this.sequis.location).toBe('discard');
-            expect(this.player1).toHavePrompt('Exterminate! Exterminate!');
-            expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
-            expect(this.player1).not.toBeAbleToSelect(this.sequis);
-            expect(this.player1).toBeAbleToSelect(this.troll);
-            expect(this.player1).not.toBeAbleToSelect(this.yxiloBolter);
-            this.player1.clickCard(this.troll);
+
+            // Select blypyp (power 2)
+            this.player1.clickCard(this.blypyp);
+            // No valid targets - complete
+
             expect(this.troll.location).toBe('discard');
+            expect(this.sequis.location).toBe('discard');
+            expect(this.commanderRemiel.location).toBe('play area');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/02-AoA/ExterminateExterminate.spec.js
+++ b/test/server/cards/02-AoA/ExterminateExterminate.spec.js
@@ -25,7 +25,7 @@ describe('Exterminate!Exterminate!', function () {
 
             // Now select a creature with power < 7 to destroy
             expect(this.player1).toHavePrompt(
-                'Zorg (7 power) chosen - choose a non-Mars creature with less power to destroy'
+                'Choose a non-Mars creature with less than 7 power to destroy'
             );
             expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
             expect(this.player1).toBeAbleToSelect(this.sequis); // power 4
@@ -42,7 +42,7 @@ describe('Exterminate!Exterminate!', function () {
 
             // Now select a creature with power < 9 to destroy
             expect(this.player1).toHavePrompt(
-                'Yxilx Dominator (9 power) chosen - choose a non-Mars creature with less power to destroy'
+                'Choose a non-Mars creature with less than 9 power to destroy'
             );
             expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
             expect(this.player1).not.toBeAbleToSelect(this.sequis); // already marked

--- a/test/server/cards/02-AoA/ExterminateExterminate.spec.js
+++ b/test/server/cards/02-AoA/ExterminateExterminate.spec.js
@@ -20,33 +20,31 @@ describe('Exterminate!Exterminate!', function () {
             expect(this.player1).toBeAbleToSelect(this.blypyp);
             expect(this.player1).toBeAbleToSelect(this.zorg);
             expect(this.player1).toBeAbleToSelect(this.yxilxDominator);
-            // Select zorg (power 7) first
             this.player1.clickCard(this.zorg);
 
             // Now select a creature with power < 7 to destroy
             expect(this.player1).toHavePrompt(
                 'Choose a non-Mars creature with less than 7 power to destroy'
             );
-            expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
-            expect(this.player1).toBeAbleToSelect(this.sequis); // power 4
-            expect(this.player1).not.toBeAbleToSelect(this.troll); // power 8
+            expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
+            expect(this.player1).toBeAbleToSelect(this.sequis);
+            expect(this.player1).not.toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.sequis);
 
-            // Select next Mars creature - zorg is no longer available
+            // Select next Mars creature
             expect(this.player1).toHavePrompt('Choose a friendly Mars creature');
             expect(this.player1).toBeAbleToSelect(this.blypyp);
-            expect(this.player1).not.toBeAbleToSelect(this.zorg); // already used
+            expect(this.player1).not.toBeAbleToSelect(this.zorg);
             expect(this.player1).toBeAbleToSelect(this.yxilxDominator);
-            // Select yxilx-dominator (power 9)
             this.player1.clickCard(this.yxilxDominator);
 
             // Now select a creature with power < 9 to destroy
             expect(this.player1).toHavePrompt(
                 'Choose a non-Mars creature with less than 9 power to destroy'
             );
-            expect(this.player1).toBeAbleToSelect(this.commanderRemiel); // power 3
-            expect(this.player1).not.toBeAbleToSelect(this.sequis); // already marked
-            expect(this.player1).toBeAbleToSelect(this.troll); // power 8 < 9
+            expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
+            expect(this.player1).not.toBeAbleToSelect(this.sequis);
+            expect(this.player1).toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.troll);
 
             // Select last Mars creature - only blypyp remains
@@ -67,22 +65,16 @@ describe('Exterminate!Exterminate!', function () {
 
         it('should not allow selecting the same target twice', function () {
             this.player1.play(this.exterminateExterminate);
-            // Select yxilx-dominator (power 9)
             this.player1.clickCard(this.yxilxDominator);
-            // Select troll (power 8)
             this.player1.clickCard(this.troll);
 
-            // Select zorg (power 7)
             this.player1.clickCard(this.zorg);
-            // Troll is already marked, so can't be selected again
             expect(this.player1).not.toBeAbleToSelect(this.troll);
             expect(this.player1).toBeAbleToSelect(this.commanderRemiel);
             expect(this.player1).toBeAbleToSelect(this.sequis);
             this.player1.clickCard(this.sequis);
 
-            // Select blypyp (power 2)
             this.player1.clickCard(this.blypyp);
-            // No valid targets - complete
 
             expect(this.troll.location).toBe('discard');
             expect(this.sequis.location).toBe('discard');


### PR DESCRIPTION
fix: exterminate-exterminate selection - fixes #200 

Sets up EE so that you can choose a friendly mars, then a lower power creature to destroy, until you've chosen each friendly mars creature or run out of targets to tag for destruction.