### PR TITLE
fix: assign unique uuids to prompt controls to prevent stuck prompts (#4851)

### DIFF
--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -45,8 +45,8 @@ class UiPrompt extends BaseStep {
         }
 
         if (prompt.controls) {
-            for (let control of prompt.controls) {
-                control.uuid = this.uuid;
+            for (let [index, control] of prompt.controls.entries()) {
+                control.uuid = `${this.uuid}:${index}`;
             }
         }
 
@@ -77,11 +77,15 @@ class UiPrompt extends BaseStep {
     }
 
     onMenuCommand(player, arg, uuid, method) {
-        if (!this.activeCondition(player) || uuid !== this.uuid) {
+        if (!this.activeCondition(player) || !this.isValidPromptUuid(uuid)) {
             return false;
         }
 
         return this.menuCommand(player, arg, method);
+    }
+
+    isValidPromptUuid(uuid) {
+        return uuid === this.uuid || (typeof uuid === 'string' && uuid.startsWith(`${this.uuid}:`));
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -77,15 +77,14 @@ class UiPrompt extends BaseStep {
     }
 
     onMenuCommand(player, arg, uuid, method) {
-        if (!this.activeCondition(player) || !this.isValidPromptUuid(uuid)) {
+        if (
+            !this.activeCondition(player) ||
+            (uuid !== this.uuid && !(typeof uuid === 'string' && uuid.startsWith(`${this.uuid}:`)))
+        ) {
             return false;
         }
 
         return this.menuCommand(player, arg, method);
-    }
-
-    isValidPromptUuid(uuid) {
-        return uuid === this.uuid || (typeof uuid === 'string' && uuid.startsWith(`${this.uuid}:`));
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -57,6 +57,17 @@ describe('the UiPrompt', function () {
                 expect(this.player1.setPrompt).toHaveBeenCalledWith(this.waitingPrompt);
             });
 
+            it('should assign unique uuids to each prompt control', function () {
+                this.prompt.activePrompt.mockReturnValue({
+                    controls: [{ type: 'targeting' }, { type: 'targeting' }]
+                });
+
+                this.prompt.continue();
+
+                const prompt = this.player2.setPrompt.mock.calls[0][0];
+                expect(prompt.controls[0].uuid).not.toBe(prompt.controls[1].uuid);
+            });
+
             it('should return false', function () {
                 expect(this.prompt.continue()).toBe(false);
             });


### PR DESCRIPTION
Fixes #4851

## Problem
When multiple controls share the same UUID, the prompt can get stuck showing stale card images from a previous prompt (e.g. after Chan > Yandylinx > Scrap Zerp > Scrap another card > Blast Shielding).

## Solution
Assign each control a unique UUID with an index suffix (e.g. `uuid:0`, `uuid:1`) instead of sharing the base UUID. Add `isValidPromptUuid` to accept both the base UUID and indexed UUIDs in `onMenuCommand`.