### PR TITLE
feat: implement skyborn

### DIFF
--- a/server/game/cards/08-AS/RecreationalJettison.js
+++ b/server/game/cards/08-AS/RecreationalJettison.js
@@ -17,9 +17,7 @@ class RecreationalJettison extends Card {
             effect: 'discard {1} from their hand and resolve its bonus icons',
             effectArgs: (context) => [context.target],
             then: {
-                condition: (context) =>
-                    context.player.keys.yellow ||
-                    (context.player.opponent && context.player.opponent.keys.yellow),
+                condition: (context) => context.game.isKeyForged('yellow'),
                 alwaysTriggers: true,
                 target: {
                     controller: 'self',

--- a/server/game/cards/08-AS/RedSkies.js
+++ b/server/game/cards/08-AS/RedSkies.js
@@ -17,9 +17,7 @@ class RedSkies extends Card {
             effect: 'move {1} to a flank and ready it',
             effectArgs: (context) => [context.target],
             then: {
-                condition: (context) =>
-                    context.player.keys.red ||
-                    (context.player.opponent && context.player.opponent.keys.red),
+                condition: (context) => context.game.isKeyForged('red'),
                 alwaysTriggers: true,
                 target: {
                     controller: 'self',

--- a/server/game/cards/14-DM/AviatrixVirtuosa.js
+++ b/server/game/cards/14-DM/AviatrixVirtuosa.js
@@ -1,0 +1,17 @@
+const Card = require('../../Card.js');
+
+class AviatrixVirtuosa extends Card {
+    // Deploy.
+    // Play: Exhaust each non-flank creature.
+    setupCardAbilities(ability) {
+        this.play({
+            gameAction: ability.actions.exhaust((context) => ({
+                target: context.game.creaturesInPlay.filter((card) => !card.isOnFlank())
+            }))
+        });
+    }
+}
+
+AviatrixVirtuosa.id = 'aviatrix-virtuosa';
+
+module.exports = AviatrixVirtuosa;

--- a/server/game/cards/14-DM/BarrelRoll.js
+++ b/server/game/cards/14-DM/BarrelRoll.js
@@ -1,0 +1,20 @@
+const Card = require('../../Card.js');
+
+class BarrelRoll extends Card {
+    // Play: Move a creature to a flank of its controller's battleline and exhaust it.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                gameAction: ability.actions.sequential([
+                    ability.actions.moveToFlank(),
+                    ability.actions.exhaust()
+                ])
+            }
+        });
+    }
+}
+
+BarrelRoll.id = 'barrel-roll';
+
+module.exports = BarrelRoll;

--- a/server/game/cards/14-DM/Bloodwing.js
+++ b/server/game/cards/14-DM/Bloodwing.js
@@ -1,0 +1,18 @@
+const Card = require('../../Card.js');
+
+class Bloodwing extends Card {
+    // Enhance.
+    // After Fight/After Reap: Put a +1 power counter on each friendly flank creature.
+    setupCardAbilities(ability) {
+        this.reap({
+            fight: true,
+            gameAction: ability.actions.addPowerCounter((context) => ({
+                target: context.player.creaturesInPlay.filter((card) => card.isOnFlank())
+            }))
+        });
+    }
+}
+
+Bloodwing.id = 'bloodwing';
+
+module.exports = Bloodwing;

--- a/server/game/cards/14-DM/Cabochon.js
+++ b/server/game/cards/14-DM/Cabochon.js
@@ -1,0 +1,24 @@
+const Card = require('../../Card.js');
+
+class Cabochon extends Card {
+    // Entrench.
+    // At the start of your turn, if Cabochon is exhausted, gain 1 for each
+    // friendly Skyborn flank creature.
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onTurnStart: (_, context) => context.player === this.game.activePlayer
+            },
+            condition: (context) => context.source.exhausted,
+            gameAction: ability.actions.gainAmber((context) => ({
+                amount: context.player.creaturesInPlay.filter(
+                    (card) => card.hasHouse('skyborn') && card.isOnFlank()
+                ).length
+            }))
+        });
+    }
+}
+
+Cabochon.id = 'cabochon';
+
+module.exports = Cabochon;

--- a/server/game/cards/14-DM/ColdRopes.js
+++ b/server/game/cards/14-DM/ColdRopes.js
@@ -1,0 +1,30 @@
+const Card = require('../../Card.js');
+
+class ColdRopes extends Card {
+    // Play: If you are overwhelmed, put an enemy creature on the bottom of
+    // its owner's deck. Otherwise, move an enemy creature to a flank of its
+    // controller's battleline and exhaust it.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                controller: 'opponent',
+                gameAction: ability.actions.conditional((context) => ({
+                    condition: context.player.isOverwhelmed(),
+                    trueGameAction: ability.actions.returnToDeck({
+                        bottom: true,
+                        target: context.target
+                    }),
+                    falseGameAction: ability.actions.sequential([
+                        ability.actions.moveToFlank({ target: context.target }),
+                        ability.actions.exhaust({ target: context.target })
+                    ])
+                }))
+            }
+        });
+    }
+}
+
+ColdRopes.id = 'cold-ropes';
+
+module.exports = ColdRopes;

