### PR TITLE
Fix duplicate artifact play log

### DIFF
--- a/server/game/BaseActions/PlayArtifactAction.js
+++ b/server/game/BaseActions/PlayArtifactAction.js
@@ -6,6 +6,11 @@ class PlayAction extends BasePlayAction {
         this.title = 'Play this artifact';
     }
 
+    displayMessage() {
+        // Suppress the default play message - PutIntoPlayAction will show the appropriate message
+        // based on whether the artifact enters play or gets returned
+    }
+
     addSubEvent(event, context) {
         super.addSubEvent(event, context);
         event.addChildEvent(

--- a/test/server/messages/play.spec.js
+++ b/test/server/messages/play.spec.js
@@ -53,10 +53,7 @@ describe('Play Messages', function () {
         it('should log correct message when playing an artifact', function () {
             this.player1.play(this.libraryOfBabble);
             expect(this.player1).isReadyToTakeAction();
-            expect(this).toHaveAllChatMessagesBe([
-                'player1 plays Library of Babble',
-                'player1 plays Library of Babble'
-            ]);
+            expect(this).toHaveAllChatMessagesBe(['player1 plays Library of Babble']);
         });
     });
 
@@ -144,7 +141,6 @@ describe('Play Messages', function () {
             this.player1.play(this.ceaseforge);
             expect(this.player1).isReadyToTakeAction();
             expect(this).toHaveAllChatMessagesBe([
-                'player1 plays Ceaseforge',
                 'player1 plays Ceaseforge',
                 "player1 gains an amber due to Ceaseforge's bonus icon",
                 'player1 uses Ceaseforge to place 2 time on Ceaseforge'

--- a/test/server/messages/token-creature.spec.js
+++ b/test/server/messages/token-creature.spec.js
@@ -15,7 +15,6 @@ describe('Token Creature Messages', function () {
             expect(this.player1).isReadyToTakeAction();
             expect(this).toHaveAllChatMessagesBe([
                 'player1 plays Tourist Trap',
-                'player1 plays Tourist Trap',
                 'player1 uses Tourist Trap to make a token creature'
             ]);
         });

--- a/test/server/messages/treachery.spec.js
+++ b/test/server/messages/treachery.spec.js
@@ -15,10 +15,7 @@ describe('Treachery Messages', function () {
         it('should log play message for treachery card', function () {
             this.player1.play(this.curseOfCowardice);
             expect(this.player1).isReadyToTakeAction();
-            expect(this).toHaveAllChatMessagesBe([
-                'player1 plays Curse of Cowardice',
-                'player2 plays Curse of Cowardice'
-            ]);
+            expect(this).toHaveAllChatMessagesBe(['player2 plays Curse of Cowardice']);
         });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- suppress the inherited generic play log for artifacts so artifact plays only log once
- update message specs to expect the correct single play log for artifacts, token-making artifacts, and treachery artifacts

## Testing
- `npm test -- test/server/messages/play.spec.js test/server/messages/token-creature.spec.js test/server/messages/treachery.spec.js`
- `npx vitest run --reporter=dot`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70486a04-1f33-4d9e-99ed-40c9f4a8789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70486a04-1f33-4d9e-99ed-40c9f4a8789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

