### PR TITLE
fix: guard Blorb return-to-hand target context

### DIFF
--- a/server/game/cards/06-WoE/Blorb.js
+++ b/server/game/cards/06-WoE/Blorb.js
@@ -14,9 +14,9 @@ class Blorb extends Card {
                 cardType: 'artifact',
                 cardCondition: (card) => card.name === 'Blorb Hive',
                 location: 'discard',
-                gameAction: ability.actions.returnToHand((context) => ({
-                    location: context.target.location
-                }))
+                gameAction: ability.actions.returnToHand({
+                    location: 'discard'
+                })
             }
         });
     }

--- a/test/server/cards/06-WoE/Blorb.spec.js
+++ b/test/server/cards/06-WoE/Blorb.spec.js
@@ -22,6 +22,19 @@ describe('Blorb', function () {
             expect(this.player1).not.toHavePrompt('Reap with this Creature');
         });
 
+        it('should evaluate the destroyed ability without a selected target', function () {
+            const destroyedAbility = this.blorb.abilities.reactions.find(
+                (ability) => ability.properties.destroyed
+            );
+            const context = destroyedAbility.createContext(this.player1.player);
+            let gameActions;
+
+            expect(() => {
+                gameActions = destroyedAbility.getGameActions(context);
+            }).not.toThrow();
+            expect(gameActions).toEqual([]);
+        });
+
         it('bring back Blorb Hive when destroyed', function () {
             this.player1.fightWith(this.blorb, this.umbra);
             this.player1.clickCard(this.blorbHive);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace Blorb's destroyed `returnToHand` action with a fixed discard location instead of reading `context.target.location`
- add a regression spec that evaluates the destroyed ability before any target is selected

## Testing
- `npm test -- test/server/cards/06-WoE/Blorb.spec.js`
- `npm test -- test/server/cards/01-Core/Faygin.spec.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77a0c77d-f538-436c-87f3-4fa3ccf65be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77a0c77d-f538-436c-87f3-4fa3ccf65be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