--- a/server/game/cards/14-DM/DeepBlueBryn.js
+++ b/server/game/cards/14-DM/DeepBlueBryn.js
@@ -1,0 +1,23 @@
+const Card = require('../../Card.js');
+
+class DeepBlueBryn extends Card {
+    // After Fight: Steal 1. If a blue key is forged, ward Deep Blue Bryn.
+    setupCardAbilities(ability) {
+        this.fight({
+            gameAction: ability.actions.steal({ amount: 1 }),
+            then: (preThenContext) => ({
+                alwaysTriggers: true,
+                condition: () =>
+                    preThenContext.player.keys.blue ||
+                    (preThenContext.player.opponent && preThenContext.player.opponent.keys.blue),
+                gameAction: ability.actions.ward((context) => ({
+                    target: context.source
+                }))
+            })
+        });
+    }
+}
+
+DeepBlueBryn.id = 'deep-blue-bryn';
+
+module.exports = DeepBlueBryn;

--- a/server/game/cards/14-DM/DeepBlueBryn.js
+++ b/server/game/cards/14-DM/DeepBlueBryn.js
@@ -7,9 +7,7 @@ class DeepBlueBryn extends Card {
             gameAction: ability.actions.steal({ amount: 1 }),
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                condition: () =>
-                    preThenContext.player.keys.blue ||
-                    (preThenContext.player.opponent && preThenContext.player.opponent.keys.blue),
+                condition: () => preThenContext.game.isKeyForged('blue'),
                 gameAction: ability.actions.ward((context) => ({
                     target: context.source
                 }))

--- a/server/game/cards/14-DM/EmberedPurse.js
+++ b/server/game/cards/14-DM/EmberedPurse.js
@@ -1,0 +1,18 @@
+const Card = require('../../Card.js');
+
+class EmberedPurse extends Card {
+    // Play: Steal 1 for each ready Skyborn creature in play.
+    setupCardAbilities(ability) {
+        this.play({
+            gameAction: ability.actions.steal((context) => ({
+                amount: context.game.creaturesInPlay.filter(
+                    (card) => !card.exhausted && card.hasHouse('skyborn')
+                ).length
+            }))
+        });
+    }
+}
+
+EmberedPurse.id = 'embered-purse';
+
+module.exports = EmberedPurse;

--- a/server/game/cards/14-DM/ForgedBolt.js
+++ b/server/game/cards/14-DM/ForgedBolt.js
@@ -1,0 +1,19 @@
+const Card = require('../../Card.js');
+
+class ForgedBolt extends Card {
+    // Play: Deal 1 to each creature for each forged key.
+    setupCardAbilities(ability) {
+        this.play({
+            gameAction: ability.actions.dealDamage((context) => ({
+                amount:
+                    context.player.getForgedKeys() +
+                    (context.player.opponent ? context.player.opponent.getForgedKeys() : 0),
+                target: context.game.creaturesInPlay
+            }))
+        });
+    }
+}
+
+ForgedBolt.id = 'forged-bolt';
+
+module.exports = ForgedBolt;

--- a/server/game/cards/14-DM/GiltEmGood.js
+++ b/server/game/cards/14-DM/GiltEmGood.js
@@ -11,9 +11,7 @@ class GiltEmGood extends Card {
             })),
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                condition: () =>
-                    preThenContext.player.keys.yellow ||
-                    (preThenContext.player.opponent && preThenContext.player.opponent.keys.yellow),
+                condition: () => preThenContext.game.isKeyForged('yellow'),
                 gameAction: ability.actions.capture((context) => ({
                     amount: 1,
                     target: context.player.creaturesInPlay.filter((card) => card.isOnFlank())

--- a/server/game/cards/14-DM/GiltEmGood.js
+++ b/server/game/cards/14-DM/GiltEmGood.js
@@ -1,0 +1,29 @@
+const Card = require('../../Card.js');
+
+class GiltEmGood extends Card {
+    // Play: Each friendly flank creature captures 1. If a yellow key is
+    // forged, repeat the preceding effect.
+    setupCardAbilities(ability) {
+        this.play({
+            gameAction: ability.actions.capture((context) => ({
+                amount: 1,
+                target: context.player.creaturesInPlay.filter((card) => card.isOnFlank())
+            })),
+            then: (preThenContext) => ({
+                alwaysTriggers: true,
+                condition: () =>
+                    preThenContext.player.keys.yellow ||
+                    (preThenContext.player.opponent && preThenContext.player.opponent.keys.yellow),
+                gameAction: ability.actions.capture((context) => ({
+                    amount: 1,
+                    target: context.player.creaturesInPlay.filter((card) => card.isOnFlank())
+                })),
+                message: '{0} uses {1} to repeat the preceding effect'
+            })
+        });
+    }
+}
+
+GiltEmGood.id = 'gilt--em-good';
+
+module.exports = GiltEmGood;

--- a/server/game/cards/14-DM/HannibalsMark.js
+++ b/server/game/cards/14-DM/HannibalsMark.js
@@ -1,0 +1,30 @@
+const Card = require('../../Card.js');
+
+class HannibalsMark extends Card {
+    // Play: Take control of an enemy flank creature and give it three +1
+    // power counters. While under your control, it belongs to house
+    // Skyborn. (Instead of its original house.)
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                controller: 'opponent',
+                cardCondition: (card) => card.isOnFlank(),
+                gameAction: [
+                    ability.actions.cardLastingEffect((context) => ({
+                        duration: 'lastingEffect',
+                        effect: [
+                            ability.effects.takeControl(context.player),
+                            ability.effects.changeHouse('skyborn')
+                        ]
+                    })),
+                    ability.actions.addPowerCounter({ amount: 3 })
+                ]
+            }
+        });
+    }
+}
+
+HannibalsMark.id = 'hannibal-s-mark';
+
+module.exports = HannibalsMark;

