### PR TITLE
feat: implement entrench and caught you napping

### DIFF
--- a/server/game/cards/14-DM/CaughtYouNapping.js
+++ b/server/game/cards/14-DM/CaughtYouNapping.js
@@ -1,0 +1,34 @@
+const Card = require('../../Card.js');
+
+class CaughtYouNapping extends Card {
+    // Play: If you are overwhelmed, exhaust an enemy creature. Steal 1 for each exhausted enemy creature.
+    setupCardAbilities(ability) {
+        const exhaustedEnemyCount = (context) =>
+            context.player.opponent
+                ? context.player.opponent.creaturesInPlay.filter((card) => card.exhausted).length
+                : 0;
+
+        this.play({
+            target: {
+                cardCondition: (_, context) => context.player.isOverwhelmed(),
+                cardType: 'creature',
+                controller: 'opponent',
+                gameAction: ability.actions.exhaust()
+            },
+            then: {
+                alwaysTriggers: true,
+                gameAction: ability.actions.steal((context) => ({
+                    amount: exhaustedEnemyCount(context)
+                })),
+                message: '{0} uses {1} to steal {3} amber',
+                messageArgs: (context) => [
+                    Math.min(exhaustedEnemyCount(context), context.player.opponent?.amber ?? 0)
+                ]
+            }
+        });
+    }
+}
+
+CaughtYouNapping.id = 'caught-you-napping';
+
+module.exports = CaughtYouNapping;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -156,6 +156,19 @@ class Player extends GameObject {
         return this.cardsInPlay.filter((card) => card.type === 'creature');
     }
 
+    /**
+     * Returns true if this player is overwhelmed, i.e. their opponent has more
+     * creatures in play than they do.
+     * @returns {boolean}
+     */
+    isOverwhelmed() {
+        if (!this.opponent) {
+            return false;
+        }
+
+        return this.opponent.creaturesInPlay.length > this.creaturesInPlay.length;
+    }
+
     get activeProphecies() {
         return this.prophecyCards.filter((card) => card.activeProphecy);
     }

--- a/test/server/cards/14-DM/CaughtYouNapping.spec.js
+++ b/test/server/cards/14-DM/CaughtYouNapping.spec.js
@@ -1,0 +1,70 @@
+describe('CaughtYouNapping', function () {
+    describe("Caught You Napping's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'shadows',
+                    amber: 1,
+                    hand: ['caught-you-napping', 'murkens'],
+                    inPlay: ['urchin']
+                },
+                player2: {
+                    amber: 3,
+                    hand: ['caught-you-napping'],
+                    inPlay: ['bumpsy', 'krump', 'troll']
+                }
+            });
+            this.caughtYouNapping1 = this.player1.hand[0];
+            this.caughtYouNapping2 = this.player2.hand[0];
+        });
+
+        it('exhausts an enemy creature and steals 1 when overwhelmed', function () {
+            this.player1.play(this.caughtYouNapping1);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.exhausted).toBe(true);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('steals 1 per exhausted enemy creature when overwhelmed', function () {
+            this.krump.exhaust();
+            this.player1.play(this.caughtYouNapping1);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.exhausted).toBe(true);
+            expect(this.player1.amber).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not exhaust but still steals when not overwhelmed', function () {
+            this.bumpsy.exhaust();
+            this.player2.moveCard(this.krump, 'hand');
+            this.player2.moveCard(this.troll, 'hand');
+            this.player1.play(this.caughtYouNapping1);
+            expect(this.bumpsy.exhausted).toBe(true);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not steal when no enemy creatures are exhausted', function () {
+            this.player2.moveCard(this.krump, 'hand');
+            this.player2.moveCard(this.troll, 'hand');
+            this.player1.play(this.caughtYouNapping1);
+            expect(this.bumpsy.exhausted).toBe(false);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it("exhausts and steals when played from opponent's deck", function () {
+            this.player2.moveCard(this.caughtYouNapping2, 'deck');
+            this.player1.play(this.murkens);
+            this.player1.clickPrompt('Top of deck');
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.exhausted).toBe(true);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});


### PR DESCRIPTION
- feat: implement entrench and caught you napping
- chore: updates branch with master
- note: the keyteki-json-data points to my fork until it gets merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new gameplay logic via a `Player.isOverwhelmed()` helper and a new card implementation that conditionally exhausts and steals, which could affect rules interactions if the overwhelmed definition is reused elsewhere.
> 
> **Overview**
> Implements the **`Caught You Napping`** card: when played, it *conditionally* prompts to exhaust an enemy creature only if the player is **overwhelmed**, then always steals amber equal to the number of exhausted enemy creatures (capped by opponent amber for messaging).
> 
> Adds `Player.isOverwhelmed()` (opponent has more creatures in play) to support this and introduces a focused test suite covering overwhelmed vs not overwhelmed behavior, steal scaling with exhausted enemies, and playing the card from an opponent’s deck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03c665c336cfdefab0b83f6e484885d018f4a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->