--- a/server/game/cards/14-DM/JeenPeary.js
+++ b/server/game/cards/14-DM/JeenPeary.js
@@ -1,0 +1,15 @@
+const Card = require('../../Card.js');
+
+class JeenPeary extends Card {
+    // After Reap: If Jeen Peary is on a flank, steal 1.
+    setupCardAbilities(ability) {
+        this.reap({
+            condition: (context) => context.source.isOnFlank(),
+            gameAction: ability.actions.steal({ amount: 1 })
+        });
+    }
+}
+
+JeenPeary.id = 'jeen-peary';
+
+module.exports = JeenPeary;

--- a/server/game/cards/14-DM/JumpStart.js
+++ b/server/game/cards/14-DM/JumpStart.js
@@ -1,0 +1,40 @@
+const Card = require('../../Card.js');
+
+class JumpStart extends Card {
+    // Play: Ready and use a friendly flank creature. If you are
+    // overwhelmed, repeat the preceding effect.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                controller: 'self',
+                cardCondition: (card) => card.isOnFlank(),
+                gameAction: ability.actions.sequential([
+                    ability.actions.ready(),
+                    ability.actions.use()
+                ])
+            },
+            effect: 'ready and use {1}',
+            effectArgs: (context) => [context.target],
+            then: {
+                alwaysTriggers: true,
+                condition: (context) => context.player.isOverwhelmed(),
+                target: {
+                    cardType: 'creature',
+                    controller: 'self',
+                    cardCondition: (card) => card.isOnFlank(),
+                    gameAction: ability.actions.sequential([
+                        ability.actions.ready(),
+                        ability.actions.use()
+                    ])
+                },
+                message: '{0} uses {1} to repeat the preceding effect and ready and use {3}',
+                messageArgs: (context) => [context.target]
+            }
+        });
+    }
+}
+
+JumpStart.id = 'jump-start';
+
+module.exports = JumpStart;

--- a/server/game/cards/14-DM/LeftenantChars.js
+++ b/server/game/cards/14-DM/LeftenantChars.js
@@ -1,0 +1,18 @@
+const Card = require('../../Card.js');
+
+class LeftenantChars extends Card {
+    // After Fight: If you are overwhelmed, steal 2. Otherwise capture 1.
+    setupCardAbilities(ability) {
+        this.fight({
+            gameAction: ability.actions.conditional((context) => ({
+                condition: context.player.isOverwhelmed(),
+                trueGameAction: ability.actions.steal({ amount: 2 }),
+                falseGameAction: ability.actions.capture({ amount: 1 })
+            }))
+        });
+    }
+}
+
+LeftenantChars.id = 'leftenant-chars';
+
+module.exports = LeftenantChars;

--- a/server/game/cards/14-DM/Malforge.js
+++ b/server/game/cards/14-DM/Malforge.js
@@ -1,0 +1,26 @@
+const Card = require('../../Card.js');
+
+class Malforge extends Card {
+    // Treachery. Versatile.
+    // You cannot forge keys.
+    // At the end of your turn, deal 2 to Malforge.
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            effect: ability.effects.playerCannot('forge')
+        });
+
+        this.interrupt({
+            when: {
+                onTurnEnd: (event, context) => event.player === context.source.controller
+            },
+            gameAction: ability.actions.dealDamage((context) => ({
+                amount: 2,
+                target: context.source
+            }))
+        });
+    }
+}
+
+Malforge.id = 'malforge';
+
+module.exports = Malforge;

--- a/server/game/cards/14-DM/RemmiHound.js
+++ b/server/game/cards/14-DM/RemmiHound.js
@@ -1,0 +1,20 @@
+const Card = require('../../Card.js');
+
+class RemmiHound extends Card {
+    // Entrench.
+    // While Remmi Hound is exhausted, each friendly flank creature gets +4 power.
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.exhausted,
+            match: (card, context) =>
+                card.type === 'creature' &&
+                card.controller === context.source.controller &&
+                card.isOnFlank(),
+            effect: ability.effects.modifyPower(4)
+        });
+    }
+}
+
+RemmiHound.id = 'remmi-hound';
+
+module.exports = RemmiHound;

--- a/server/game/cards/14-DM/RubyRackham.js
+++ b/server/game/cards/14-DM/RubyRackham.js
@@ -1,0 +1,24 @@
+const Card = require('../../Card.js');
+
+class RubyRackham extends Card {
+    // After Fight: If a red key is forged, deal 4 to each enemy flank
+    // creature. Otherwise, deal 1 to each enemy flank creature.
+    setupCardAbilities(ability) {
+        this.fight({
+            gameAction: ability.actions.dealDamage((context) => ({
+                amount:
+                    context.player.keys.red ||
+                    (context.player.opponent && context.player.opponent.keys.red)
+                        ? 4
+                        : 1,
+                target: context.player.opponent
+                    ? context.player.opponent.creaturesInPlay.filter((card) => card.isOnFlank())
+                    : []
+            }))
+        });
+    }
+}
+
+RubyRackham.id = 'ruby-rackham';
+
+module.exports = RubyRackham;

--- a/server/game/cards/14-DM/RubyRackham.js
+++ b/server/game/cards/14-DM/RubyRackham.js
@@ -6,11 +6,7 @@ class RubyRackham extends Card {
     setupCardAbilities(ability) {
         this.fight({
             gameAction: ability.actions.dealDamage((context) => ({
-                amount:
-                    context.player.keys.red ||
-                    (context.player.opponent && context.player.opponent.keys.red)
-                        ? 4
-                        : 1,
+                amount: context.game.isKeyForged('red') ? 4 : 1,
                 target: context.player.opponent
                     ? context.player.opponent.creaturesInPlay.filter((card) => card.isOnFlank())
                     : []

--- a/server/game/cards/14-DM/TurBoProp.js
+++ b/server/game/cards/14-DM/TurBoProp.js
@@ -5,11 +5,7 @@ class TurBoProp extends Card {
     setupCardAbilities(ability) {
         this.reap({
             gameAction: ability.actions.draw((context) => ({
-                amount:
-                    context.player.keys.blue ||
-                    (context.player.opponent && context.player.opponent.keys.blue)
-                        ? 2
-                        : 1
+                amount: context.game.isKeyForged('blue') ? 2 : 1
             }))
         });
     }

--- a/server/game/cards/14-DM/TurBoProp.js
+++ b/server/game/cards/14-DM/TurBoProp.js
@@ -1,0 +1,20 @@
+const Card = require('../../Card.js');
+
+class TurBoProp extends Card {
+    // After Reap: If a blue key is forged, draw 2 cards. Otherwise, draw a card.
+    setupCardAbilities(ability) {
+        this.reap({
+            gameAction: ability.actions.draw((context) => ({
+                amount:
+                    context.player.keys.blue ||
+                    (context.player.opponent && context.player.opponent.keys.blue)
+                        ? 2
+                        : 1
+            }))
+        });
+    }
+}
+
+TurBoProp.id = 'tur-bo-prop';
+
+module.exports = TurBoProp;

--- a/server/game/cards/14-DM/TyLourd.js
+++ b/server/game/cards/14-DM/TyLourd.js
@@ -1,0 +1,20 @@
+const Card = require('../../Card.js');
+
+class TyLourd extends Card {
+    // After your opponent discards a card from their hand, gain 1.
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardDiscarded: (event, context) =>
+                    event.location === 'hand' &&
+                    !!context.source.controller.opponent &&
+                    event.card.controller === context.source.controller.opponent
+            },
+            gameAction: ability.actions.gainAmber()
+        });
+    }
+}
+
+TyLourd.id = 'ty-lourd';
+
+module.exports = TyLourd;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1409,6 +1409,10 @@ class Game extends EventEmitter {
         return length === 1 ? '1 key' : `${length} keys`;
     }
 
+    isKeyForged(color) {
+        return this.getPlayers().some((player) => player.keys[color]);
+    }
+
     get cardsInPlay() {
         return this.getPlayers().reduce((array, player) => array.concat(player.cardsInPlay), []);
     }

--- a/test/server/cards/14-DM/AviatrixVirtuosa.spec.js
+++ b/test/server/cards/14-DM/AviatrixVirtuosa.spec.js
@@ -1,0 +1,28 @@
+describe('Aviatrix Virtuosa', function () {
+    describe("Aviatrix Virtuosa's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['aviatrix-virtuosa'],
+                    inPlay: ['bosun-creen', 'flip-stallard']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('exhausts each non-flank creature when played', function () {
+            // Place Aviatrix on the right flank.
+            this.player1.play(this.aviatrixVirtuosa);
+            // Player1 battleline: bosun-creen (left), flip-stallard (center), aviatrix (right)
+            expect(this.flipStallard.exhausted).toBe(true);
+            // Player2 battleline: troll (left), krump (center), bumpsy (right)
+            expect(this.troll.exhausted).toBe(false);
+            expect(this.krump.exhausted).toBe(true);
+            expect(this.bumpsy.exhausted).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/BarrelRoll.spec.js
+++ b/test/server/cards/14-DM/BarrelRoll.spec.js
@@ -1,0 +1,37 @@
+describe('Barrel Roll', function () {
+    describe("Barrel Roll's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['barrel-roll'],
+                    inPlay: ['flip-stallard']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('moves a friendly creature to a flank and exhausts it', function () {
+            this.player1.play(this.barrelRoll);
+            this.player1.clickCard(this.flipStallard);
+            this.player1.clickPrompt('Left');
+            expect(this.flipStallard.exhausted).toBe(true);
+            expect(this.flipStallard.isOnFlank()).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('moves an enemy creature to a flank of its controller and exhausts it', function () {
+            this.player1.play(this.barrelRoll);
+            this.player1.clickCard(this.krump);
+            this.player1.clickPrompt('Right');
+            expect(this.krump.exhausted).toBe(true);
+            expect(this.krump.isOnFlank()).toBe(true);
+            expect(
+                this.player2.player.cardsInPlay[this.player2.player.cardsInPlay.length - 1]
+            ).toBe(this.krump);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/Bloodwing.spec.js
+++ b/test/server/cards/14-DM/Bloodwing.spec.js
@@ -1,0 +1,44 @@
+describe('Bloodwing', function () {
+    describe("Bloodwing's reap ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['bosun-creen', 'flip-stallard', 'bloodwing']
+                },
+                player2: {}
+            });
+        });
+
+        it('puts a +1 power counter on each friendly flank creature on reap', function () {
+            this.player1.reap(this.bloodwing);
+            // Battleline: bosun-creen (left flank), flip-stallard (center), bloodwing (right flank)
+            expect(this.bosunCreen.powerCounters).toBe(1);
+            expect(this.flipStallard.powerCounters).toBe(0);
+            expect(this.bloodwing.powerCounters).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Bloodwing's fight ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['bosun-creen', 'flip-stallard', 'bloodwing']
+                },
+                player2: {
+                    inPlay: ['bad-penny']
+                }
+            });
+        });
+
+        it('puts a +1 power counter on each friendly flank creature on fight', function () {
+            this.player1.fightWith(this.bloodwing, this.badPenny);
+            expect(this.bosunCreen.powerCounters).toBe(1);
+            expect(this.flipStallard.powerCounters).toBe(0);
+            expect(this.bloodwing.powerCounters).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/Cabochon.spec.js
+++ b/test/server/cards/14-DM/Cabochon.spec.js
@@ -1,0 +1,78 @@
+describe('Cabochon', function () {
+    describe("Cabochon's ability when exhausted at start of turn", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['cabochon', 'bosun-creen', 'flip-stallard']
+                },
+                player2: {
+                    house: 'shadows'
+                }
+            });
+        });
+
+        it('gains amber for each friendly Skyborn flank creature', function () {
+            this.cabochon.exhaust();
+            this.player1.endTurn();
+            // entrench prompt for Cabochon
+            this.player1.clickPrompt('Done');
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            this.player1.clickPrompt('skyborn');
+            // Battleline: cabochon (left flank, skyborn), bosun-creen (center), flip-stallard (right flank, skyborn)
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Cabochon's ability when ready at start of turn", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['cabochon', 'bosun-creen', 'flip-stallard']
+                },
+                player2: {
+                    house: 'shadows'
+                }
+            });
+        });
+
+        it('does not gain amber', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            this.player1.clickPrompt('skyborn');
+            expect(this.player1.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Cabochon with non-Skyborn flank creature', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['cabochon', 'flip-stallard', 'troll']
+                },
+                player2: {
+                    house: 'shadows'
+                }
+            });
+        });
+
+        it('does not count non-Skyborn flank creatures', function () {
+            this.cabochon.exhaust();
+            this.player1.endTurn();
+            this.player1.clickPrompt('Done');
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            this.player1.clickPrompt('skyborn');
+            // Cabochon (left, skyborn) + flip-stallard (center) + troll (right, brobnar)
+            // Only Cabochon is a Skyborn flank.
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ColdRopes.spec.js
+++ b/test/server/cards/14-DM/ColdRopes.spec.js
@@ -1,0 +1,49 @@
+describe('Cold Ropes', function () {
+    describe('Cold Ropes when not overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['cold-ropes'],
+                    inPlay: ['bosun-creen', 'flip-stallard', 'troll']
+                },
+                player2: {
+                    inPlay: ['bad-penny', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('moves an enemy non-flank creature to a flank and exhausts it', function () {
+            this.player1.play(this.coldRopes);
+            this.player1.clickCard(this.krump);
+            this.player1.clickPrompt('Right');
+            expect(this.krump.exhausted).toBe(true);
+            expect(this.krump.location).toBe('play area');
+            expect(this.krump.isOnFlank()).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Cold Ropes when overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['cold-ropes']
+                },
+                player2: {
+                    inPlay: ['bad-penny', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('puts an enemy creature on the bottom of its owner deck', function () {
+            this.player1.play(this.coldRopes);
+            this.player1.clickCard(this.krump);
+            expect(this.krump.location).toBe('deck');
+            const deck = this.player2.player.deck;
+            expect(deck[deck.length - 1]).toBe(this.krump);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/DeepBlueBryn.spec.js
+++ b/test/server/cards/14-DM/DeepBlueBryn.spec.js
@@ -1,0 +1,72 @@
+describe('Deep Blue Bryn', function () {
+    describe('Deep Blue Bryn after fight when no blue key forged', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['deep-blue-bryn']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['bad-penny']
+                }
+            });
+        });
+
+        it('steals 1 and does not ward', function () {
+            this.player1.fightWith(this.deepBlueBryn, this.badPenny);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(2);
+            expect(this.deepBlueBryn.warded).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Deep Blue Bryn after fight when player has forged blue key', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['deep-blue-bryn']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['bad-penny']
+                }
+            });
+            this.player1.player.keys.blue = true;
+        });
+
+        it('steals 1 and wards Deep Blue Bryn', function () {
+            this.player1.fightWith(this.deepBlueBryn, this.badPenny);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(2);
+            expect(this.deepBlueBryn.warded).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Deep Blue Bryn after fight when opponent has forged blue key', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['deep-blue-bryn']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['bad-penny']
+                }
+            });
+            this.player2.player.keys.blue = true;
+        });
+
+        it('steals 1 and wards Deep Blue Bryn', function () {
+            this.player1.fightWith(this.deepBlueBryn, this.badPenny);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(2);
+            expect(this.deepBlueBryn.warded).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/EmberedPurse.spec.js
+++ b/test/server/cards/14-DM/EmberedPurse.spec.js
@@ -1,0 +1,45 @@
+describe('Embered Purse', function () {
+    describe("Embered Purse's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['embered-purse'],
+                    inPlay: ['bosun-creen', 'flip-stallard']
+                },
+                player2: {
+                    amber: 5,
+                    inPlay: ['han-peregrine', 'troll']
+                }
+            });
+        });
+
+        it('steals 1 for each ready Skyborn creature in play (both players)', function () {
+            this.player1.play(this.emberedPurse);
+            // bosun-creen, flip-stallard, han-peregrine = 3 ready skyborn creatures
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not count exhausted Skyborn creatures', function () {
+            this.bosunCreen.exhausted = true;
+            this.hanPeregrine.exhausted = true;
+            this.player1.play(this.emberedPurse);
+            // only flip-stallard is a ready skyborn
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('steals 0 when no ready Skyborn creatures', function () {
+            this.bosunCreen.exhausted = true;
+            this.flipStallard.exhausted = true;
+            this.hanPeregrine.exhausted = true;
+            this.player1.play(this.emberedPurse);
+            expect(this.player1.amber).toBe(0);
+            expect(this.player2.amber).toBe(5);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ForgedBolt.spec.js
+++ b/test/server/cards/14-DM/ForgedBolt.spec.js
@@ -1,0 +1,46 @@
+describe('Forged Bolt', function () {
+    describe("Forged Bolt's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['forged-bolt'],
+                    inPlay: ['troll']
+                },
+                player2: {
+                    inPlay: ['murmook', 'krump']
+                }
+            });
+        });
+
+        it('deals no damage when no keys are forged', function () {
+            this.player1.play(this.forgedBolt);
+            expect(this.troll.tokens.damage).toBeUndefined();
+            expect(this.murmook.tokens.damage).toBeUndefined();
+            expect(this.krump.tokens.damage).toBeUndefined();
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('deals 1 to each creature for 1 forged key', function () {
+            this.player1.player.keys.red = true;
+            this.player1.play(this.forgedBolt);
+            expect(this.troll.tokens.damage).toBe(1);
+            expect(this.murmook.tokens.damage).toBe(1);
+            expect(this.krump.tokens.damage).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('counts forged keys from both players', function () {
+            this.player1.player.keys.red = true;
+            this.player2.player.keys.blue = true;
+            this.player2.player.keys.yellow = true;
+            this.player1.play(this.forgedBolt);
+            // 3 forged keys.
+            expect(this.troll.tokens.damage).toBe(3);
+            // murmook has 3 power, takes 3 dmg => dies
+            expect(this.murmook.location).toBe('discard');
+            expect(this.krump.tokens.damage).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/GiltEmGood.spec.js
+++ b/test/server/cards/14-DM/GiltEmGood.spec.js
@@ -1,0 +1,44 @@
+describe('Gilt Em Good', function () {
+    describe("Gilt Em Good's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['gilt--em-good'],
+                    inPlay: ['bosun-creen', 'troll', 'flip-stallard']
+                },
+                player2: {
+                    amber: 6
+                }
+            });
+        });
+
+        it('each friendly flank creature captures 1 when no yellow key is forged', function () {
+            this.player1.play(this.giltEmGood);
+            expect(this.bosunCreen.amber).toBe(1);
+            expect(this.troll.amber).toBe(0);
+            expect(this.flipStallard.amber).toBe(1);
+            expect(this.player2.amber).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('repeats the capture when player has forged yellow key', function () {
+            this.player1.player.keys = { red: false, blue: false, yellow: true };
+            this.player1.play(this.giltEmGood);
+            expect(this.bosunCreen.amber).toBe(2);
+            expect(this.troll.amber).toBe(0);
+            expect(this.flipStallard.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('repeats the capture when opponent has forged yellow key', function () {
+            this.player2.player.keys = { red: false, blue: false, yellow: true };
+            this.player1.play(this.giltEmGood);
+            expect(this.bosunCreen.amber).toBe(2);
+            expect(this.flipStallard.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/HannibalsMark.spec.js
+++ b/test/server/cards/14-DM/HannibalsMark.spec.js
@@ -1,0 +1,33 @@
+describe("Hannibal's Mark", function () {
+    describe("Hannibal's Mark's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['hannibal-s-mark']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('takes control of an enemy flank creature, makes it Skyborn, and adds 3 power counters', function () {
+            this.player1.play(this.hannibalSMark);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.controller).toBe(this.player1.player);
+            expect(this.troll.hasHouse('skyborn')).toBe(true);
+            expect(this.troll.powerCounters).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('cannot target a non-flank enemy creature', function () {
+            this.player1.play(this.hannibalSMark);
+            this.player1.clickCard(this.krump);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/JeenPeary.spec.js
+++ b/test/server/cards/14-DM/JeenPeary.spec.js
@@ -1,0 +1,43 @@
+describe('Jeen Peary', function () {
+    describe('Jeen Peary on a flank', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['jeen-peary', 'bosun-creen']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('steals 1 after reaping', function () {
+            this.player1.reap(this.jeenPeary);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Jeen Peary not on a flank', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['bosun-creen', 'jeen-peary', 'flip-stallard']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('does not steal after reaping', function () {
+            this.player1.reap(this.jeenPeary);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/JumpStart.spec.js
+++ b/test/server/cards/14-DM/JumpStart.spec.js
@@ -1,0 +1,54 @@
+describe('Jump Start', function () {
+    describe('Jump Start when not overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['jump-start'],
+                    inPlay: ['flip-stallard', 'bosun-creen']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+        });
+
+        it('readies and uses a flank creature once', function () {
+            this.flipStallard.exhausted = true;
+            this.player1.play(this.jumpStart);
+            this.player1.clickCard(this.flipStallard);
+            // Player chooses how to use it (e.g. reap)
+            this.player1.clickPrompt('Reap with this creature');
+            expect(this.flipStallard.exhausted).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Jump Start when overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    hand: ['jump-start'],
+                    inPlay: ['flip-stallard']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('repeats the ready and use', function () {
+            this.flipStallard.exhausted = true;
+            this.player1.play(this.jumpStart);
+            this.player1.clickCard(this.flipStallard);
+            this.player1.clickPrompt('Reap with this creature');
+            // After first ready+use, repeat triggers since still overwhelmed
+            this.player1.clickCard(this.flipStallard);
+            this.player1.clickPrompt('Reap with this creature');
+            expect(this.flipStallard.exhausted).toBe(true);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/LeftenantChars.spec.js
+++ b/test/server/cards/14-DM/LeftenantChars.spec.js
@@ -1,0 +1,46 @@
+describe('Leftenant Chars', function () {
+    describe('Leftenant Chars when not overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['leftenant-chars', 'bosun-creen']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['bad-penny']
+                }
+            });
+        });
+
+        it('captures 1 after fighting', function () {
+            this.player1.fightWith(this.leftenantChars, this.badPenny);
+            expect(this.leftenantChars.amber).toBe(1);
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Leftenant Chars when overwhelmed', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['leftenant-chars']
+                },
+                player2: {
+                    amber: 3,
+                    inPlay: ['bad-penny', 'krump', 'bumpsy']
+                }
+            });
+        });
+
+        it('steals 2 after fighting', function () {
+            this.player1.fightWith(this.leftenantChars, this.badPenny);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player2.amber).toBe(1);
+            expect(this.leftenantChars.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/Malforge.spec.js
+++ b/test/server/cards/14-DM/Malforge.spec.js
@@ -1,0 +1,40 @@
+describe('Malforge', function () {
+    describe("Malforge's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    amber: 6,
+                    inPlay: ['malforge']
+                },
+                player2: {
+                    house: 'shadows'
+                }
+            });
+        });
+
+        it('prevents the controller from forging keys at end of turn', function () {
+            this.player1.endTurn();
+            expect(this.player1.player.getForgedKeys()).toBe(0);
+            this.player2.clickPrompt('shadows');
+            expect(this.player2).isReadyToTakeAction();
+        });
+
+        it('deals 2 to Malforge at the end of the controller turn', function () {
+            this.player1.endTurn();
+            expect(this.malforge.tokens.damage).toBe(2);
+            this.player2.clickPrompt('shadows');
+            expect(this.player2).isReadyToTakeAction();
+        });
+
+        it('does not deal damage at the end of the opponent turn', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            const damageBefore = this.malforge.tokens.damage;
+            this.player2.endTurn();
+            this.player1.clickPrompt('skyborn');
+            expect(this.malforge.tokens.damage).toBe(damageBefore);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/RemmiHound.spec.js
+++ b/test/server/cards/14-DM/RemmiHound.spec.js
@@ -1,0 +1,44 @@
+describe('Remmi Hound', function () {
+    describe('Remmi Hound while exhausted', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['bosun-creen', 'troll', 'remmi-hound']
+                },
+                player2: {}
+            });
+        });
+
+        it('grants +4 power to friendly flank creatures', function () {
+            this.player1.reap(this.remmiHound);
+            // bosun-creen 3p + 4 = 7
+            expect(this.bosunCreen.power).toBe(7);
+            // remmi-hound 3p + 4 = 7
+            expect(this.remmiHound.power).toBe(7);
+            // troll center, 8p, no buff
+            expect(this.troll.power).toBe(8);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Remmi Hound while ready', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['bosun-creen', 'troll', 'remmi-hound']
+                },
+                player2: {}
+            });
+        });
+
+        it('does not grant power', function () {
+            expect(this.remmiHound.exhausted).toBe(false);
+            expect(this.bosunCreen.power).toBe(3);
+            expect(this.remmiHound.power).toBe(3);
+            expect(this.troll.power).toBe(8);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/RubyRackham.spec.js
+++ b/test/server/cards/14-DM/RubyRackham.spec.js
@@ -1,0 +1,51 @@
+describe('Ruby Rackham', function () {
+    describe('Ruby Rackham when no red key is forged', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['ruby-rackham']
+                },
+                player2: {
+                    inPlay: ['murmook', 'krump', 'troll']
+                }
+            });
+        });
+
+        it('deals 1 to each enemy flank creature after fight', function () {
+            // Ruby (3p, 1 armor) fights left-flank murmook (3p): murmook dies, ruby survives
+            this.player1.fightWith(this.rubyRackham, this.murmook);
+            expect(this.rubyRackham.location).toBe('play area');
+            expect(this.murmook.location).toBe('discard');
+            // After murmook dies, krump (was center) is left flank, troll stays right flank
+            expect(this.krump.tokens.damage).toBe(1);
+            expect(this.troll.tokens.damage).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Ruby Rackham when red key is forged', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['ruby-rackham']
+                },
+                player2: {
+                    inPlay: ['murmook', 'krump', 'troll']
+                }
+            });
+            this.player1.player.keys.red = true;
+        });
+
+        it('deals 4 to each enemy flank creature after fight', function () {
+            this.player1.fightWith(this.rubyRackham, this.murmook);
+            expect(this.rubyRackham.location).toBe('play area');
+            expect(this.murmook.location).toBe('discard');
+            // krump (6p) takes 4, troll (8p) takes 4
+            expect(this.krump.tokens.damage).toBe(4);
+            expect(this.troll.tokens.damage).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/TurBoProp.spec.js
+++ b/test/server/cards/14-DM/TurBoProp.spec.js
@@ -1,0 +1,63 @@
+describe('Tur-Bo Prop', function () {
+    describe('Tur-Bo Prop when no blue key is forged', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['tur-bo-prop'],
+                    deck: ['troll', 'krump', 'bumpsy']
+                },
+                player2: {}
+            });
+        });
+
+        it('draws 1 card on reap', function () {
+            const handBefore = this.player1.hand.length;
+            this.player1.reap(this.turBoProp);
+            expect(this.player1.hand.length).toBe(handBefore + 1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Tur-Bo Prop when player has forged blue key', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['tur-bo-prop'],
+                    deck: ['troll', 'krump', 'bumpsy']
+                },
+                player2: {}
+            });
+            this.player1.player.keys.blue = true;
+        });
+
+        it('draws 2 cards on reap', function () {
+            const handBefore = this.player1.hand.length;
+            this.player1.reap(this.turBoProp);
+            expect(this.player1.hand.length).toBe(handBefore + 2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Tur-Bo Prop when opponent has forged blue key', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['tur-bo-prop'],
+                    deck: ['troll', 'krump', 'bumpsy']
+                },
+                player2: {}
+            });
+            this.player2.player.keys.blue = true;
+        });
+
+        it('draws 2 cards on reap', function () {
+            const handBefore = this.player1.hand.length;
+            this.player1.reap(this.turBoProp);
+            expect(this.player1.hand.length).toBe(handBefore + 2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/TyLourd.spec.js
+++ b/test/server/cards/14-DM/TyLourd.spec.js
@@ -1,0 +1,46 @@
+describe('Ty Lourd', function () {
+    describe('Ty Lourd when opponent discards from hand', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['ty-lourd']
+                },
+                player2: {
+                    house: 'brobnar',
+                    hand: ['troll']
+                }
+            });
+        });
+
+        it('gains 1 amber for each card discarded', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.scrap(this.troll);
+            expect(this.player1.amber).toBe(1);
+            this.player2.endTurn();
+            this.player1.clickPrompt('skyborn');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Ty Lourd when an opponent's creature is discarded from play", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['ty-lourd']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+        });
+
+        it('does not gain amber', function () {
+            this.player2.moveCard(this.troll, 'discard');
+            expect(this.player1.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds many new card implementations plus a new `Game.isKeyForged` helper that changes how some repeat/conditional effects detect forged keys, so gameplay regressions are possible if key state is interpreted differently than before.
> 
> **Overview**
> Implements a batch of new Skyborn-related cards (set `14-DM`) with play/fight/reap/reaction/persistent effects such as flank-based buffs, overwhelmed conditionals, control-changing lasting effects, and key-dependent scaling.
> 
> Adds `Game.isKeyForged(color)` and updates existing cards (`RecreationalJettison`, `RedSkies`) to use a *global* “any player forged this key” check instead of per-player/opponent checks, and introduces comprehensive unit tests for the new cards’ behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e4a14a9ce6095ea63d6a66504d65afe2e39380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->