### PR TITLE
feat: implement ekwidon

### DIFF
--- a/server/game/cards/14-DM/AuthorizedRequisitions.js
+++ b/server/game/cards/14-DM/AuthorizedRequisitions.js
@@ -1,0 +1,22 @@
+const Card = require('../../Card.js');
+
+class AuthorizedRequisitions extends Card {
+    // Play: A friendly creature captures 2A. Draw a card.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                controller: 'self',
+                gameAction: ability.actions.capture({ amount: 2 })
+            },
+            then: {
+                alwaysTriggers: true,
+                gameAction: ability.actions.draw()
+            }
+        });
+    }
+}
+
+AuthorizedRequisitions.id = 'authorized-requisitions';
+
+module.exports = AuthorizedRequisitions;

--- a/server/game/cards/14-DM/BleaForh.js
+++ b/server/game/cards/14-DM/BleaForh.js
@@ -5,44 +5,33 @@ class BleaForh extends Card {
     // healed this way, exalt that creature.
     setupCardAbilities(ability) {
         this.fight({
-            targets: {
-                creature: {
-                    activePromptTitle: 'Choose a creature to heal',
-                    cardType: 'creature'
-                },
-                amount: {
-                    dependsOn: 'creature',
-                    mode: 'select',
-                    choices: {
-                        0: () => true,
-                        1: (context) =>
-                            context.targets.creature && context.targets.creature.damage >= 1,
-                        2: (context) =>
-                            context.targets.creature && context.targets.creature.damage >= 2
-                    }
-                }
+            target: {
+                activePromptTitle: 'Choose a creature to heal',
+                cardType: 'creature',
+                gameAction: ability.actions.heal({ amount: 2, upTo: true })
             },
-            effect: 'heal {1} for {2} damage',
-            effectArgs: (context) => [
-                context.targets.creature,
-                context.selects && context.selects.amount ? context.selects.amount.choice : 0
-            ],
-            gameAction: [
-                ability.actions.heal((context) => ({
-                    target: context.targets.creature,
-                    amount:
-                        context.selects && context.selects.amount
-                            ? parseInt(context.selects.amount.choice)
-                            : 0
-                })),
-                ability.actions.exalt((context) => ({
-                    target: context.targets.creature,
-                    amount:
-                        context.selects && context.selects.amount
-                            ? parseInt(context.selects.amount.choice)
-                            : 0
+            preferActionPromptMessage: true,
+            then: (preThenContext) => ({
+                condition: (context) =>
+                    (context.preThenEvents || []).some(
+                        (event) => !event.cancelled && event.amount > 0
+                    ),
+                message: '{0} uses {1} to exalt {3} with {4} amber',
+                messageArgs: (context) => [
+                    preThenContext.target,
+                    (context.preThenEvents || []).reduce(
+                        (sum, event) => sum + (event.cancelled ? 0 : event.amount || 0),
+                        0
+                    )
+                ],
+                gameAction: ability.actions.exalt((context) => ({
+                    target: preThenContext.target,
+                    amount: (context.preThenEvents || []).reduce(
+                        (sum, event) => sum + (event.cancelled ? 0 : event.amount || 0),
+                        0
+                    )
                 }))
-            ]
+            })
         });
     }
 }

--- a/server/game/cards/14-DM/BleaForh.js
+++ b/server/game/cards/14-DM/BleaForh.js
@@ -1,0 +1,50 @@
+const Card = require('../../Card.js');
+
+class BleaForh extends Card {
+    // After Fight: Heal up to 2 damage from a creature. For each damage
+    // healed this way, exalt that creature.
+    setupCardAbilities(ability) {
+        this.fight({
+            targets: {
+                creature: {
+                    activePromptTitle: 'Choose a creature to heal',
+                    cardType: 'creature'
+                },
+                amount: {
+                    dependsOn: 'creature',
+                    mode: 'select',
+                    activePromptTitle: 'Choose how much damage to heal',
+                    choices: {
+                        0: () => true,
+                        1: (context) =>
+                            context.targets.creature && context.targets.creature.damage >= 1,
+                        2: (context) =>
+                            context.targets.creature && context.targets.creature.damage >= 2
+                    }
+                }
+            },
+            effect: 'heal {1} for {2} damage',
+            effectArgs: (context) => [context.targets.creature, context.selects.amount.choice],
+            gameAction: [
+                ability.actions.heal((context) => ({
+                    target: context.targets.creature,
+                    amount:
+                        context.selects && context.selects.amount
+                            ? parseInt(context.selects.amount.choice)
+                            : 0
+                })),
+                ability.actions.exalt((context) => ({
+                    target: context.targets.creature,
+                    amount:
+                        context.selects && context.selects.amount
+                            ? parseInt(context.selects.amount.choice)
+                            : 0
+                }))
+            ]
+        });
+    }
+}
+
+BleaForh.id = 'blea-forh';
+
+module.exports = BleaForh;

--- a/server/game/cards/14-DM/BleaForh.js
+++ b/server/game/cards/14-DM/BleaForh.js
@@ -13,7 +13,6 @@ class BleaForh extends Card {
                 amount: {
                     dependsOn: 'creature',
                     mode: 'select',
-                    activePromptTitle: 'Choose how much damage to heal',
                     choices: {
                         0: () => true,
                         1: (context) =>
@@ -24,7 +23,10 @@ class BleaForh extends Card {
                 }
             },
             effect: 'heal {1} for {2} damage',
-            effectArgs: (context) => [context.targets.creature, context.selects.amount.choice],
+            effectArgs: (context) => [
+                context.targets.creature,
+                context.selects && context.selects.amount ? context.selects.amount.choice : 0
+            ],
             gameAction: [
                 ability.actions.heal((context) => ({
                     target: context.targets.creature,
@@ -45,6 +47,6 @@ class BleaForh extends Card {
     }
 }
 
-BleaForh.id = 'blea-forh';
+BleaForh.id = 'bleă-fŏrh';
 
 module.exports = BleaForh;

--- a/server/game/cards/14-DM/BypassBurglar.js
+++ b/server/game/cards/14-DM/BypassBurglar.js
@@ -15,8 +15,7 @@ class BypassBurglar extends Card {
                         target: context.source
                     }))
                 ]),
-                effect: 'steal 1 amber and deal 1 damage to {0}',
-                effectArgs: (context) => [context.source]
+                effect: 'steal 1 amber and deal 1 damage to itself'
             })
         });
     }

--- a/server/game/cards/14-DM/BypassBurglar.js
+++ b/server/game/cards/14-DM/BypassBurglar.js
@@ -1,0 +1,27 @@
+const Card = require('../../Card.js');
+
+class BypassBurglar extends Card {
+    // Entrench.
+    // While Bypass Burglar is exhausted, each of its neighbors gains, "Action:
+    // Steal 1A. Deal 1D to this creature."
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.exhausted,
+            match: (card, context) => context.source.neighbors.includes(card),
+            effect: ability.effects.gainAbility('action', {
+                gameAction: ability.actions.sequential([
+                    ability.actions.steal(),
+                    ability.actions.dealDamage((context) => ({
+                        target: context.source
+                    }))
+                ]),
+                effect: 'steal 1 amber and deal 1 damage to {0}',
+                effectArgs: (context) => [context.source]
+            })
+        });
+    }
+}
+
+BypassBurglar.id = 'bypass-burglar';
+
+module.exports = BypassBurglar;

--- a/server/game/cards/14-DM/ChromaticGuardian.js
+++ b/server/game/cards/14-DM/ChromaticGuardian.js
@@ -1,0 +1,30 @@
+const Card = require('../../Card.js');
+
+class ChromaticGuardian extends Card {
+    // After Fight/After Reap: If you are overwhelmed, destroy an enemy
+    // creature. Otherwise, destroy an enemy artifact.
+    setupCardAbilities(ability) {
+        this.reap({
+            fight: true,
+            gameAction: ability.actions.conditional((context) => ({
+                condition: context.player.isOverwhelmed(),
+                trueGameAction: ability.actions.destroy({
+                    promptForSelect: {
+                        cardType: 'creature',
+                        controller: 'opponent'
+                    }
+                }),
+                falseGameAction: ability.actions.destroy({
+                    promptForSelect: {
+                        cardType: 'artifact',
+                        controller: 'opponent'
+                    }
+                })
+            }))
+        });
+    }
+}
+
+ChromaticGuardian.id = 'chromatic-guardian';
+
+module.exports = ChromaticGuardian;

--- a/server/game/cards/14-DM/ConradFisique.js
+++ b/server/game/cards/14-DM/ConradFisique.js
@@ -9,14 +9,12 @@ class ConradFisique extends Card {
             optional: true,
             targets: {
                 source: {
-                    activePromptTitle: 'Choose a creature to move power counters from',
                     cardType: 'creature',
                     cardCondition: (card) => card.hasToken('power'),
                     gameAction: ability.actions.removePowerCounter({ all: true })
                 },
                 dest: {
                     dependsOn: 'source',
-                    activePromptTitle: 'Choose a creature to move power counters to',
                     cardType: 'creature',
                     cardCondition: (card, context) => card !== context.targets.source,
                     gameAction: ability.actions.addPowerCounter((context) => ({
@@ -30,6 +28,6 @@ class ConradFisique extends Card {
     }
 }
 
-ConradFisique.id = 'conrad-fisique';
+ConradFisique.id = 'cŏnrăd-fisiquĕ';
 
 module.exports = ConradFisique;

--- a/server/game/cards/14-DM/ConradFisique.js
+++ b/server/game/cards/14-DM/ConradFisique.js
@@ -7,21 +7,22 @@ class ConradFisique extends Card {
     setupCardAbilities(ability) {
         this.play({
             optional: true,
-            target: {
-                activePromptTitle: 'Choose a creature to move power counters from',
-                cardType: 'creature',
-                cardCondition: (card) => card.hasToken('power'),
-                gameAction: ability.actions.removePowerCounter((context) => ({
-                    amount: context.target ? context.target.tokens.power || 0 : 0
-                }))
-            },
-            then: {
-                target: {
+            targets: {
+                source: {
+                    activePromptTitle: 'Choose a creature to move power counters from',
+                    cardType: 'creature',
+                    cardCondition: (card) => card.hasToken('power'),
+                    gameAction: ability.actions.removePowerCounter({ all: true })
+                },
+                dest: {
+                    dependsOn: 'source',
                     activePromptTitle: 'Choose a creature to move power counters to',
                     cardType: 'creature',
-                    cardCondition: (card, context) => card !== context.preThenEvent.card,
+                    cardCondition: (card, context) => card !== context.targets.source,
                     gameAction: ability.actions.addPowerCounter((context) => ({
-                        amount: context.preThenEvent.amount
+                        amount: context.targets.source
+                            ? context.targets.source.tokens.power || 0
+                            : 0
                     }))
                 }
             }

--- a/server/game/cards/14-DM/ConradFisique.js
+++ b/server/game/cards/14-DM/ConradFisique.js
@@ -10,7 +10,6 @@ class ConradFisique extends Card {
             targets: {
                 source: {
                     cardType: 'creature',
-                    cardCondition: (card) => card.hasToken('power'),
                     gameAction: ability.actions.removePowerCounter({ all: true })
                 },
                 dest: {
@@ -23,6 +22,16 @@ class ConradFisique extends Card {
                             : 0
                     }))
                 }
+            },
+            effect: 'move {1} +1 power {2} from {3}{4}',
+            effectArgs: (context) => {
+                const amount = (context.targets.source && context.targets.source.tokens.power) || 0;
+                return [
+                    amount,
+                    amount === 1 ? 'counter' : 'counters',
+                    context.targets.source,
+                    context.targets.dest ? ' to ' + context.targets.dest.name : ''
+                ];
             }
         });
     }

--- a/server/game/cards/14-DM/ConradFisique.js
+++ b/server/game/cards/14-DM/ConradFisique.js
@@ -1,0 +1,34 @@
+const Card = require('../../Card.js');
+
+class ConradFisique extends Card {
+    // Enhance.
+    // Play: You may move each +1 power counter from a creature to another
+    // creature.
+    setupCardAbilities(ability) {
+        this.play({
+            optional: true,
+            target: {
+                activePromptTitle: 'Choose a creature to move power counters from',
+                cardType: 'creature',
+                cardCondition: (card) => card.hasToken('power'),
+                gameAction: ability.actions.removePowerCounter((context) => ({
+                    amount: context.target ? context.target.tokens.power || 0 : 0
+                }))
+            },
+            then: {
+                target: {
+                    activePromptTitle: 'Choose a creature to move power counters to',
+                    cardType: 'creature',
+                    cardCondition: (card, context) => card !== context.preThenEvent.card,
+                    gameAction: ability.actions.addPowerCounter((context) => ({
+                        amount: context.preThenEvent.amount
+                    }))
+                }
+            }
+        });
+    }
+}
+
+ConradFisique.id = 'conrad-fisique';
+
+module.exports = ConradFisique;

--- a/server/game/cards/14-DM/DapperChapeau.js
+++ b/server/game/cards/14-DM/DapperChapeau.js
@@ -12,23 +12,52 @@ class DapperChapeau extends Card {
                     cardType: 'creature',
                     gameAction: ability.actions.dealDamage({ amount: 4 })
                 },
-                then: {
-                    alwaysTriggers: true,
-                    gameAction: ability.actions.conditional((context) => ({
-                        condition: !!(
-                            context.preThenEvent &&
-                            context.preThenEvent.destroyEvent &&
-                            context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
-                            context.preThenEvent.destroyEvent.resolved
-                        ),
-                        trueGameAction: ability.actions.returnToHand({
-                            target: upgrade
-                        }),
-                        falseGameAction: ability.actions.attach({
-                            target: context.preThenEvent ? context.preThenEvent.card : undefined,
-                            upgrade: upgrade
+                then: (preThenContext) => {
+                    const targetCard = preThenContext.target;
+                    return {
+                        alwaysTriggers: true,
+                        gameAction: ability.actions.conditional({
+                            // Damage destroyed the target -> return DC to hand.
+                            condition: (context) =>
+                                !!(
+                                    context.preThenEvent &&
+                                    context.preThenEvent.destroyEvent &&
+                                    context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
+                                    context.preThenEvent.destroyEvent.resolved
+                                ),
+                            trueGameAction: ability.actions.returnToHand({
+                                target: upgrade,
+                                location: ['play area', 'discard']
+                            }),
+                            falseGameAction: ability.actions.conditional({
+                                // Both target and host are still alive ->
+                                // attach DC to the target.
+                                condition: () =>
+                                    upgrade.location === 'play area' &&
+                                    !!targetCard &&
+                                    targetCard.location === 'play area',
+                                trueGameAction: ability.actions.attach({
+                                    target: targetCard,
+                                    upgrade: upgrade
+                                }),
+                                falseGameAction: ability.actions.conditional({
+                                    // Host died as collateral but target
+                                    // survived -> return DC to hand from
+                                    // discard. Otherwise (target also gone)
+                                    // DC stays in the discard.
+                                    condition: () =>
+                                        upgrade.location === 'discard' &&
+                                        !!targetCard &&
+                                        targetCard.location === 'play area',
+                                    trueGameAction: ability.actions.returnToHand({
+                                        target: upgrade,
+                                        location: ['play area', 'discard']
+                                    }),
+                                    falseGameAction: []
+                                })
+                            })
                         })
-                    }))
+                    };
                 }
             })
         });

--- a/server/game/cards/14-DM/DapperChapeau.js
+++ b/server/game/cards/14-DM/DapperChapeau.js
@@ -1,0 +1,40 @@
+const Card = require('../../Card.js');
+
+class DapperChapeau extends Card {
+    // This creature gains, "Action: Deal 4 to a creature. If this damage
+    // destroys that creature, return Dapper Chapeau to its owner's hand.
+    // Otherwise, attach Dapper Chapeau to that creature."
+    setupCardAbilities(ability) {
+        const upgrade = this;
+        this.whileAttached({
+            effect: ability.effects.gainAbility('action', {
+                target: {
+                    cardType: 'creature',
+                    gameAction: ability.actions.dealDamage({ amount: 4 })
+                },
+                then: {
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.conditional((context) => ({
+                        condition: !!(
+                            context.preThenEvent &&
+                            context.preThenEvent.destroyEvent &&
+                            context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
+                            context.preThenEvent.destroyEvent.resolved
+                        ),
+                        trueGameAction: ability.actions.returnToHand({
+                            target: upgrade
+                        }),
+                        falseGameAction: ability.actions.attach({
+                            target: context.preThenEvent ? context.preThenEvent.card : undefined,
+                            upgrade: upgrade
+                        })
+                    }))
+                }
+            })
+        });
+    }
+}
+
+DapperChapeau.id = 'dapper-chapeau';
+
+module.exports = DapperChapeau;

--- a/server/game/cards/14-DM/DapperChapeau.js
+++ b/server/game/cards/14-DM/DapperChapeau.js
@@ -1,7 +1,7 @@
 const Card = require('../../Card.js');
 
 class DapperChapeau extends Card {
-    // This creature gains, "Action: Deal 4 to a creature. If this damage
+    // This creature gains, "Action: Deal 4 damage to a creature. If this damage
     // destroys that creature, return Dapper Chapeau to its owner's hand.
     // Otherwise, attach Dapper Chapeau to that creature."
     setupCardAbilities(ability) {

--- a/server/game/cards/14-DM/DapperChapeau.js
+++ b/server/game/cards/14-DM/DapperChapeau.js
@@ -12,53 +12,24 @@ class DapperChapeau extends Card {
                     cardType: 'creature',
                     gameAction: ability.actions.dealDamage({ amount: 4 })
                 },
-                then: (preThenContext) => {
-                    const targetCard = preThenContext.target;
-                    return {
-                        alwaysTriggers: true,
-                        gameAction: ability.actions.conditional({
-                            // Damage destroyed the target -> return DC to hand.
-                            condition: (context) =>
-                                !!(
-                                    context.preThenEvent &&
-                                    context.preThenEvent.destroyEvent &&
-                                    context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
-                                    context.preThenEvent.destroyEvent.resolved
-                                ),
-                            trueGameAction: ability.actions.returnToHand({
-                                target: upgrade,
-                                location: ['play area', 'discard']
-                            }),
-                            falseGameAction: ability.actions.conditional({
-                                // Both target and host are still alive ->
-                                // attach DC to the target.
-                                condition: () =>
-                                    upgrade.location === 'play area' &&
-                                    !!targetCard &&
-                                    targetCard.location === 'play area',
-                                trueGameAction: ability.actions.attach({
-                                    target: targetCard,
-                                    upgrade: upgrade
-                                }),
-                                falseGameAction: ability.actions.conditional({
-                                    // Host died as collateral but target
-                                    // survived -> return DC to hand from
-                                    // discard. Otherwise (target also gone)
-                                    // DC stays in the discard.
-                                    condition: () =>
-                                        upgrade.location === 'discard' &&
-                                        !!targetCard &&
-                                        targetCard.location === 'play area',
-                                    trueGameAction: ability.actions.returnToHand({
-                                        target: upgrade,
-                                        location: ['play area', 'discard']
-                                    }),
-                                    falseGameAction: []
-                                })
-                            })
+                then: (preThenContext) => ({
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.conditional({
+                        condition: (context) =>
+                            upgrade.location === 'play area' &&
+                            !!(
+                                context.preThenEvent &&
+                                context.preThenEvent.destroyEvent &&
+                                context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
+                                context.preThenEvent.destroyEvent.resolved
+                            ),
+                        trueGameAction: ability.actions.returnToHand({ target: upgrade }),
+                        falseGameAction: ability.actions.attach({
+                            target: preThenContext.target,
+                            upgrade: upgrade
                         })
-                    };
-                }
+                    })
+                })
             })
         });
     }

--- a/server/game/cards/14-DM/DrasticMeasures.js
+++ b/server/game/cards/14-DM/DrasticMeasures.js
@@ -12,12 +12,12 @@ class DrasticMeasures extends Card {
                 controller: 'self',
                 gameAction: ability.actions.purge()
             },
-            then: (preThenContext) => ({
+            then: {
                 alwaysTriggers: true,
-                gameAction: ability.actions.gainAmber({
-                    amount: preThenContext.target ? preThenContext.target.length : 0
-                })
-            })
+                gameAction: ability.actions.gainAmber((context) => ({
+                    amount: (context.preThenEvents || []).filter((event) => !event.cancelled).length
+                }))
+            }
         });
     }
 }

--- a/server/game/cards/14-DM/DrasticMeasures.js
+++ b/server/game/cards/14-DM/DrasticMeasures.js
@@ -1,0 +1,27 @@
+const Card = require('../../Card.js');
+
+class DrasticMeasures extends Card {
+    // Play: Purge up to 2 cards from your hand. For each card purged this way,
+    // gain 1A.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                mode: 'upTo',
+                numCards: 2,
+                location: 'hand',
+                controller: 'self',
+                gameAction: ability.actions.purge()
+            },
+            then: (preThenContext) => ({
+                alwaysTriggers: true,
+                gameAction: ability.actions.gainAmber({
+                    amount: preThenContext.target ? preThenContext.target.length : 0
+                })
+            })
+        });
+    }
+}
+
+DrasticMeasures.id = 'drastic-measures';
+
+module.exports = DrasticMeasures;

--- a/server/game/cards/14-DM/EvenSwap.js
+++ b/server/game/cards/14-DM/EvenSwap.js
@@ -30,12 +30,12 @@ class EvenSwap extends Card {
         });
 
         this.play({
-            target: giveTarget('a'),
+            target: giveTarget(),
             effect: 'give control of {0} to {1}',
             effectArgs: (context) => context.player.opponent,
             then: (firstCtx) => ({
                 alwaysTriggers: true,
-                target: giveTarget('another'),
+                target: giveTarget(),
                 message: '{0} uses {1} to give control of {2} to {3}',
                 messageArgs: (context) => context.player.opponent,
                 then: (secondCtx) => {
@@ -46,11 +46,11 @@ class EvenSwap extends Card {
                     }
                     return {
                         alwaysTriggers: true,
-                        target: takeTarget('an'),
+                        target: takeTarget(),
                         message: '{0} uses {1} to take control of {2}',
                         then: () => ({
                             alwaysTriggers: true,
-                            target: takeTarget('another'),
+                            target: takeTarget(),
                             message: '{0} uses {1} to take control of {2}'
                         })
                     };

--- a/server/game/cards/14-DM/EvenSwap.js
+++ b/server/game/cards/14-DM/EvenSwap.js
@@ -4,37 +4,46 @@ class EvenSwap extends Card {
     // Play: Give control of two friendly creatures to your opponent, one at a
     // time. If you do, take control of two enemy creatures, one at a time.
     setupCardAbilities(ability) {
+        const giveTarget = (titleSuffix) => ({
+            mode: 'exactly',
+            numCards: (context) => (context.player.creaturesInPlay.length >= 1 ? 1 : 0),
+            activePromptTitle: `Choose ${titleSuffix} friendly creature to give to your opponent`,
+            cardType: 'creature',
+            controller: 'self',
+            gameAction: ability.actions.cardLastingEffect((context) => ({
+                duration: 'lastingEffect',
+                effect: ability.effects.takeControl(context.player.opponent)
+            }))
+        });
+
         this.play({
-            condition: (context) =>
-                !!context.player.opponent &&
-                context.player.creaturesInPlay.length >= 2 &&
-                context.player.opponent.creaturesInPlay.length >= 2,
-            target: {
-                mode: 'exactly',
-                numCards: 2,
-                activePromptTitle: 'Choose two friendly creatures to give to your opponent',
-                cardType: 'creature',
-                controller: 'self',
-                gameAction: ability.actions.cardLastingEffect((context) => ({
-                    duration: 'lastingEffect',
-                    effect: ability.effects.takeControl(context.player.opponent)
-                }))
-            },
-            effect: 'give control of two friendly creatures to their opponent',
-            then: {
+            target: giveTarget('a'),
+            effect: 'give control of friendly creatures to their opponent',
+            then: (firstCtx) => ({
                 alwaysTriggers: true,
-                target: {
-                    mode: 'exactly',
-                    numCards: 2,
-                    activePromptTitle: 'Choose two enemy creatures to take',
-                    cardType: 'creature',
-                    controller: 'opponent',
-                    gameAction: ability.actions.cardLastingEffect((context) => ({
-                        duration: 'lastingEffect',
-                        effect: ability.effects.takeControl(context.player)
-                    }))
+                target: giveTarget('another'),
+                then: (secondCtx) => {
+                    const gaveFirst = !!firstCtx.target;
+                    const gaveSecond = !!secondCtx.target;
+                    if (!(gaveFirst && gaveSecond)) {
+                        return { alwaysTriggers: true };
+                    }
+                    return {
+                        alwaysTriggers: true,
+                        target: {
+                            mode: 'upTo',
+                            numCards: 2,
+                            activePromptTitle: 'Choose enemy creatures to take',
+                            cardType: 'creature',
+                            controller: 'opponent',
+                            gameAction: ability.actions.cardLastingEffect((context) => ({
+                                duration: 'lastingEffect',
+                                effect: ability.effects.takeControl(context.player)
+                            }))
+                        }
+                    };
                 }
-            }
+            })
         });
     }
 }

--- a/server/game/cards/14-DM/EvenSwap.js
+++ b/server/game/cards/14-DM/EvenSwap.js
@@ -1,0 +1,44 @@
+const Card = require('../../Card.js');
+
+class EvenSwap extends Card {
+    // Play: Give control of two friendly creatures to your opponent, one at a
+    // time. If you do, take control of two enemy creatures, one at a time.
+    setupCardAbilities(ability) {
+        this.play({
+            condition: (context) =>
+                !!context.player.opponent &&
+                context.player.creaturesInPlay.length >= 2 &&
+                context.player.opponent.creaturesInPlay.length >= 2,
+            target: {
+                mode: 'exactly',
+                numCards: 2,
+                activePromptTitle: 'Choose two friendly creatures to give to your opponent',
+                cardType: 'creature',
+                controller: 'self',
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'lastingEffect',
+                    effect: ability.effects.takeControl(context.player.opponent)
+                }))
+            },
+            effect: 'give control of two friendly creatures to their opponent',
+            then: {
+                alwaysTriggers: true,
+                target: {
+                    mode: 'exactly',
+                    numCards: 2,
+                    activePromptTitle: 'Choose two enemy creatures to take',
+                    cardType: 'creature',
+                    controller: 'opponent',
+                    gameAction: ability.actions.cardLastingEffect((context) => ({
+                        duration: 'lastingEffect',
+                        effect: ability.effects.takeControl(context.player)
+                    }))
+                }
+            }
+        });
+    }
+}
+
+EvenSwap.id = 'even-swap';
+
+module.exports = EvenSwap;

--- a/server/game/cards/14-DM/EvenSwap.js
+++ b/server/game/cards/14-DM/EvenSwap.js
@@ -4,10 +4,9 @@ class EvenSwap extends Card {
     // Play: Give control of two friendly creatures to your opponent, one at a
     // time. If you do, take control of two enemy creatures, one at a time.
     setupCardAbilities(ability) {
-        const giveTarget = (titleSuffix) => ({
+        const giveTarget = () => ({
             mode: 'exactly',
             numCards: (context) => (context.player.creaturesInPlay.length >= 1 ? 1 : 0),
-            activePromptTitle: `Choose ${titleSuffix} friendly creature to give to your opponent`,
             cardType: 'creature',
             controller: 'self',
             gameAction: ability.actions.cardLastingEffect((context) => ({
@@ -16,12 +15,29 @@ class EvenSwap extends Card {
             }))
         });
 
+        const takeTarget = () => ({
+            mode: 'exactly',
+            numCards: (context) =>
+                context.player.opponent && context.player.opponent.creaturesInPlay.length >= 1
+                    ? 1
+                    : 0,
+            cardType: 'creature',
+            controller: 'opponent',
+            gameAction: ability.actions.cardLastingEffect((context) => ({
+                duration: 'lastingEffect',
+                effect: ability.effects.takeControl(context.player)
+            }))
+        });
+
         this.play({
             target: giveTarget('a'),
-            effect: 'give control of friendly creatures to their opponent',
+            effect: 'give control of {0} to {1}',
+            effectArgs: (context) => context.player.opponent,
             then: (firstCtx) => ({
                 alwaysTriggers: true,
                 target: giveTarget('another'),
+                message: '{0} uses {1} to give control of {2} to {3}',
+                messageArgs: (context) => context.player.opponent,
                 then: (secondCtx) => {
                     const gaveFirst = !!firstCtx.target;
                     const gaveSecond = !!secondCtx.target;
@@ -30,17 +46,13 @@ class EvenSwap extends Card {
                     }
                     return {
                         alwaysTriggers: true,
-                        target: {
-                            mode: 'upTo',
-                            numCards: 2,
-                            activePromptTitle: 'Choose enemy creatures to take',
-                            cardType: 'creature',
-                            controller: 'opponent',
-                            gameAction: ability.actions.cardLastingEffect((context) => ({
-                                duration: 'lastingEffect',
-                                effect: ability.effects.takeControl(context.player)
-                            }))
-                        }
+                        target: takeTarget('an'),
+                        message: '{0} uses {1} to take control of {2}',
+                        then: () => ({
+                            alwaysTriggers: true,
+                            target: takeTarget('another'),
+                            message: '{0} uses {1} to take control of {2}'
+                        })
                     };
                 }
             })

--- a/server/game/cards/14-DM/ExeldonYash.js
+++ b/server/game/cards/14-DM/ExeldonYash.js
@@ -1,0 +1,34 @@
+const Card = require('../../Card.js');
+
+class ExeldonYash extends Card {
+    // After Reap: Capture 2A. You may discard a card. If you do, move 1A from
+    // Exeldon Yash to your pool.
+    setupCardAbilities(ability) {
+        this.reap({
+            gameAction: ability.actions.capture({ amount: 2 }),
+            then: {
+                alwaysTriggers: true,
+                target: {
+                    optional: true,
+                    activePromptTitle: 'You may discard a card to move 1 amber to your pool',
+                    location: 'hand',
+                    controller: 'self',
+                    gameAction: ability.actions.discard()
+                },
+                then: (preThenContext) => ({
+                    condition: () =>
+                        !!preThenContext.target && preThenContext.source.hasToken('amber'),
+                    gameAction: ability.actions.returnAmber((context) => ({
+                        target: context.source,
+                        amount: 1,
+                        recipient: context.player
+                    }))
+                })
+            }
+        });
+    }
+}
+
+ExeldonYash.id = 'exeldon-yash';
+
+module.exports = ExeldonYash;

--- a/server/game/cards/14-DM/ExeldonYash.js
+++ b/server/game/cards/14-DM/ExeldonYash.js
@@ -10,7 +10,6 @@ class ExeldonYash extends Card {
                 alwaysTriggers: true,
                 target: {
                     optional: true,
-                    activePromptTitle: 'You may discard a card to move 1 amber to your pool',
                     location: 'hand',
                     controller: 'self',
                     gameAction: ability.actions.discard()

--- a/server/game/cards/14-DM/FiatTranscoder.js
+++ b/server/game/cards/14-DM/FiatTranscoder.js
@@ -1,0 +1,29 @@
+const Card = require('../../Card.js');
+
+class FiatTranscoder extends Card {
+    // Action: Lose 1A. If you do, take control of an enemy creature.
+    setupCardAbilities(ability) {
+        this.action({
+            gameAction: ability.actions.loseAmber((context) => ({
+                target: context.player
+            })),
+            then: {
+                alwaysTriggers: true,
+                condition: (context) => context.preThenEvent && !context.preThenEvent.cancelled,
+                target: {
+                    cardType: 'creature',
+                    controller: 'opponent',
+                    gameAction: ability.actions.cardLastingEffect((context) => ({
+                        duration: 'lastingEffect',
+                        effect: ability.effects.takeControl(context.player)
+                    }))
+                },
+                effect: 'take control of {0}'
+            }
+        });
+    }
+}
+
+FiatTranscoder.id = 'fiat-transcoder';
+
+module.exports = FiatTranscoder;

--- a/server/game/cards/14-DM/FiatTranscoder.js
+++ b/server/game/cards/14-DM/FiatTranscoder.js
@@ -8,8 +8,6 @@ class FiatTranscoder extends Card {
                 target: context.player
             })),
             then: {
-                alwaysTriggers: true,
-                condition: (context) => context.preThenEvent && !context.preThenEvent.cancelled,
                 target: {
                     cardType: 'creature',
                     controller: 'opponent',

--- a/server/game/cards/14-DM/ForgedCurrency.js
+++ b/server/game/cards/14-DM/ForgedCurrency.js
@@ -7,7 +7,18 @@ class ForgedCurrency extends Card {
     // supply this way (to a minimum of 6).
     setupCardAbilities(ability) {
         this.play({
-            effect: 'move all +1 power counters and amber from friendly creatures to the common supply',
+            effect: 'move {1} +1 power {2} and {3} amber from friendly creatures to the common supply',
+            effectArgs: (context) => {
+                const power = context.player.creaturesInPlay.reduce(
+                    (sum, c) => sum + (c.tokens.power || 0),
+                    0
+                );
+                const amber = context.player.creaturesInPlay.reduce(
+                    (sum, c) => sum + (c.tokens.amber || 0),
+                    0
+                );
+                return [power, power === 1 ? 'counter' : 'counters', amber];
+            },
             gameAction: ability.actions.jointAction([
                 ability.actions.removePowerCounter((context) => ({
                     target: context.player.creaturesInPlay.filter((c) => c.hasToken('power')),

--- a/server/game/cards/14-DM/ForgedCurrency.js
+++ b/server/game/cards/14-DM/ForgedCurrency.js
@@ -8,7 +8,7 @@ class ForgedCurrency extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'move all +1 power counters and amber from friendly creatures to the common supply',
-            gameAction: [
+            gameAction: ability.actions.jointAction([
                 ability.actions.removePowerCounter((context) => ({
                     target: context.player.creaturesInPlay.filter((c) => c.hasToken('power')),
                     all: true
@@ -17,7 +17,7 @@ class ForgedCurrency extends Card {
                     target: context.player.creaturesInPlay.filter((c) => c.hasToken('amber')),
                     all: true
                 }))
-            ],
+            ]),
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.forgeKey((preThenContext) => ({

--- a/server/game/cards/14-DM/ForgedCurrency.js
+++ b/server/game/cards/14-DM/ForgedCurrency.js
@@ -1,0 +1,40 @@
+const Card = require('../../Card.js');
+
+class ForgedCurrency extends Card {
+    // Play: Move each +1 power counter and each A from friendly creatures
+    // to the common supply. Forge a key at +6 current cost, reduced by 1
+    // for the total number of +1 power counters and A moved to the common
+    // supply this way (to a minimum of 6).
+    setupCardAbilities(ability) {
+        this.play({
+            effect: 'move all +1 power counters and amber from friendly creatures to the common supply',
+            gameAction: [
+                ability.actions.removePowerCounter((context) => ({
+                    target: context.player.creaturesInPlay.filter((c) => c.hasToken('power')),
+                    all: true
+                })),
+                ability.actions.removeAmber((context) => ({
+                    target: context.player.creaturesInPlay.filter((c) => c.hasToken('amber')),
+                    all: true
+                }))
+            ],
+            then: {
+                alwaysTriggers: true,
+                gameAction: ability.actions.forgeKey((preThenContext) => ({
+                    modifier: Math.max(
+                        0,
+                        6 -
+                            (preThenContext.preThenEvents || []).reduce(
+                                (sum, event) => sum + (event.cancelled ? 0 : event.amount || 0),
+                                0
+                            )
+                    )
+                }))
+            }
+        });
+    }
+}
+
+ForgedCurrency.id = 'forged-currency';
+
+module.exports = ForgedCurrency;

--- a/server/game/cards/14-DM/GoldenDagger.js
+++ b/server/game/cards/14-DM/GoldenDagger.js
@@ -14,7 +14,7 @@ class GoldenDagger extends Card {
                     context.preThenEvent.destroyEvent &&
                     context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
                     context.preThenEvent.destroyEvent.resolved,
-                message: '{0} uses {1} to make {2} gain 1 amber',
+                message: '{0} uses {1} to make {3} gain 1 amber',
                 messageArgs: (context) => [context.preThenEvent.card.owner],
                 gameAction: ability.actions.gainAmber((context) => ({
                     target: context.preThenEvent.card.owner

--- a/server/game/cards/14-DM/GoldenDagger.js
+++ b/server/game/cards/14-DM/GoldenDagger.js
@@ -1,0 +1,29 @@
+const Card = require('../../Card.js');
+
+class GoldenDagger extends Card {
+    // After Reap: Deal 3D to a creature. If this damage destroys that
+    // creature, its owner gains 1A.
+    setupCardAbilities(ability) {
+        this.reap({
+            target: {
+                cardType: 'creature',
+                gameAction: ability.actions.dealDamage({ amount: 3 })
+            },
+            then: {
+                condition: (context) =>
+                    context.preThenEvent.destroyEvent &&
+                    context.preThenEvent.destroyEvent.destroyedByDamageDealt &&
+                    context.preThenEvent.destroyEvent.resolved,
+                message: '{0} uses {1} to make {2} gain 1 amber',
+                messageArgs: (context) => [context.preThenEvent.card.owner],
+                gameAction: ability.actions.gainAmber((context) => ({
+                    target: context.preThenEvent.card.owner
+                }))
+            }
+        });
+    }
+}
+
+GoldenDagger.id = 'golden-dagger';
+
+module.exports = GoldenDagger;

--- a/server/game/cards/14-DM/HotBunk.js
+++ b/server/game/cards/14-DM/HotBunk.js
@@ -1,0 +1,23 @@
+const Card = require('../../Card.js');
+
+class HotBunk extends Card {
+    // Play: Exhaust a creature. If you do, ready a creature.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                cardType: 'creature',
+                gameAction: ability.actions.exhaust()
+            },
+            then: {
+                target: {
+                    cardType: 'creature',
+                    gameAction: ability.actions.ready()
+                }
+            }
+        });
+    }
+}
+
+HotBunk.id = 'hot-bunk';
+
+module.exports = HotBunk;

--- a/server/game/cards/14-DM/KrisperRuld.js
+++ b/server/game/cards/14-DM/KrisperRuld.js
@@ -5,7 +5,6 @@ class KrisperRuld extends Card {
     setupCardAbilities(ability) {
         this.fight({
             target: {
-                activePromptTitle: 'Choose an enemy artifact',
                 cardType: 'artifact',
                 controller: 'opponent',
                 gameAction: ability.actions.cardLastingEffect((context) => ({

--- a/server/game/cards/14-DM/KrisperRuld.js
+++ b/server/game/cards/14-DM/KrisperRuld.js
@@ -1,0 +1,23 @@
+const Card = require('../../Card.js');
+
+class KrisperRuld extends Card {
+    // After Fight: Take control of an enemy artifact.
+    setupCardAbilities(ability) {
+        this.fight({
+            target: {
+                activePromptTitle: 'Choose an enemy artifact',
+                cardType: 'artifact',
+                controller: 'opponent',
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'lastingEffect',
+                    effect: ability.effects.takeControl(context.player)
+                }))
+            },
+            effect: 'take control of {0}'
+        });
+    }
+}
+
+KrisperRuld.id = 'krisper-ruld';
+
+module.exports = KrisperRuld;

--- a/server/game/cards/14-DM/NadaTax.js
+++ b/server/game/cards/14-DM/NadaTax.js
@@ -11,7 +11,7 @@ class NadaTax extends Card {
                 condition: (context) =>
                     context.preThenEvent.cards.length > 0 &&
                     context.preThenEvent.cards[0].bonusIcons.length > 0,
-                message: '{0} uses {1} to make {2} lose {3} amber',
+                message: '{0} uses {1} to make {3} lose {4} amber',
                 messageArgs: (context) => [
                     context.player.opponent,
                     context.preThenEvent.cards[0].bonusIcons.length

--- a/server/game/cards/14-DM/NadaTax.js
+++ b/server/game/cards/14-DM/NadaTax.js
@@ -1,0 +1,33 @@
+const Card = require('../../Card.js');
+
+class NadaTax extends Card {
+    // Play: Your opponent discards a random card from their hand. For each
+    // bonus icon on the discarded card, they lose 1A.
+    setupCardAbilities(ability) {
+        this.play({
+            condition: (context) => !!context.player.opponent,
+            gameAction: ability.actions.discardAtRandom(),
+            then: {
+                condition: (context) =>
+                    context.preThenEvent.cards.length > 0 &&
+                    context.preThenEvent.cards[0].bonusIcons.length > 0,
+                message: '{0} uses {1} to make {2} lose {3} amber',
+                messageArgs: (context) => [
+                    context.player.opponent,
+                    context.preThenEvent.cards[0].bonusIcons.length
+                ],
+                gameAction: ability.actions.loseAmber((context) => ({
+                    target: context.player.opponent,
+                    amount:
+                        context.preThenEvent.cards.length > 0
+                            ? context.preThenEvent.cards[0].bonusIcons.length
+                            : 0
+                }))
+            }
+        });
+    }
+}
+
+NadaTax.id = 'nada-tax';
+
+module.exports = NadaTax;

--- a/server/game/cards/14-DM/NowAndLater.js
+++ b/server/game/cards/14-DM/NowAndLater.js
@@ -1,0 +1,46 @@
+const Card = require('../../Card.js');
+
+class NowAndLater extends Card {
+    // Play: Return a creature to its owner's hand and archive a card. If you
+    // are overwhelmed, repeat the preceding effect.
+    setupCardAbilities(ability) {
+        this.play({
+            target: {
+                activePromptTitle: "Choose a creature to return to its owner's hand",
+                cardType: 'creature',
+                gameAction: ability.actions.returnToHand()
+            },
+            then: {
+                alwaysTriggers: true,
+                target: {
+                    activePromptTitle: 'Choose a card to archive',
+                    location: 'hand',
+                    controller: 'self',
+                    gameAction: ability.actions.archive()
+                },
+                then: {
+                    alwaysTriggers: true,
+                    condition: (context) => context.player.isOverwhelmed(),
+                    target: {
+                        activePromptTitle: "Choose a creature to return to its owner's hand",
+                        cardType: 'creature',
+                        gameAction: ability.actions.returnToHand()
+                    },
+                    then: {
+                        alwaysTriggers: true,
+                        target: {
+                            activePromptTitle: 'Choose a card to archive',
+                            location: 'hand',
+                            controller: 'self',
+                            gameAction: ability.actions.archive()
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+NowAndLater.id = 'now-and-later';
+
+module.exports = NowAndLater;

--- a/server/game/cards/14-DM/NowAndLater.js
+++ b/server/game/cards/14-DM/NowAndLater.js
@@ -6,7 +6,6 @@ class NowAndLater extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
-                activePromptTitle: "Choose a creature to return to its owner's hand",
                 cardType: 'creature',
                 gameAction: ability.actions.returnToHand()
             },
@@ -22,7 +21,6 @@ class NowAndLater extends Card {
                     alwaysTriggers: true,
                     condition: (context) => context.player.isOverwhelmed(),
                     target: {
-                        activePromptTitle: "Choose a creature to return to its owner's hand",
                         cardType: 'creature',
                         gameAction: ability.actions.returnToHand()
                     },

--- a/server/game/cards/14-DM/NowAndLater.js
+++ b/server/game/cards/14-DM/NowAndLater.js
@@ -9,6 +9,8 @@ class NowAndLater extends Card {
                 cardType: 'creature',
                 gameAction: ability.actions.returnToHand()
             },
+            message: "{0} uses {1} to return {2} to its owner's hand",
+            messageArgs: (context) => [context.player, context.source, context.target || 'nothing'],
             then: {
                 alwaysTriggers: true,
                 target: {
@@ -17,6 +19,7 @@ class NowAndLater extends Card {
                     controller: 'self',
                     gameAction: ability.actions.archive()
                 },
+                message: '{0} uses {1} to archive a card',
                 then: {
                     alwaysTriggers: true,
                     condition: (context) => context.player.isOverwhelmed(),
@@ -24,6 +27,8 @@ class NowAndLater extends Card {
                         cardType: 'creature',
                         gameAction: ability.actions.returnToHand()
                     },
+                    message: "{0} uses {1} to return {2} to its owner's hand",
+                    messageArgs: (context) => [context.target || 'nothing'],
                     then: {
                         alwaysTriggers: true,
                         target: {
@@ -31,7 +36,8 @@ class NowAndLater extends Card {
                             location: 'hand',
                             controller: 'self',
                             gameAction: ability.actions.archive()
-                        }
+                        },
+                        message: '{0} uses {1} to archive a card'
                     }
                 }
             }

--- a/server/game/cards/14-DM/OoniLars.js
+++ b/server/game/cards/14-DM/OoniLars.js
@@ -22,6 +22,6 @@ class OoniLars extends Card {
     }
 }
 
-OoniLars.id = 'ooni-lars';
+OoniLars.id = 'oŏni-lars';
 
 module.exports = OoniLars;

--- a/server/game/cards/14-DM/OoniLars.js
+++ b/server/game/cards/14-DM/OoniLars.js
@@ -15,7 +15,7 @@ class OoniLars extends Card {
                     targetController: 'opponent',
                     effect: ability.effects.modifyKeyCost(4)
                 }),
-                message: "{0} uses {1} to increase {2}'s key cost by 4 during their next turn",
+                message: "{0} uses {1} to increase {3}'s key cost by 4 during their next turn",
                 messageArgs: (context) => [context.player.opponent]
             }
         });

--- a/server/game/cards/14-DM/OoniLars.js
+++ b/server/game/cards/14-DM/OoniLars.js
@@ -1,0 +1,27 @@
+const Card = require('../../Card.js');
+
+class OoniLars extends Card {
+    // After Reap: You may pay your opponent 1A. If you do, your opponent's
+    // keys cost +4 during their next turn.
+    setupCardAbilities(ability) {
+        this.reap({
+            optional: true,
+            gameAction: ability.actions.transferAmber((context) => ({
+                target: context.player,
+                amount: 1
+            })),
+            then: {
+                gameAction: ability.actions.duringOpponentNextTurn({
+                    targetController: 'opponent',
+                    effect: ability.effects.modifyKeyCost(4)
+                }),
+                message: "{0} uses {1} to increase {2}'s key cost by 4 during their next turn",
+                messageArgs: (context) => [context.player.opponent]
+            }
+        });
+    }
+}
+
+OoniLars.id = 'ooni-lars';
+
+module.exports = OoniLars;

--- a/server/game/cards/14-DM/TheGoldenQueen.js
+++ b/server/game/cards/14-DM/TheGoldenQueen.js
@@ -18,22 +18,41 @@ class TheGoldenQueen extends GiganticCard {
             effect: ability.effects.modifyHandSize(1)
         });
 
+        const playerDiscard = (context) =>
+            ability.actions.discardAtRandom({ target: context.player });
+        const opponentDiscard = (context) =>
+            ability.actions.discardAtRandom({ target: context.player.opponent });
+
         this.fight({
             reap: true,
-            gameAction: ability.actions.discardAtRandom((context) => ({
-                target: [context.player, context.player.opponent].filter((p) => !!p)
-            })),
-            then: (preThenContext) => {
-                const cards = (preThenContext.preThenEvents || []).reduce(
-                    (acc, e) => acc.concat(e.cards || []),
-                    []
-                );
-                const nonEkwidon = cards.filter((c) => !c.hasHouse('ekwidon')).length;
+            gameAction: ability.actions.chooseAction((context) => {
+                if (!context.player.opponent) {
+                    return { choices: { Me: [playerDiscard(context)] } };
+                }
+                if (!context.player.optionSettings.orderForcedAbilities) {
+                    return {
+                        choices: { Me: [playerDiscard(context), opponentDiscard(context)] }
+                    };
+                }
                 return {
-                    alwaysTriggers: true,
-                    gameAction: ability.actions.gainAmber({ amount: nonEkwidon })
+                    activePromptTitle: 'Choose which player discards first',
+                    choices: {
+                        Me: [playerDiscard(context), opponentDiscard(context)],
+                        Opponent: [opponentDiscard(context), playerDiscard(context)]
+                    }
                 };
-            }
+            }),
+            then: () => ({
+                alwaysTriggers: true,
+                gameAction: ability.actions.gainAmber((context) => {
+                    const cards = (context.preThenEvents || []).reduce(
+                        (acc, e) => acc.concat(e.cards || []),
+                        []
+                    );
+                    const nonEkwidon = cards.filter((c) => !c.hasHouse('ekwidon')).length;
+                    return { amount: nonEkwidon };
+                })
+            })
         });
     }
 }

--- a/server/game/cards/14-DM/TheGoldenQueen.js
+++ b/server/game/cards/14-DM/TheGoldenQueen.js
@@ -1,0 +1,43 @@
+const GiganticCard = require('../../GiganticCard.js');
+
+class TheGoldenQueen extends GiganticCard {
+    // (Play only with the other half of The Golden Queen.)
+    // Each player refills their hand to 1 additional card during their
+    // "draw cards" step.
+    // After Fight/After Reap: Each player discards a random card from their
+    // hand. For each non-Ekwidon card discarded this way, gain 1A.
+    constructor(owner, cardData) {
+        super(owner, cardData);
+    }
+
+    setupCardAbilities(ability) {
+        super.setupCardAbilities(ability);
+
+        this.persistentEffect({
+            targetController: 'any',
+            effect: ability.effects.modifyHandSize(1)
+        });
+
+        this.fight({
+            reap: true,
+            gameAction: ability.actions.discardAtRandom((context) => ({
+                target: [context.player, context.player.opponent].filter((p) => !!p)
+            })),
+            then: (preThenContext) => {
+                const cards = (preThenContext.preThenEvents || []).reduce(
+                    (acc, e) => acc.concat(e.cards || []),
+                    []
+                );
+                const nonEkwidon = cards.filter((c) => !c.hasHouse('ekwidon')).length;
+                return {
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.gainAmber({ amount: nonEkwidon })
+                };
+            }
+        });
+    }
+}
+
+TheGoldenQueen.id = 'the-golden-queen';
+
+module.exports = TheGoldenQueen;

--- a/server/game/cards/14-DM/TheGoldenQueen2.js
+++ b/server/game/cards/14-DM/TheGoldenQueen2.js
@@ -1,13 +1,8 @@
 const GiganticCard = require('../../GiganticCard.js');
 
 class TheGoldenQueen2 extends GiganticCard {
-    // (Play only with the other half of The Golden Queen.) Top half - art only.
     constructor(owner, cardData) {
         super(owner, cardData);
-    }
-
-    setupCardAbilities(ability) {
-        super.setupCardAbilities(ability);
     }
 }
 

--- a/server/game/cards/14-DM/TheGoldenQueen2.js
+++ b/server/game/cards/14-DM/TheGoldenQueen2.js
@@ -1,0 +1,16 @@
+const GiganticCard = require('../../GiganticCard.js');
+
+class TheGoldenQueen2 extends GiganticCard {
+    // (Play only with the other half of The Golden Queen.) Top half - art only.
+    constructor(owner, cardData) {
+        super(owner, cardData);
+    }
+
+    setupCardAbilities(ability) {
+        super.setupCardAbilities(ability);
+    }
+}
+
+TheGoldenQueen2.id = 'the-golden-queen2';
+
+module.exports = TheGoldenQueen2;

--- a/server/game/cards/14-DM/VastStoik.js
+++ b/server/game/cards/14-DM/VastStoik.js
@@ -9,13 +9,14 @@ class VastStoik extends Card {
             target: {
                 activePromptTitle: 'Choose a creature',
                 cardType: 'creature',
-                gameAction: ability.actions.conditional((context) => ({
-                    condition: context.target && context.target.hasToken('amber'),
-                    trueGameAction: ability.actions.sequential([
-                        ability.actions.removeAmber({ target: context.target }),
-                        ability.actions.draw({ target: context.player })
-                    ])
-                }))
+                gameAction: ability.actions.removeAmber()
+            },
+            then: {
+                condition: (context) =>
+                    !!context.preThenEvent &&
+                    !context.preThenEvent.cancelled &&
+                    context.preThenEvent.amount > 0,
+                gameAction: ability.actions.draw()
             }
         });
     }

--- a/server/game/cards/14-DM/VastStoik.js
+++ b/server/game/cards/14-DM/VastStoik.js
@@ -1,0 +1,26 @@
+const Card = require('../../Card.js');
+
+class VastStoik extends Card {
+    // Taunt.
+    // After Fight: Move 1A from a creature to the common supply. If you do,
+    // draw a card.
+    setupCardAbilities(ability) {
+        this.fight({
+            target: {
+                activePromptTitle: 'Choose a creature',
+                cardType: 'creature',
+                gameAction: ability.actions.conditional((context) => ({
+                    condition: context.target && context.target.hasToken('amber'),
+                    trueGameAction: ability.actions.sequential([
+                        ability.actions.removeAmber({ target: context.target }),
+                        ability.actions.draw({ target: context.player })
+                    ])
+                }))
+            }
+        });
+    }
+}
+
+VastStoik.id = 'vast-stoik';
+
+module.exports = VastStoik;

--- a/server/game/cards/14-DM/VastStoik.js
+++ b/server/game/cards/14-DM/VastStoik.js
@@ -21,6 +21,6 @@ class VastStoik extends Card {
     }
 }
 
-VastStoik.id = 'vast-stoik';
+VastStoik.id = 'văst-stŏik';
 
 module.exports = VastStoik;

--- a/server/game/cards/14-DM/Waspscream.js
+++ b/server/game/cards/14-DM/Waspscream.js
@@ -1,0 +1,28 @@
+const Card = require('../../Card.js');
+
+class Waspscream extends Card {
+    // Entrench. Poison.
+    // At the start of your turn, if Waspscream is exhausted, take control of
+    // an enemy creature.
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onTurnStart: (event, context) =>
+                    event.player === context.player && context.source.exhausted
+            },
+            target: {
+                cardType: 'creature',
+                controller: 'opponent',
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'lastingEffect',
+                    effect: ability.effects.takeControl(context.player)
+                }))
+            },
+            effect: 'take control of {0}'
+        });
+    }
+}
+
+Waspscream.id = 'waspscream';
+
+module.exports = Waspscream;

--- a/test/server/cards/14-DM/AuthorizedRequisitions.spec.js
+++ b/test/server/cards/14-DM/AuthorizedRequisitions.spec.js
@@ -9,7 +9,8 @@ describe('AuthorizedRequisitions', function () {
                     deck: ['mack-the-knife', 'troll']
                 },
                 player2: {
-                    amber: 3
+                    amber: 3,
+                    inPlay: ['troll']
                 }
             });
         });
@@ -17,6 +18,8 @@ describe('AuthorizedRequisitions', function () {
         it('captures 2 amber on a friendly creature and draws a card', function () {
             const handSizeBefore = this.player1.hand.length;
             this.player1.play(this.authorizedRequisitions);
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            expect(this.player1).not.toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.exeldonYash);
             expect(this.exeldonYash.amber).toBe(2);
             expect(this.player2.amber).toBe(1);

--- a/test/server/cards/14-DM/AuthorizedRequisitions.spec.js
+++ b/test/server/cards/14-DM/AuthorizedRequisitions.spec.js
@@ -1,0 +1,46 @@
+describe('AuthorizedRequisitions', function () {
+    describe("Authorized Requisitions's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['authorized-requisitions'],
+                    inPlay: ['exeldon-yash'],
+                    deck: ['mack-the-knife', 'troll']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('captures 2 amber on a friendly creature and draws a card', function () {
+            const handSizeBefore = this.player1.hand.length;
+            this.player1.play(this.authorizedRequisitions);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.player2.amber).toBe(1);
+            expect(this.player1.hand.length).toBe(handSizeBefore);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('still draws when opponent has no amber', function () {
+            this.player2.amber = 0;
+            const handSizeBefore = this.player1.hand.length;
+            this.player1.play(this.authorizedRequisitions);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1.hand.length).toBe(handSizeBefore);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('still draws when there are no friendly creatures to capture onto', function () {
+            this.player1.moveCard(this.exeldonYash, 'discard');
+            const handSizeBefore = this.player1.hand.length;
+            this.player1.play(this.authorizedRequisitions);
+            expect(this.player2.amber).toBe(3);
+            expect(this.player1.hand.length).toBe(handSizeBefore);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/BleaForh.spec.js
+++ b/test/server/cards/14-DM/BleaForh.spec.js
@@ -4,7 +4,7 @@ describe('BleaForh', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    inPlay: ['blea-forh', 'exeldon-yash', 'troll']
+                    inPlay: ['bleă-fŏrh', 'exeldon-yash', 'troll']
                 },
                 player2: {
                     inPlay: ['urchin']
@@ -13,7 +13,7 @@ describe('BleaForh', function () {
         });
 
         it('can target an undamaged creature and auto-resolves with no exalt', function () {
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             expect(this.player1).toBeAbleToSelect(this.exeldonYash);
             this.player1.clickCard(this.exeldonYash);
             expect(this.exeldonYash.damage).toBe(0);
@@ -23,7 +23,7 @@ describe('BleaForh', function () {
 
         it('heals 1 damage and exalts once', function () {
             this.exeldonYash.damage = 1;
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -36,7 +36,7 @@ describe('BleaForh', function () {
 
         it('heals 2 damage and exalts twice', function () {
             this.exeldonYash.damage = 2;
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -50,7 +50,7 @@ describe('BleaForh', function () {
 
         it('can heal 0 from a damaged creature', function () {
             this.exeldonYash.damage = 2;
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -64,7 +64,7 @@ describe('BleaForh', function () {
 
         it('can heal 1 from a creature with 3 damage and exalt once', function () {
             this.troll.damage = 3;
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             this.player1.clickCard(this.troll);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -78,7 +78,7 @@ describe('BleaForh', function () {
 
         it('can heal 2 from a creature with 3 damage and exalt twice', function () {
             this.troll.damage = 3;
-            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.fightWith(this.bleăFŏrh, this.urchin);
             this.player1.clickCard(this.troll);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');

--- a/test/server/cards/14-DM/BleaForh.spec.js
+++ b/test/server/cards/14-DM/BleaForh.spec.js
@@ -7,15 +7,36 @@ describe('BleaForh', function () {
                     inPlay: ['blea-forh', 'exeldon-yash', 'troll']
                 },
                 player2: {
-                    inPlay: ['flaxia']
+                    inPlay: ['urchin']
                 }
             });
         });
 
+        it('can target an undamaged creature and auto-resolves with no exalt', function () {
+            this.player1.fightWith(this.bleaForh, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.damage).toBe(0);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('heals 1 damage and exalts once', function () {
+            this.exeldonYash.damage = 1;
+            this.player1.fightWith(this.bleaForh, this.urchin);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).not.toHavePromptButton('2');
+            this.player1.clickPrompt('1');
+            expect(this.exeldonYash.damage).toBe(0);
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
         it('heals 2 damage and exalts twice', function () {
             this.exeldonYash.damage = 2;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
-            expect(this.player1).toHavePrompt('Choose a creature to heal');
+            this.player1.fightWith(this.bleaForh, this.urchin);
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -27,54 +48,9 @@ describe('BleaForh', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('heals 1 damage and exalts once', function () {
-            this.exeldonYash.damage = 1;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
-            this.player1.clickCard(this.exeldonYash);
-            expect(this.player1).toHavePromptButton('0');
-            expect(this.player1).toHavePromptButton('1');
-            expect(this.player1).not.toHavePromptButton('2');
-            this.player1.clickPrompt('1');
-            expect(this.exeldonYash.damage).toBe(0);
-            expect(this.exeldonYash.amber).toBe(1);
-            expect(this.player1).isReadyToTakeAction();
-        });
-
-        it('does not exalt when there is no damage to heal', function () {
-            this.player1.fightWith(this.bleaForh, this.flaxia);
-            this.player1.clickCard(this.exeldonYash);
-            expect(this.exeldonYash.amber).toBe(0);
-            expect(this.player1).isReadyToTakeAction();
-        });
-
-        it('can target an undamaged creature and auto-resolves with no exalt', function () {
-            this.player1.fightWith(this.bleaForh, this.flaxia);
-            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
-            expect(this.player1).not.toHavePromptButton('1');
-            expect(this.player1).not.toHavePromptButton('2');
-            expect(this.player1).not.toHavePromptButton('3');
-            this.player1.clickCard(this.exeldonYash);
-            expect(this.exeldonYash.damage).toBe(0);
-            expect(this.exeldonYash.amber).toBe(0);
-            expect(this.player1).isReadyToTakeAction();
-        });
-
-        it('only offers 0 and 1 when the creature has 1 damage', function () {
-            this.exeldonYash.damage = 1;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
-            this.player1.clickCard(this.exeldonYash);
-            expect(this.player1).toHavePromptButton('0');
-            expect(this.player1).toHavePromptButton('1');
-            expect(this.player1).not.toHavePromptButton('2');
-            this.player1.clickPrompt('0');
-            expect(this.exeldonYash.damage).toBe(1);
-            expect(this.exeldonYash.amber).toBe(0);
-            expect(this.player1).isReadyToTakeAction();
-        });
-
         it('can heal 0 from a damaged creature', function () {
             this.exeldonYash.damage = 2;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.fightWith(this.bleaForh, this.urchin);
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
@@ -88,11 +64,12 @@ describe('BleaForh', function () {
 
         it('can heal 1 from a creature with 3 damage and exalt once', function () {
             this.troll.damage = 3;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.fightWith(this.bleaForh, this.urchin);
             this.player1.clickCard(this.troll);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');
             expect(this.player1).toHavePromptButton('2');
+            expect(this.player1).not.toHavePromptButton('3');
             this.player1.clickPrompt('1');
             expect(this.troll.damage).toBe(2);
             expect(this.troll.amber).toBe(1);
@@ -101,7 +78,7 @@ describe('BleaForh', function () {
 
         it('can heal 2 from a creature with 3 damage and exalt twice', function () {
             this.troll.damage = 3;
-            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.fightWith(this.bleaForh, this.urchin);
             this.player1.clickCard(this.troll);
             expect(this.player1).toHavePromptButton('0');
             expect(this.player1).toHavePromptButton('1');

--- a/test/server/cards/14-DM/BleaForh.spec.js
+++ b/test/server/cards/14-DM/BleaForh.spec.js
@@ -1,0 +1,116 @@
+describe('BleaForh', function () {
+    describe("Blea-Forh's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['blea-forh', 'exeldon-yash', 'troll']
+                },
+                player2: {
+                    inPlay: ['flaxia']
+                }
+            });
+        });
+
+        it('heals 2 damage and exalts twice', function () {
+            this.exeldonYash.damage = 2;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            expect(this.player1).toHavePrompt('Choose a creature to heal');
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).toHavePromptButton('2');
+            expect(this.player1).not.toHavePromptButton('3');
+            this.player1.clickPrompt('2');
+            expect(this.exeldonYash.damage).toBe(0);
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('heals 1 damage and exalts once', function () {
+            this.exeldonYash.damage = 1;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).not.toHavePromptButton('2');
+            this.player1.clickPrompt('1');
+            expect(this.exeldonYash.damage).toBe(0);
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not exalt when there is no damage to heal', function () {
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can target an undamaged creature and auto-resolves with no exalt', function () {
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            expect(this.player1).not.toHavePromptButton('1');
+            expect(this.player1).not.toHavePromptButton('2');
+            expect(this.player1).not.toHavePromptButton('3');
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.damage).toBe(0);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('only offers 0 and 1 when the creature has 1 damage', function () {
+            this.exeldonYash.damage = 1;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).not.toHavePromptButton('2');
+            this.player1.clickPrompt('0');
+            expect(this.exeldonYash.damage).toBe(1);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can heal 0 from a damaged creature', function () {
+            this.exeldonYash.damage = 2;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).toHavePromptButton('2');
+            expect(this.player1).not.toHavePromptButton('3');
+            this.player1.clickPrompt('0');
+            expect(this.exeldonYash.damage).toBe(2);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can heal 1 from a creature with 3 damage and exalt once', function () {
+            this.troll.damage = 3;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.troll);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).toHavePromptButton('2');
+            this.player1.clickPrompt('1');
+            expect(this.troll.damage).toBe(2);
+            expect(this.troll.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can heal 2 from a creature with 3 damage and exalt twice', function () {
+            this.troll.damage = 3;
+            this.player1.fightWith(this.bleaForh, this.flaxia);
+            this.player1.clickCard(this.troll);
+            expect(this.player1).toHavePromptButton('0');
+            expect(this.player1).toHavePromptButton('1');
+            expect(this.player1).toHavePromptButton('2');
+            expect(this.player1).not.toHavePromptButton('3');
+            this.player1.clickPrompt('2');
+            expect(this.troll.damage).toBe(1);
+            expect(this.troll.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/BypassBurglar.spec.js
+++ b/test/server/cards/14-DM/BypassBurglar.spec.js
@@ -15,7 +15,7 @@ describe('BypassBurglar', function () {
         it('grants steal/self-damage action to neighbors when exhausted', function () {
             this.player1.reap(this.bypassBurglar);
             this.player1.useAction(this.exeldonYash);
-            expect(this.player1.amber).toBe(2); // 1 reap + 1 stolen
+            expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(2);
             expect(this.exeldonYash.damage).toBe(1);
             expect(this.player1).isReadyToTakeAction();
@@ -24,14 +24,13 @@ describe('BypassBurglar', function () {
         it('right neighbor also gains the action', function () {
             this.player1.reap(this.bypassBurglar);
             this.player1.useAction(this.krisperRuld);
-            expect(this.player1.amber).toBe(2); // 1 reap + 1 stolen
-            // Krisper Ruld has 1 armor, absorbs the 1 damage
+            expect(this.player1.amber).toBe(2);
             expect(this.krisperRuld.damage).toBe(0);
+            expect(this.krisperRuld.armor).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
         it('does not grant the action when ready', function () {
-            // Bypass Burglar is ready by default
             this.player1.clickCard(this.exeldonYash);
             expect(this.player1).not.toHavePromptButton("Use this card's Action ability");
             this.player1.clickPrompt('Cancel');

--- a/test/server/cards/14-DM/BypassBurglar.spec.js
+++ b/test/server/cards/14-DM/BypassBurglar.spec.js
@@ -1,0 +1,41 @@
+describe('BypassBurglar', function () {
+    describe("Bypass Burglar's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['exeldon-yash', 'bypass-burglar', 'krisper-ruld']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('grants steal/self-damage action to neighbors when exhausted', function () {
+            this.player1.reap(this.bypassBurglar);
+            this.player1.useAction(this.exeldonYash);
+            expect(this.player1.amber).toBe(2); // 1 reap + 1 stolen
+            expect(this.player2.amber).toBe(2);
+            expect(this.exeldonYash.damage).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('right neighbor also gains the action', function () {
+            this.player1.reap(this.bypassBurglar);
+            this.player1.useAction(this.krisperRuld);
+            expect(this.player1.amber).toBe(2); // 1 reap + 1 stolen
+            // Krisper Ruld has 1 armor, absorbs the 1 damage
+            expect(this.krisperRuld.damage).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not grant the action when ready', function () {
+            // Bypass Burglar is ready by default
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.player1).not.toHavePromptButton("Use this card's Action ability");
+            this.player1.clickPrompt('Cancel');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ChromaticGuardian.spec.js
+++ b/test/server/cards/14-DM/ChromaticGuardian.spec.js
@@ -1,0 +1,48 @@
+describe('ChromaticGuardian', function () {
+    describe("Chromatic Guardian's ability", function () {
+        it('destroys an enemy creature when overwhelmed', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['chromatic-guardian', 'city-gates']
+                },
+                player2: {
+                    inPlay: ['troll', 'flaxia', 'mack-the-knife', 'gauntlet-of-command']
+                }
+            });
+            this.player1.reap(this.chromaticGuardian);
+            expect(this.player1).toBeAbleToSelect(this.troll);
+            expect(this.player1).toBeAbleToSelect(this.flaxia);
+            expect(this.player1).toBeAbleToSelect(this.mackTheKnife);
+            expect(this.player1).not.toBeAbleToSelect(this.gauntletOfCommand); // enemy artifact
+            expect(this.player1).not.toBeAbleToSelect(this.chromaticGuardian); // friendly creature
+            expect(this.player1).not.toBeAbleToSelect(this.cityGates); // friendly artifact
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.gauntletOfCommand.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('destroys an enemy artifact when not overwhelmed', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['chromatic-guardian', 'urchin', 'golden-dagger', 'city-gates']
+                },
+                player2: {
+                    inPlay: ['troll', 'gauntlet-of-command', 'hallowed-shield']
+                }
+            });
+            this.player1.reap(this.chromaticGuardian);
+            expect(this.player1).toBeAbleToSelect(this.gauntletOfCommand);
+            expect(this.player1).toBeAbleToSelect(this.hallowedShield);
+            expect(this.player1).not.toBeAbleToSelect(this.troll); // enemy creature
+            expect(this.player1).not.toBeAbleToSelect(this.urchin); // friendly creature
+            expect(this.player1).not.toBeAbleToSelect(this.cityGates); // friendly artifact
+            this.player1.clickCard(this.gauntletOfCommand);
+            expect(this.gauntletOfCommand.location).toBe('discard');
+            expect(this.troll.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ChromaticGuardian.spec.js
+++ b/test/server/cards/14-DM/ChromaticGuardian.spec.js
@@ -11,14 +11,16 @@ describe('ChromaticGuardian', function () {
                 }
             });
             this.player1.reap(this.chromaticGuardian);
+            expect(this.player1).not.toBeAbleToSelect(this.chromaticGuardian);
+            expect(this.player1).not.toBeAbleToSelect(this.cityGates);
             expect(this.player1).toBeAbleToSelect(this.troll);
             expect(this.player1).toBeAbleToSelect(this.flaxia);
             expect(this.player1).toBeAbleToSelect(this.mackTheKnife);
-            expect(this.player1).not.toBeAbleToSelect(this.gauntletOfCommand); // enemy artifact
-            expect(this.player1).not.toBeAbleToSelect(this.chromaticGuardian); // friendly creature
-            expect(this.player1).not.toBeAbleToSelect(this.cityGates); // friendly artifact
+            expect(this.player1).not.toBeAbleToSelect(this.gauntletOfCommand);
             this.player1.clickCard(this.troll);
             expect(this.troll.location).toBe('discard');
+            expect(this.flaxia.location).toBe('play area');
+            expect(this.mackTheKnife.location).toBe('play area');
             expect(this.gauntletOfCommand.location).toBe('play area');
             expect(this.player1).isReadyToTakeAction();
         });
@@ -27,21 +29,22 @@ describe('ChromaticGuardian', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    inPlay: ['chromatic-guardian', 'urchin', 'golden-dagger', 'city-gates']
+                    inPlay: ['chromatic-guardian', 'city-gates']
                 },
                 player2: {
                     inPlay: ['troll', 'gauntlet-of-command', 'hallowed-shield']
                 }
             });
             this.player1.reap(this.chromaticGuardian);
+            expect(this.player1).not.toBeAbleToSelect(this.chromaticGuardian);
+            expect(this.player1).not.toBeAbleToSelect(this.cityGates);
+            expect(this.player1).not.toBeAbleToSelect(this.troll);
             expect(this.player1).toBeAbleToSelect(this.gauntletOfCommand);
             expect(this.player1).toBeAbleToSelect(this.hallowedShield);
-            expect(this.player1).not.toBeAbleToSelect(this.troll); // enemy creature
-            expect(this.player1).not.toBeAbleToSelect(this.urchin); // friendly creature
-            expect(this.player1).not.toBeAbleToSelect(this.cityGates); // friendly artifact
             this.player1.clickCard(this.gauntletOfCommand);
-            expect(this.gauntletOfCommand.location).toBe('discard');
             expect(this.troll.location).toBe('play area');
+            expect(this.gauntletOfCommand.location).toBe('discard');
+            expect(this.hallowedShield.location).toBe('play area');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/ConradFisique.spec.js
+++ b/test/server/cards/14-DM/ConradFisique.spec.js
@@ -4,7 +4,7 @@ describe('ConradFisique', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    hand: ['conrad-fisique'],
+                    hand: ['cŏnrăd-fisiquĕ'],
                     inPlay: ['exeldon-yash']
                 },
                 player2: {
@@ -15,8 +15,8 @@ describe('ConradFisique', function () {
         });
 
         it('moves all +1 power counters from one creature to another', function () {
-            this.player1.play(this.conradFisique);
-            this.player1.clickCard(this.conradFisique);
+            this.player1.play(this.cŏnrădFisiquĕ);
+            this.player1.clickCard(this.cŏnrădFisiquĕ);
             this.player1.clickCard(this.exeldonYash);
             this.player1.clickCard(this.troll);
             expect(this.exeldonYash.powerCounters).toBe(0);
@@ -25,7 +25,7 @@ describe('ConradFisique', function () {
         });
 
         it('skips effect if player declines', function () {
-            this.player1.play(this.conradFisique);
+            this.player1.play(this.cŏnrădFisiquĕ);
             this.player1.clickPrompt('Done');
             expect(this.exeldonYash.powerCounters).toBe(2);
             expect(this.troll.powerCounters).toBe(0);
@@ -38,7 +38,7 @@ describe('ConradFisique', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    hand: ['conrad-fisique'],
+                    hand: ['cŏnrăd-fisiquĕ'],
                     inPlay: ['exeldon-yash', 'urchin', 'phoenix-heart']
                 },
                 player2: {}
@@ -52,8 +52,8 @@ describe('ConradFisique', function () {
         });
 
         it('moves counters simultaneously so destination survives Phoenix Heart damage', function () {
-            this.player1.play(this.conradFisique);
-            this.player1.clickCard(this.conradFisique);
+            this.player1.play(this.cŏnrădFisiquĕ);
+            this.player1.clickCard(this.cŏnrădFisiquĕ);
             this.player1.clickCard(this.exeldonYash);
             this.player1.clickCard(this.urchin);
             // Exeldon Yash is destroyed by losing its power counters; Phoenix Heart

--- a/test/server/cards/14-DM/ConradFisique.spec.js
+++ b/test/server/cards/14-DM/ConradFisique.spec.js
@@ -1,0 +1,35 @@
+describe('ConradFisique', function () {
+    describe("Conrad Fisique's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['conrad-fisique'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.exeldonYash.powerCounters = 2;
+        });
+
+        it('moves all +1 power counters from one creature to another', function () {
+            this.player1.play(this.conradFisique);
+            this.player1.clickCard(this.conradFisique);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickCard(this.troll);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.troll.powerCounters).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('skips effect if player declines', function () {
+            this.player1.play(this.conradFisique);
+            this.player1.clickPrompt('Done');
+            expect(this.exeldonYash.powerCounters).toBe(2);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ConradFisique.spec.js
+++ b/test/server/cards/14-DM/ConradFisique.spec.js
@@ -31,6 +31,19 @@ describe('ConradFisique', function () {
             expect(this.troll.powerCounters).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
+
+        it('can select a creature with no power counters as the source', function () {
+            this.exeldonYash.powerCounters = 0;
+            this.player1.play(this.cŏnrădFisiquĕ);
+            this.player1.clickCard(this.cŏnrădFisiquĕ);
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            expect(this.player1).toBeAbleToSelect(this.troll);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickCard(this.troll);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.troll.powerCounters).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
     });
 
     describe("Conrad Fisique's simultaneous power counter movement", function () {

--- a/test/server/cards/14-DM/ConradFisique.spec.js
+++ b/test/server/cards/14-DM/ConradFisique.spec.js
@@ -32,4 +32,38 @@ describe('ConradFisique', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe("Conrad Fisique's simultaneous power counter movement", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['conrad-fisique'],
+                    inPlay: ['exeldon-yash', 'urchin', 'phoenix-heart']
+                },
+                player2: {}
+            });
+            // Manually attach Phoenix Heart to Exeldon Yash
+            this.exeldonYash.upgrades.push(this.phoenixHeart);
+            this.phoenixHeart.parent = this.exeldonYash;
+            this.game.checkGameState(true);
+            this.exeldonYash.powerCounters = 3;
+            this.exeldonYash.damage = 5;
+        });
+
+        it('moves counters simultaneously so destination survives Phoenix Heart damage', function () {
+            this.player1.play(this.conradFisique);
+            this.player1.clickCard(this.conradFisique);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickCard(this.urchin);
+            // Exeldon Yash is destroyed by losing its power counters; Phoenix Heart
+            // returns it to hand and deals 3 damage to all creatures. Because the
+            // counters move to Urchin simultaneously, Urchin has +3 power when the
+            // damage is dealt and survives.
+            expect(this.exeldonYash.location).toBe('hand');
+            expect(this.urchin.location).toBe('play area');
+            expect(this.urchin.powerCounters).toBe(3);
+            expect(this.urchin.damage).toBe(3);
+        });
+    });
 });

--- a/test/server/cards/14-DM/DapperChapeau.spec.js
+++ b/test/server/cards/14-DM/DapperChapeau.spec.js
@@ -17,6 +17,9 @@ describe('DapperChapeau', function () {
         it('returns to hand if damage destroys the target', function () {
             this.player1.clickCard(this.exeldonYash);
             this.player1.clickPrompt("Use this card's Action ability");
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            expect(this.player1).toBeAbleToSelect(this.troll);
+            expect(this.player1).toBeAbleToSelect(this.urchin);
             this.player1.clickCard(this.urchin);
             expect(this.urchin.location).toBe('discard');
             expect(this.dapperChapeau.location).toBe('hand');
@@ -30,6 +33,98 @@ describe('DapperChapeau', function () {
             expect(this.troll.location).toBe('play area');
             expect(this.troll.damage).toBe(4);
             expect(this.troll.upgrades).toContain(this.dapperChapeau);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('returns to hand from discard when it destroys its own host', function () {
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt("Use this card's Action ability");
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.dapperChapeau.location).toBe('hand');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Dapper Chapeau when the host dies but the target survives', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['dapper-chapeau'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    inPlay: ['master-of-2', 'urchin', 'soulkeeper', 'friendship']
+                }
+            });
+            this.player1.playUpgrade(this.dapperChapeau, this.exeldonYash);
+            // Manually attach Soulkeeper to Master of 2 (a low-power neighbor
+            // of Urchin) and Friendship to Urchin (the action target).
+            this.masterOf2.upgrades.push(this.soulkeeper);
+            this.soulkeeper.parent = this.masterOf2;
+            this.urchin.upgrades.push(this.friendship);
+            this.friendship.parent = this.urchin;
+            this.game.checkGameState(true);
+        });
+
+        it('returns Dapper Chapeau to hand when the host dies as collateral', function () {
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt("Use this card's Action ability");
+            // Targeting Urchin (which has Friendship) redirects all 4 damage
+            // to its only neighbor Master of 2, destroying it. Soulkeeper on
+            // Master of 2 then prompts to destroy the most powerful enemy
+            // creature -- Exeldon Yash, the host of Dapper Chapeau.
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.urchin.location).toBe('play area');
+            expect(this.masterOf2.location).toBe('discard');
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.dapperChapeau.location).toBe('hand');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Dapper Chapeau when both the host and the target die', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['dapper-chapeau'],
+                    inPlay: ['exeldon-yash', 'soulkeeper']
+                },
+                player2: {
+                    inPlay: ['master-of-2', 'urchin', 'soulkeeper', 'friendship']
+                }
+            });
+            this.player1.playUpgrade(this.dapperChapeau, this.exeldonYash);
+            const hostSoulkeeper = this.player1.findCardByName('Soulkeeper', 'play area');
+            const enemySoulkeeper = this.player2.findCardByName('Soulkeeper', 'play area');
+            this.exeldonYash.upgrades.push(hostSoulkeeper);
+            hostSoulkeeper.parent = this.exeldonYash;
+            this.masterOf2.upgrades.push(enemySoulkeeper);
+            enemySoulkeeper.parent = this.masterOf2;
+            this.urchin.upgrades.push(this.friendship);
+            this.friendship.parent = this.urchin;
+            this.game.checkGameState(true);
+        });
+
+        it('leaves Dapper Chapeau in the discard pile', function () {
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt("Use this card's Action ability");
+            // Damage to Urchin is redirected by Friendship to Master of 2,
+            // destroying it. The Soulkeeper on Master of 2 then destroys
+            // Exeldon Yash (the host). The Soulkeeper on Exeldon Yash then
+            // destroys Urchin (the target). Urchin's destruction is by
+            // a destroy effect, not by the dealt damage, so Dapper Chapeau
+            // stays in the discard.
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickCard(this.urchin);
+            expect(this.masterOf2.location).toBe('discard');
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.urchin.location).toBe('discard');
+            expect(this.dapperChapeau.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/DapperChapeau.spec.js
+++ b/test/server/cards/14-DM/DapperChapeau.spec.js
@@ -1,0 +1,36 @@
+describe('DapperChapeau', function () {
+    describe("Dapper Chapeau's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['dapper-chapeau'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    inPlay: ['troll', 'urchin']
+                }
+            });
+            this.player1.playUpgrade(this.dapperChapeau, this.exeldonYash);
+        });
+
+        it('returns to hand if damage destroys the target', function () {
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt("Use this card's Action ability");
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.dapperChapeau.location).toBe('hand');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('attaches to the damaged creature when it survives', function () {
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt("Use this card's Action ability");
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('play area');
+            expect(this.troll.damage).toBe(4);
+            expect(this.troll.upgrades).toContain(this.dapperChapeau);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/DapperChapeau.spec.js
+++ b/test/server/cards/14-DM/DapperChapeau.spec.js
@@ -36,94 +36,11 @@ describe('DapperChapeau', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('returns to hand from discard when it destroys its own host', function () {
+        it('stays in discard when it destroys its own host', function () {
             this.player1.clickCard(this.exeldonYash);
             this.player1.clickPrompt("Use this card's Action ability");
             this.player1.clickCard(this.exeldonYash);
             expect(this.exeldonYash.location).toBe('discard');
-            expect(this.dapperChapeau.location).toBe('hand');
-            expect(this.player1).isReadyToTakeAction();
-        });
-    });
-
-    describe('Dapper Chapeau when the host dies but the target survives', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'ekwidon',
-                    hand: ['dapper-chapeau'],
-                    inPlay: ['exeldon-yash']
-                },
-                player2: {
-                    inPlay: ['master-of-2', 'urchin', 'soulkeeper', 'friendship']
-                }
-            });
-            this.player1.playUpgrade(this.dapperChapeau, this.exeldonYash);
-            // Manually attach Soulkeeper to Master of 2 (a low-power neighbor
-            // of Urchin) and Friendship to Urchin (the action target).
-            this.masterOf2.upgrades.push(this.soulkeeper);
-            this.soulkeeper.parent = this.masterOf2;
-            this.urchin.upgrades.push(this.friendship);
-            this.friendship.parent = this.urchin;
-            this.game.checkGameState(true);
-        });
-
-        it('returns Dapper Chapeau to hand when the host dies as collateral', function () {
-            this.player1.clickCard(this.exeldonYash);
-            this.player1.clickPrompt("Use this card's Action ability");
-            // Targeting Urchin (which has Friendship) redirects all 4 damage
-            // to its only neighbor Master of 2, destroying it. Soulkeeper on
-            // Master of 2 then prompts to destroy the most powerful enemy
-            // creature -- Exeldon Yash, the host of Dapper Chapeau.
-            this.player1.clickCard(this.urchin);
-            this.player1.clickCard(this.exeldonYash);
-            expect(this.urchin.location).toBe('play area');
-            expect(this.masterOf2.location).toBe('discard');
-            expect(this.exeldonYash.location).toBe('discard');
-            expect(this.dapperChapeau.location).toBe('hand');
-            expect(this.player1).isReadyToTakeAction();
-        });
-    });
-
-    describe('Dapper Chapeau when both the host and the target die', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'ekwidon',
-                    hand: ['dapper-chapeau'],
-                    inPlay: ['exeldon-yash', 'soulkeeper']
-                },
-                player2: {
-                    inPlay: ['master-of-2', 'urchin', 'soulkeeper', 'friendship']
-                }
-            });
-            this.player1.playUpgrade(this.dapperChapeau, this.exeldonYash);
-            const hostSoulkeeper = this.player1.findCardByName('Soulkeeper', 'play area');
-            const enemySoulkeeper = this.player2.findCardByName('Soulkeeper', 'play area');
-            this.exeldonYash.upgrades.push(hostSoulkeeper);
-            hostSoulkeeper.parent = this.exeldonYash;
-            this.masterOf2.upgrades.push(enemySoulkeeper);
-            enemySoulkeeper.parent = this.masterOf2;
-            this.urchin.upgrades.push(this.friendship);
-            this.friendship.parent = this.urchin;
-            this.game.checkGameState(true);
-        });
-
-        it('leaves Dapper Chapeau in the discard pile', function () {
-            this.player1.clickCard(this.exeldonYash);
-            this.player1.clickPrompt("Use this card's Action ability");
-            // Damage to Urchin is redirected by Friendship to Master of 2,
-            // destroying it. The Soulkeeper on Master of 2 then destroys
-            // Exeldon Yash (the host). The Soulkeeper on Exeldon Yash then
-            // destroys Urchin (the target). Urchin's destruction is by
-            // a destroy effect, not by the dealt damage, so Dapper Chapeau
-            // stays in the discard.
-            this.player1.clickCard(this.urchin);
-            this.player1.clickCard(this.exeldonYash);
-            this.player1.clickCard(this.urchin);
-            expect(this.masterOf2.location).toBe('discard');
-            expect(this.exeldonYash.location).toBe('discard');
-            expect(this.urchin.location).toBe('discard');
             expect(this.dapperChapeau.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();
         });

--- a/test/server/cards/14-DM/DrasticMeasures.spec.js
+++ b/test/server/cards/14-DM/DrasticMeasures.spec.js
@@ -1,0 +1,42 @@
+describe('DrasticMeasures', function () {
+    describe("Drastic Measures's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['drastic-measures', 'troll', 'krump']
+                }
+            });
+        });
+
+        it('purges 2 cards and gains 2 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickCard(this.troll);
+            this.player1.clickCard(this.krump);
+            this.player1.clickPrompt('Done');
+            expect(this.troll.location).toBe('purged');
+            expect(this.krump.location).toBe('purged');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('purges 1 card and gains 1 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickCard(this.troll);
+            this.player1.clickPrompt('Done');
+            expect(this.troll.location).toBe('purged');
+            expect(this.krump.location).toBe('hand');
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('purges 0 cards and gains 0 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickPrompt('Done');
+            expect(this.troll.location).toBe('hand');
+            expect(this.krump.location).toBe('hand');
+            expect(this.player1.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/DrasticMeasures.spec.js
+++ b/test/server/cards/14-DM/DrasticMeasures.spec.js
@@ -39,4 +39,50 @@ describe('DrasticMeasures', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe("Drastic Measures's ability with only one other card in hand", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['drastic-measures', 'troll']
+                }
+            });
+        });
+
+        it('purges the only available card and gains 1 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickCard(this.troll);
+            this.player1.clickPrompt('Done');
+            expect(this.troll.location).toBe('purged');
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can decline to purge any card and gains 0 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickPrompt('Done');
+            expect(this.troll.location).toBe('hand');
+            expect(this.player1.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Drastic Measures's ability with no other cards in hand", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['drastic-measures']
+                }
+            });
+        });
+
+        it('resolves with no cards to purge and gains 0 amber', function () {
+            this.player1.play(this.drasticMeasures);
+            this.player1.clickPrompt('Done');
+            expect(this.player1.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });

--- a/test/server/cards/14-DM/EvenSwap.spec.js
+++ b/test/server/cards/14-DM/EvenSwap.spec.js
@@ -1,5 +1,5 @@
 describe('EvenSwap', function () {
-    describe("Even Swap's ability", function () {
+    describe("Even Swap's ability with 2 creatures on each side", function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -15,11 +15,26 @@ describe('EvenSwap', function () {
 
         it('swaps two friendly and two enemy creatures', function () {
             this.player1.play(this.evenSwap);
+            // First give: only friendly creatures should be selectable.
+            expect(this.player1).toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.snufflegator);
+            expect(this.player1).not.toBeAbleToSelect(this.flaxia);
+            expect(this.player1).not.toBeAbleToSelect(this.exeldonYash);
             this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            // Second give: only the remaining friendly creature is selectable.
+            expect(this.player1).not.toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.snufflegator);
+            expect(this.player1).not.toBeAbleToSelect(this.flaxia);
+            expect(this.player1).not.toBeAbleToSelect(this.exeldonYash);
             this.player1.clickCard(this.snufflegator);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
-            this.player1.clickPrompt('Left');
+            // Take phase: every creature is now controlled by the opponent
+            // (both originals plus the two just given), all selectable.
+            expect(this.player1).toBeAbleToSelect(this.flaxia);
+            expect(this.player1).toBeAbleToSelect(this.exeldonYash);
+            expect(this.player1).toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.snufflegator);
             this.player1.clickCard(this.flaxia);
             this.player1.clickCard(this.exeldonYash);
             this.player1.clickPrompt('Done');
@@ -30,12 +45,186 @@ describe('EvenSwap', function () {
             expect(this.exeldonYash.controller).toBe(this.player1.player);
             expect(this.player1).isReadyToTakeAction();
         });
+    });
 
-        it('does nothing if a side has fewer than 2 creatures', function () {
-            this.player2.moveCard(this.flaxia, 'discard');
+    describe("Even Swap's ability when the player has only 1 creature", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['urchin']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'exeldon-yash']
+                }
+            });
+        });
+
+        it('gives the only friendly creature but takes none', function () {
             this.player1.play(this.evenSwap);
-            expect(this.urchin.controller).toBe(this.player1.player);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player2.player);
             expect(this.exeldonYash.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Even Swap's ability when the player has 0 creatures", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: []
+                },
+                player2: {
+                    inPlay: ['flaxia', 'exeldon-yash']
+                }
+            });
+        });
+
+        it('can be played and resolves with no swaps', function () {
+            this.player1.play(this.evenSwap);
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
+            expect(this.evenSwap.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Even Swap's ability when the opponent has only 1 creature", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['urchin', 'snufflegator']
+                },
+                player2: {
+                    inPlay: ['flaxia']
+                }
+            });
+        });
+
+        it('gives 2 friendly and takes the 1 enemy plus 1 of the given creatures', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Left');
+            // Now player2 controls flaxia, urchin, snufflegator. Take 2 back.
+            this.player1.clickCard(this.flaxia);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Even Swap's ability when the opponent has 0 creatures", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['urchin', 'snufflegator']
+                },
+                player2: {
+                    inPlay: []
+                }
+            });
+        });
+
+        it('gives 2 friendly creatures and takes both back', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Even Swap's ability with Tribune Pompitus", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['tribune-pompitus', 'exeldon-yash', 'conrad-fisique']
+                },
+                player2: {
+                    inPlay: []
+                }
+            });
+            // Each given creature has 1 amber and enough damage that without
+            // Tribune Pompitus's +2 power per A, it would be destroyed.
+            this.exeldonYash.amber = 1;
+            this.exeldonYash.damage = 4;
+            this.conradFisique.amber = 1;
+            this.conradFisique.damage = 3;
+        });
+
+        it('gives 2 creatures who die on the opponent side and player1 gains their amber', function () {
+            // Even Swap has a printed +1 amber bonus, plus 1 amber from each
+            // destroyed given creature = +3 total.
+            const startingAmber = this.player1.amber;
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickCard(this.conradFisique);
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.conradFisique.location).toBe('discard');
+            expect(this.tribunePompitus.controller).toBe(this.player1.player);
+            expect(this.player1.amber).toBe(startingAmber + 3);
+            this.player1.clickPrompt('Done');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Even Swap's ability when giving the first creature kills the second", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['tribune-pompitus', 'exeldon-yash']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'urchin']
+                }
+            });
+            // Exeldon Yash relies on Tribune Pompitus's buff to survive its
+            // accumulated damage. Once Pompitus is given to the opponent, Yash
+            // loses the buff and dies before being given.
+            this.exeldonYash.amber = 1;
+            this.exeldonYash.damage = 4;
+        });
+
+        it('does not allow taking enemy creatures since only one was given', function () {
+            const startingAmber = this.player1.amber;
+            const startingOpponentAmber = this.player2.amber;
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.tribunePompitus);
+            this.player1.clickPrompt('Left');
+            expect(this.tribunePompitus.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.urchin.controller).toBe(this.player2.player);
+            // +1 from the card's printed amber bonus. Yash died on player1's
+            // side, so its amber goes to the opponent.
+            expect(this.player1.amber).toBe(startingAmber + 1);
+            expect(this.player2.amber).toBe(startingOpponentAmber + 1);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/EvenSwap.spec.js
+++ b/test/server/cards/14-DM/EvenSwap.spec.js
@@ -1,0 +1,42 @@
+describe('EvenSwap', function () {
+    describe("Even Swap's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['urchin', 'snufflegator']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'exeldon-yash']
+                }
+            });
+        });
+
+        it('swaps two friendly and two enemy creatures', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.exeldonYash.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing if a side has fewer than 2 creatures', function () {
+            this.player2.moveCard(this.flaxia, 'discard');
+            this.player1.play(this.evenSwap);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/EvenSwap.spec.js
+++ b/test/server/cards/14-DM/EvenSwap.spec.js
@@ -22,6 +22,7 @@ describe('EvenSwap', function () {
             expect(this.player1).not.toBeAbleToSelect(this.exeldonYash);
             this.player1.clickCard(this.urchin);
             this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
             // Second give: only the remaining friendly creature is selectable.
             expect(this.player1).not.toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.snufflegator);
@@ -29,21 +30,42 @@ describe('EvenSwap', function () {
             expect(this.player1).not.toBeAbleToSelect(this.exeldonYash);
             this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
-            // Take phase: every creature is now controlled by the opponent
-            // (both originals plus the two just given), all selectable.
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            // Take phase: every creature is now controlled by the opponent, all selectable.
             expect(this.player1).toBeAbleToSelect(this.flaxia);
             expect(this.player1).toBeAbleToSelect(this.exeldonYash);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.snufflegator);
             this.player1.clickCard(this.flaxia);
+            expect(this.flaxia.controller).toBe(this.player1.player);
             this.player1.clickCard(this.exeldonYash);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
             expect(this.urchin.controller).toBe(this.player2.player);
             expect(this.snufflegator.controller).toBe(this.player2.player);
             expect(this.flaxia.controller).toBe(this.player1.player);
             expect(this.exeldonYash.controller).toBe(this.player1.player);
+
+            const logs = this.getChatLogs(10);
+            expect(logs).toContain('player1 uses Even Swap to give control of Urchin to player2');
+            expect(logs).toContain(
+                'player1 uses Even Swap to give control of Snufflegator to player2'
+            );
+            expect(logs).toContain('player1 uses Even Swap to take control of Flaxia');
+            expect(logs).toContain('player1 uses Even Swap to take control of Exeldon Yash');
+
             expect(this.player1).isReadyToTakeAction();
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.exeldonYash.controller).toBe(this.player1.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.exeldonYash.controller).toBe(this.player1.player);
         });
     });
 
@@ -61,7 +83,7 @@ describe('EvenSwap', function () {
             });
         });
 
-        it('gives the only friendly creature but takes none', function () {
+        it('gives the only friendly creature and takes none', function () {
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.urchin);
             this.player1.clickPrompt('Left');
@@ -69,6 +91,20 @@ describe('EvenSwap', function () {
             expect(this.flaxia.controller).toBe(this.player2.player);
             expect(this.exeldonYash.controller).toBe(this.player2.player);
             expect(this.player1).isReadyToTakeAction();
+            this.player1.endTurn();
+
+            const logs = this.getChatLogs(10);
+            expect(logs).toContain('player1 uses Even Swap to give control of Urchin to player2');
+
+            this.player2.clickPrompt('untamed');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
         });
     });
 
@@ -88,10 +124,19 @@ describe('EvenSwap', function () {
 
         it('can be played and resolves with no swaps', function () {
             this.player1.play(this.evenSwap);
+            expect(this.evenSwap.location).toBe('discard');
             expect(this.flaxia.controller).toBe(this.player2.player);
             expect(this.exeldonYash.controller).toBe(this.player2.player);
-            expect(this.evenSwap.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.controller).toBe(this.player2.player);
         });
     });
 
@@ -113,17 +158,30 @@ describe('EvenSwap', function () {
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.urchin);
             this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
             this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
+            expect(this.snufflegator.controller).toBe(this.player2.player);
             // Now player2 controls flaxia, urchin, snufflegator. Take 2 back.
             this.player1.clickCard(this.flaxia);
+            expect(this.flaxia.controller).toBe(this.player1.player);
             this.player1.clickCard(this.urchin);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
             expect(this.flaxia.controller).toBe(this.player1.player);
             expect(this.urchin.controller).toBe(this.player1.player);
             expect(this.snufflegator.controller).toBe(this.player2.player);
             expect(this.player1).isReadyToTakeAction();
+            this.player1.endTurn();
+
+            this.player2.clickPrompt('untamed');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
         });
     });
 
@@ -144,15 +202,27 @@ describe('EvenSwap', function () {
         it('gives 2 friendly creatures and takes both back', function () {
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.urchin);
+            expect(this.urchin.controller).toBe(this.player2.player);
             this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.snufflegator.controller).toBe(this.player2.player);
             this.player1.clickCard(this.urchin);
+            expect(this.urchin.controller).toBe(this.player1.player);
             this.player1.clickCard(this.snufflegator);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
             expect(this.urchin.controller).toBe(this.player1.player);
             expect(this.snufflegator.controller).toBe(this.player1.player);
             expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player1.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.snufflegator.controller).toBe(this.player1.player);
         });
     });
 
@@ -162,7 +232,7 @@ describe('EvenSwap', function () {
                 player1: {
                     house: 'ekwidon',
                     hand: ['even-swap'],
-                    inPlay: ['tribune-pompitus', 'exeldon-yash', 'conrad-fisique']
+                    inPlay: ['tribune-pompitus', 'exeldon-yash', 'cŏnrăd-fisiquĕ']
                 },
                 player2: {
                     inPlay: []
@@ -172,22 +242,18 @@ describe('EvenSwap', function () {
             // Tribune Pompitus's +2 power per A, it would be destroyed.
             this.exeldonYash.amber = 1;
             this.exeldonYash.damage = 4;
-            this.conradFisique.amber = 1;
-            this.conradFisique.damage = 3;
+            this.cŏnrădFisiquĕ.amber = 1;
+            this.cŏnrădFisiquĕ.damage = 3;
         });
 
         it('gives 2 creatures who die on the opponent side and player1 gains their amber', function () {
-            // Even Swap has a printed +1 amber bonus, plus 1 amber from each
-            // destroyed given creature = +3 total.
-            const startingAmber = this.player1.amber;
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.exeldonYash);
-            this.player1.clickCard(this.conradFisique);
             expect(this.exeldonYash.location).toBe('discard');
-            expect(this.conradFisique.location).toBe('discard');
+            this.player1.clickCard(this.cŏnrădFisiquĕ);
+            expect(this.cŏnrădFisiquĕ.location).toBe('discard');
             expect(this.tribunePompitus.controller).toBe(this.player1.player);
-            expect(this.player1.amber).toBe(startingAmber + 3);
-            this.player1.clickPrompt('Done');
+            expect(this.player1.amber).toBe(3);
             expect(this.player1).isReadyToTakeAction();
         });
     });
@@ -212,8 +278,6 @@ describe('EvenSwap', function () {
         });
 
         it('does not allow taking enemy creatures since only one was given', function () {
-            const startingAmber = this.player1.amber;
-            const startingOpponentAmber = this.player2.amber;
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.tribunePompitus);
             this.player1.clickPrompt('Left');
@@ -221,10 +285,108 @@ describe('EvenSwap', function () {
             expect(this.exeldonYash.location).toBe('discard');
             expect(this.flaxia.controller).toBe(this.player2.player);
             expect(this.urchin.controller).toBe(this.player2.player);
-            // +1 from the card's printed amber bonus. Yash died on player1's
-            // side, so its amber goes to the opponent.
-            expect(this.player1.amber).toBe(startingAmber + 1);
-            expect(this.player2.amber).toBe(startingOpponentAmber + 1);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            expect(this.tribunePompitus.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.urchin.controller).toBe(this.player2.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.tribunePompitus.controller).toBe(this.player2.player);
+            expect(this.exeldonYash.location).toBe('discard');
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.urchin.controller).toBe(this.player2.player);
+        });
+    });
+
+    describe("Even Swap's ability when both given creatures die immediately", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['tribune-pompitus', 'exeldon-yash', 'cŏnrăd-fisiquĕ']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'urchin']
+                }
+            });
+            // Pompitus's +2 power per A keeps these damaged creatures alive
+            // while on player1's side. Once given to player2, they lose the
+            // buff and die.
+            this.exeldonYash.amber = 1;
+            this.exeldonYash.damage = 4;
+            this.cŏnrădFisiquĕ.amber = 1;
+            this.cŏnrădFisiquĕ.damage = 3;
+        });
+
+        it('still allows taking 2 enemy creatures', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt('Left');
+            expect(this.exeldonYash.location).toBe('discard');
+            this.player1.clickCard(this.cŏnrădFisiquĕ);
+            this.player1.clickPrompt('Left');
+            expect(this.cŏnrădFisiquĕ.location).toBe('discard');
+            // Both given creatures died on player2's side. Take phase still
+            // proceeds with the 2 enemy creatures available.
+            this.player1.clickCard(this.flaxia);
+            this.player1.clickPrompt('Left');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.tribunePompitus.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.flaxia.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
+        });
+    });
+
+    describe("Even Swap's ability when taking the first creature destroys all creatures", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['urchin', 'snufflegator']
+                },
+                player2: {
+                    inPlay: ['tribune-pompitus', 'harbinger-of-doom']
+                }
+            });
+            // Harbinger of Doom survives its damage only because Tribune
+            // Pompitus's +2 power per A keeps it alive. Once Pompitus changes
+            // controller, Harbinger dies and triggers "destroy each creature".
+            this.harbingerOfDoom.amber = 2;
+            this.harbingerOfDoom.damage = 3;
+        });
+
+        it('skips the second take because no creatures remain', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Left');
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            this.player1.clickCard(this.tribunePompitus);
+            expect(this.tribunePompitus.location).toBe('discard');
+            expect(this.harbingerOfDoom.location).toBe('discard');
+            expect(this.urchin.location).toBe('discard');
+            expect(this.snufflegator.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/ExeldonYash.spec.js
+++ b/test/server/cards/14-DM/ExeldonYash.spec.js
@@ -1,0 +1,39 @@
+describe('ExeldonYash', function () {
+    describe("Exeldon Yash's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['troll'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('captures 2 then discards a card to move 1 to pool', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.player2.amber).toBe(1);
+            expect(this.player1).toHavePrompt(
+                'You may discard a card to move 1 amber to your pool'
+            );
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('captures 2 and skips discard when player declines', function () {
+            this.player1.reap(this.exeldonYash);
+            this.player1.clickPrompt('Done');
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.troll.location).toBe('hand');
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ExeldonYash.spec.js
+++ b/test/server/cards/14-DM/ExeldonYash.spec.js
@@ -17,9 +17,7 @@ describe('ExeldonYash', function () {
             this.player1.reap(this.exeldonYash);
             expect(this.exeldonYash.amber).toBe(2);
             expect(this.player2.amber).toBe(1);
-            expect(this.player1).toHavePrompt(
-                'You may discard a card to move 1 amber to your pool'
-            );
+            expect(this.player1).toHavePrompt('Choose a card');
             this.player1.clickCard(this.troll);
             expect(this.troll.location).toBe('discard');
             expect(this.exeldonYash.amber).toBe(1);
@@ -33,6 +31,61 @@ describe('ExeldonYash', function () {
             expect(this.exeldonYash.amber).toBe(2);
             expect(this.troll.location).toBe('hand');
             expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Exeldon Yash's ability when opponent has no amber", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['troll'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 0
+                }
+            });
+        });
+
+        it('still prompts to discard but no amber is gained when there is none on Exeldon Yash', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Exeldon Yash's ability when opponent has no amber but Exeldon Yash has amber on it", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['troll'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 0
+                }
+            });
+            this.exeldonYash.amber = 1;
+        });
+
+        it('discards to move the existing amber from Exeldon Yash to pool', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.exeldonYash.amber).toBe(0);
+            expect(this.player1.amber).toBe(2);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/FiatTranscoder.spec.js
+++ b/test/server/cards/14-DM/FiatTranscoder.spec.js
@@ -5,26 +5,37 @@ describe('FiatTranscoder', function () {
                 player1: {
                     house: 'ekwidon',
                     amber: 2,
-                    inPlay: ['fiat-transcoder']
+                    inPlay: ['fiat-transcoder', 'bumpsy']
                 },
                 player2: {
-                    inPlay: ['urchin']
+                    inPlay: ['urchin', 'flaxia', 'troll']
                 }
             });
         });
 
         it('loses 1 amber and takes control of an enemy creature', function () {
             this.player1.useAction(this.fiatTranscoder);
+            expect(this.player1).not.toBeAbleToSelect(this.bumpsy);
+            expect(this.player1).toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.flaxia);
+            expect(this.player1).toBeAbleToSelect(this.troll);
             this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
             expect(this.player1.amber).toBe(1);
+            expect(this.bumpsy.controller).toBe(this.player1.player);
             expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.troll.controller).toBe(this.player2.player);
             expect(this.player1).isReadyToTakeAction();
         });
 
         it('does nothing if player has no amber', function () {
             this.player1.amber = 0;
             this.player1.useAction(this.fiatTranscoder);
+            expect(this.bumpsy.controller).toBe(this.player1.player);
             expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.flaxia.controller).toBe(this.player2.player);
+            expect(this.troll.controller).toBe(this.player2.player);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/FiatTranscoder.spec.js
+++ b/test/server/cards/14-DM/FiatTranscoder.spec.js
@@ -1,0 +1,31 @@
+describe('FiatTranscoder', function () {
+    describe("Fiat Transcoder's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    amber: 2,
+                    inPlay: ['fiat-transcoder']
+                },
+                player2: {
+                    inPlay: ['urchin']
+                }
+            });
+        });
+
+        it('loses 1 amber and takes control of an enemy creature', function () {
+            this.player1.useAction(this.fiatTranscoder);
+            this.player1.clickCard(this.urchin);
+            expect(this.player1.amber).toBe(1);
+            expect(this.urchin.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing if player has no amber', function () {
+            this.player1.amber = 0;
+            this.player1.useAction(this.fiatTranscoder);
+            expect(this.urchin.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/ForgedCurrency.spec.js
+++ b/test/server/cards/14-DM/ForgedCurrency.spec.js
@@ -1,34 +1,112 @@
 describe('ForgedCurrency', function () {
     describe("Forged Currency's ability", function () {
-        it('forges no key when total moved is 0 and player has no extra amber', function () {
+        beforeEach(function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
                     hand: ['forged-currency'],
-                    inPlay: ['exeldon-yash']
+                    inPlay: ['exeldon-yash', 'krisper-ruld']
+                },
+                player2: {
+                    inPlay: ['flaxia']
                 }
             });
+        });
+
+        it('forges no key when total moved is 0 and player has no extra amber', function () {
+            this.player1.amber = 3;
             this.player1.play(this.forgedCurrency);
+            expect(this.player1.amber).toBe(3);
             expect(this.player1.player.getForgedKeys()).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('forges a key reduced by total power counters and amber moved', function () {
-            this.setupTest({
-                player1: {
-                    house: 'ekwidon',
-                    amber: 6,
-                    hand: ['forged-currency'],
-                    inPlay: ['exeldon-yash', 'krisper-ruld']
-                }
-            });
-            this.exeldonYash.powerCounters = 3;
-            this.krisperRuld.amber = 3;
+        it('forges no key from enemy creatures', function () {
+            this.player1.amber = 6;
+            this.flaxia.amber = 3;
+            this.flaxia.powerCounters = 3;
             this.player1.play(this.forgedCurrency);
-            expect(this.exeldonYash.powerCounters).toBe(0);
-            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.player1.amber).toBe(6);
+            expect(this.player1.player.getForgedKeys()).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by total power counters and amber moved from different creatures', function () {
+            this.player1.amber = 6;
+            this.krisperRuld.amber = 3;
+            this.exeldonYash.powerCounters = 3;
+            this.player1.play(this.forgedCurrency);
             this.player1.clickPrompt('Red');
             expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by total power counters and amber moved at a minimum cost of 6', function () {
+            this.player1.amber = 9;
+            this.krisperRuld.amber = 6;
+            this.exeldonYash.powerCounters = 6;
+            this.player1.play(this.forgedCurrency);
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(3);
+            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by total power counters and amber moved from the same creature', function () {
+            this.player1.amber = 6;
+            this.exeldonYash.amber = 3;
+            this.exeldonYash.powerCounters = 3;
+            this.player1.play(this.forgedCurrency);
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by amber moved', function () {
+            this.player1.amber = 6;
+            this.krisperRuld.amber = 6;
+            this.player1.play(this.forgedCurrency);
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by power counters moved', function () {
+            this.player1.amber = 6;
+            this.krisperRuld.powerCounters = 6;
+            this.player1.play(this.forgedCurrency);
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by total power counters and amber moved from a damaged creature', function () {
+            this.player1.amber = 6;
+            this.exeldonYash.amber = 3;
+            this.exeldonYash.powerCounters = 3;
+            this.exeldonYash.damage = 3;
+            this.player1.play(this.forgedCurrency);
+            expect(this.player2.amber).toBe(0);
+            expect(this.exeldonYash.location).toBe('discard');
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/ForgedCurrency.spec.js
+++ b/test/server/cards/14-DM/ForgedCurrency.spec.js
@@ -1,0 +1,35 @@
+describe('ForgedCurrency', function () {
+    describe("Forged Currency's ability", function () {
+        it('forges no key when total moved is 0 and player has no extra amber', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['forged-currency'],
+                    inPlay: ['exeldon-yash']
+                }
+            });
+            this.player1.play(this.forgedCurrency);
+            expect(this.player1.player.getForgedKeys()).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('forges a key reduced by total power counters and amber moved', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    amber: 6,
+                    hand: ['forged-currency'],
+                    inPlay: ['exeldon-yash', 'krisper-ruld']
+                }
+            });
+            this.exeldonYash.powerCounters = 3;
+            this.krisperRuld.amber = 3;
+            this.player1.play(this.forgedCurrency);
+            expect(this.exeldonYash.powerCounters).toBe(0);
+            expect(this.krisperRuld.amber).toBe(0);
+            this.player1.clickPrompt('Red');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/GoldenDagger.spec.js
+++ b/test/server/cards/14-DM/GoldenDagger.spec.js
@@ -4,7 +4,7 @@ describe('GoldenDagger', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    inPlay: ['golden-dagger']
+                    inPlay: ['golden-dagger', 'lamindra']
                 },
                 player2: {
                     inPlay: ['troll', 'urchin']
@@ -30,23 +30,11 @@ describe('GoldenDagger', function () {
             expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
-    });
-
-    describe('Golden Dagger destroying a friendly creature', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'ekwidon',
-                    inPlay: ['golden-dagger', 'urchin']
-                },
-                player2: {}
-            });
-        });
 
         it('gains 1 amber for the friendly owner', function () {
             this.player1.reap(this.goldenDagger);
-            this.player1.clickCard(this.urchin);
-            expect(this.urchin.location).toBe('discard');
+            this.player1.clickCard(this.lamindra);
+            expect(this.lamindra.location).toBe('discard');
             expect(this.player1.amber).toBe(2); // 1 from reap + 1 from owner gain
             expect(this.player2.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
@@ -74,16 +62,14 @@ describe('GoldenDagger', function () {
             this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
             this.player1.clickCard(this.flaxia);
-            this.player1.clickCard(this.exeldonYash);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.exeldonYash);
             this.player1.clickPrompt('Left');
             expect(this.urchin.controller).toBe(this.player2.player);
             this.player1.reap(this.goldenDagger);
             this.player1.clickCard(this.urchin);
             expect(this.urchin.location).toBe('discard');
-            // owner is still player1, so player1 gains the amber
-            expect(this.player1.amber).toBe(3); // 1 even-swap bonus + 1 reap + 1 owner gain
+            expect(this.player1.amber).toBe(3);
             expect(this.player2.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });

--- a/test/server/cards/14-DM/GoldenDagger.spec.js
+++ b/test/server/cards/14-DM/GoldenDagger.spec.js
@@ -70,9 +70,8 @@ describe('GoldenDagger', function () {
         it('credits amber to the original owner even when the creature has changed control', function () {
             this.player1.play(this.evenSwap);
             this.player1.clickCard(this.urchin);
-            this.player1.clickCard(this.snufflegator);
-            this.player1.clickPrompt('Done');
             this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
             this.player1.clickCard(this.flaxia);
             this.player1.clickCard(this.exeldonYash);

--- a/test/server/cards/14-DM/GoldenDagger.spec.js
+++ b/test/server/cards/14-DM/GoldenDagger.spec.js
@@ -1,0 +1,92 @@
+describe('GoldenDagger', function () {
+    describe("Golden Dagger's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['golden-dagger']
+                },
+                player2: {
+                    inPlay: ['troll', 'urchin']
+                }
+            });
+        });
+
+        it('deals 3 damage and gains 1 amber for the owner when the damage destroys an enemy creature', function () {
+            this.player1.reap(this.goldenDagger);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player2.amber).toBe(1);
+            expect(this.player1.amber).toBe(1); // 1 from reap
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('deals 3 damage but does not destroy a tougher creature, no amber gained', function () {
+            this.player1.reap(this.goldenDagger);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.damage).toBe(3);
+            expect(this.troll.location).toBe('play area');
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Golden Dagger destroying a friendly creature', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['golden-dagger', 'urchin']
+                },
+                player2: {}
+            });
+        });
+
+        it('gains 1 amber for the friendly owner', function () {
+            this.player1.reap(this.goldenDagger);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player1.amber).toBe(2); // 1 from reap + 1 from owner gain
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Golden Dagger and changed control', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['even-swap'],
+                    inPlay: ['golden-dagger', 'urchin', 'snufflegator']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'exeldon-yash']
+                }
+            });
+        });
+
+        it('credits amber to the original owner even when the creature has changed control', function () {
+            this.player1.play(this.evenSwap);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            this.player1.clickPrompt('Left');
+            this.player1.clickCard(this.flaxia);
+            this.player1.clickCard(this.exeldonYash);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('Left');
+            this.player1.clickPrompt('Left');
+            expect(this.urchin.controller).toBe(this.player2.player);
+            this.player1.reap(this.goldenDagger);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.location).toBe('discard');
+            // owner is still player1, so player1 gains the amber
+            expect(this.player1.amber).toBe(3); // 1 even-swap bonus + 1 reap + 1 owner gain
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/HotBunk.spec.js
+++ b/test/server/cards/14-DM/HotBunk.spec.js
@@ -1,0 +1,64 @@
+describe('HotBunk', function () {
+    describe("Hot Bunk's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['hot-bunk'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.troll.exhausted = true;
+        });
+
+        it('exhausts a creature, then readies a creature', function () {
+            this.player1.play(this.hotBunk);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.exhausted).toBe(true);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.exhausted).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can ready a friendly creature that was just exhausted', function () {
+            this.exeldonYash.exhausted = false;
+            this.player1.play(this.hotBunk);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.exhausted).toBe(true);
+            this.player1.clickCard(this.exeldonYash);
+            expect(this.exeldonYash.exhausted).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Hot Bunk's ability with Sariel the Steadfast", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['hot-bunk']
+                },
+                player2: {
+                    inPlay: ['sariel-the-steadfast', 'troll']
+                }
+            });
+            this.troll.exhausted = true;
+        });
+
+        it('does not ready a creature when no creature can be exhausted', function () {
+            this.player1.play(this.hotBunk);
+            // Sariel prevents player2's creatures from exhausting while it is
+            // not their turn, so targeting sariel does not exhaust it and the
+            // ready step is skipped.
+            this.player1.clickCard(this.sarielTheSteadfast);
+            expect(this.sarielTheSteadfast.exhausted).toBe(false);
+            expect(this.troll.exhausted).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/HotBunk.spec.js
+++ b/test/server/cards/14-DM/HotBunk.spec.js
@@ -11,10 +11,10 @@ describe('HotBunk', function () {
                     inPlay: ['troll']
                 }
             });
-            this.troll.exhausted = true;
         });
 
         it('exhausts a creature, then readies a creature', function () {
+            this.troll.exhausted = true;
             this.player1.play(this.hotBunk);
             expect(this.player1).toHavePrompt('Choose a creature');
             this.player1.clickCard(this.exeldonYash);
@@ -25,8 +25,16 @@ describe('HotBunk', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('can ready a friendly creature that was just exhausted', function () {
-            this.exeldonYash.exhausted = false;
+        it('exhausts an exhausted creature, and does not ready a creature', function () {
+            this.troll.exhausted = true;
+            this.player1.play(this.hotBunk);
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.exhausted).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can ready a creature that was just exhausted', function () {
             this.player1.play(this.hotBunk);
             this.player1.clickCard(this.exeldonYash);
             expect(this.exeldonYash.exhausted).toBe(true);
@@ -52,9 +60,6 @@ describe('HotBunk', function () {
 
         it('does not ready a creature when no creature can be exhausted', function () {
             this.player1.play(this.hotBunk);
-            // Sariel prevents player2's creatures from exhausting while it is
-            // not their turn, so targeting sariel does not exhaust it and the
-            // ready step is skipped.
             this.player1.clickCard(this.sarielTheSteadfast);
             expect(this.sarielTheSteadfast.exhausted).toBe(false);
             expect(this.troll.exhausted).toBe(true);

--- a/test/server/cards/14-DM/KrisperRuld.spec.js
+++ b/test/server/cards/14-DM/KrisperRuld.spec.js
@@ -1,0 +1,50 @@
+describe('KrisperRuld', function () {
+    describe("Krisper Ruld's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['krisper-ruld']
+                },
+                player2: {
+                    inPlay: ['flaxia', 'city-gates']
+                }
+            });
+        });
+
+        it('takes control of an enemy artifact after fighting', function () {
+            this.player1.fightWith(this.krisperRuld, this.flaxia);
+            expect(this.player1).toHavePrompt('Choose an enemy artifact');
+            this.player1.clickCard(this.cityGates);
+            expect(this.cityGates.controller).toBe(this.player1.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing if there are no enemy artifacts', function () {
+            this.player2.moveCard(this.cityGates, 'discard');
+            this.player1.fightWith(this.krisperRuld, this.flaxia);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Krisper Ruld's ability when destroyed in fight", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['krisper-ruld']
+                },
+                player2: {
+                    inPlay: ['valdr', 'city-gates']
+                }
+            });
+        });
+
+        it('does not take control of an artifact when destroyed', function () {
+            this.player1.fightWith(this.krisperRuld, this.valdr);
+            expect(this.krisperRuld.location).toBe('discard');
+            expect(this.cityGates.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/KrisperRuld.spec.js
+++ b/test/server/cards/14-DM/KrisperRuld.spec.js
@@ -4,17 +4,19 @@ describe('KrisperRuld', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    inPlay: ['krisper-ruld']
+                    inPlay: ['krisper-ruld', 'autocannon']
                 },
                 player2: {
-                    inPlay: ['flaxia', 'city-gates']
+                    inPlay: ['flaxia', 'valdr', 'city-gates']
                 }
             });
         });
 
         it('takes control of an enemy artifact after fighting', function () {
             this.player1.fightWith(this.krisperRuld, this.flaxia);
-            expect(this.player1).toHavePrompt('Choose an enemy artifact');
+            expect(this.player1).toHavePrompt('Choose a artifact');
+            expect(this.player1).not.toBeAbleToSelect(this.autocannon);
+            expect(this.player1).toBeAbleToSelect(this.cityGates);
             this.player1.clickCard(this.cityGates);
             expect(this.cityGates.controller).toBe(this.player1.player);
             expect(this.player1).isReadyToTakeAction();
@@ -24,20 +26,6 @@ describe('KrisperRuld', function () {
             this.player2.moveCard(this.cityGates, 'discard');
             this.player1.fightWith(this.krisperRuld, this.flaxia);
             expect(this.player1).isReadyToTakeAction();
-        });
-    });
-
-    describe("Krisper Ruld's ability when destroyed in fight", function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'ekwidon',
-                    inPlay: ['krisper-ruld']
-                },
-                player2: {
-                    inPlay: ['valdr', 'city-gates']
-                }
-            });
         });
 
         it('does not take control of an artifact when destroyed', function () {

--- a/test/server/cards/14-DM/NadaTax.spec.js
+++ b/test/server/cards/14-DM/NadaTax.spec.js
@@ -1,0 +1,87 @@
+describe('NadaTax', function () {
+    describe("Nada Tax's ability", function () {
+        it('makes opponent lose 1 amber per bonus icon on discarded card', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['nada-tax']
+                },
+                player2: {
+                    amber: 3,
+                    hand: ['caught-you-napping']
+                }
+            });
+            this.player1.play(this.nadaTax);
+            expect(this.caughtYouNapping.location).toBe('discard');
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not lose amber when discarded card has no bonus icons', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['nada-tax']
+                },
+                player2: {
+                    amber: 3,
+                    hand: ['troll']
+                }
+            });
+            this.player1.play(this.nadaTax);
+            expect(this.troll.location).toBe('discard');
+            expect(this.player2.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing if opponent has empty hand', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['nada-tax']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+            this.player1.play(this.nadaTax);
+            expect(this.player2.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('makes opponent lose 1 amber per bonus icon when card has multiple amber bonus icons', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['nada-tax']
+                },
+                player2: {
+                    amber: 5,
+                    hand: ['virtuous-works']
+                }
+            });
+            this.player1.play(this.nadaTax);
+            expect(this.virtuousWorks.location).toBe('discard');
+            expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('makes opponent lose amber for house enhancements on the discarded card', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['nada-tax']
+                },
+                player2: {
+                    amber: 5,
+                    hand: ['troll']
+                }
+            });
+            this.troll.enhancements = ['amber', 'capture'];
+            this.player1.play(this.nadaTax);
+            expect(this.troll.location).toBe('discard');
+            expect(this.player2.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/NowAndLater.spec.js
+++ b/test/server/cards/14-DM/NowAndLater.spec.js
@@ -1,0 +1,44 @@
+describe('NowAndLater', function () {
+    describe("Now and Later's ability", function () {
+        it('returns a creature to hand and archives a card', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('repeats the effect when overwhelmed', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    amber: 7,
+                    hand: ['now-and-later', 'mack-the-knife', 'urchin']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.troll);
+            this.player1.clickCard(this.mackTheKnife);
+            this.player1.clickCard(this.krump);
+            this.player1.clickCard(this.urchin);
+            expect(this.troll.location).toBe('hand');
+            expect(this.krump.location).toBe('hand');
+            expect(this.mackTheKnife.location).toBe('archives');
+            expect(this.urchin.location).toBe('archives');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/NowAndLater.spec.js
+++ b/test/server/cards/14-DM/NowAndLater.spec.js
@@ -1,6 +1,6 @@
 describe('NowAndLater', function () {
     describe("Now and Later's ability", function () {
-        it('returns a creature to hand and archives a card', function () {
+        it('returns an enemy creature to hand and archives a card', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
@@ -18,11 +18,92 @@ describe('NowAndLater', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
+        it('returns a friendly creature to hand and archives a card', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife'],
+                    inPlay: ['urchin', 'bumpsy']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('archives a card when there are no creatures in play', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife']
+                },
+                player2: {}
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('returns a creature when the player has no cards to archive', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('hand');
+            expect(this.player1.player.hand.length).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing when there are no creatures and no cards to archive', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later']
+                },
+                player2: {}
+            });
+            this.player1.play(this.nowAndLater);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not repeat when not overwhelmed', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife', 'urchin'],
+                    inPlay: ['bumpsy']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            expect(this.urchin.location).toBe('hand');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
         it('repeats the effect when overwhelmed', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    amber: 7,
                     hand: ['now-and-later', 'mack-the-knife', 'urchin']
                 },
                 player2: {
@@ -31,13 +112,57 @@ describe('NowAndLater', function () {
             });
             this.player1.play(this.nowAndLater);
             this.player1.clickCard(this.troll);
-            this.player1.clickCard(this.mackTheKnife);
-            this.player1.clickCard(this.krump);
-            this.player1.clickCard(this.urchin);
             expect(this.troll.location).toBe('hand');
-            expect(this.krump.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
             expect(this.mackTheKnife.location).toBe('archives');
+            this.player1.clickCard(this.krump);
+            expect(this.krump.location).toBe('hand');
+            this.player1.clickCard(this.urchin);
             expect(this.urchin.location).toBe('archives');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('repeats the return but not the archive when overwhelmed and the player has no more cards to archive', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            this.player1.clickCard(this.krump);
+            expect(this.krump.location).toBe('hand');
+            expect(this.player1.player.hand.length).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('repeats the effect when returning a friendly creature causes overwhelm', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['now-and-later', 'mack-the-knife'],
+                    inPlay: ['bumpsy', 'urchin']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump']
+                }
+            });
+            this.player1.play(this.nowAndLater);
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.location).toBe('hand');
+            this.player1.clickCard(this.mackTheKnife);
+            expect(this.mackTheKnife.location).toBe('archives');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('hand');
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.location).toBe('archives');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/OoniLars.spec.js
+++ b/test/server/cards/14-DM/OoniLars.spec.js
@@ -5,17 +5,18 @@ describe('OoniLars', function () {
                 player1: {
                     house: 'ekwidon',
                     amber: 3,
-                    inPlay: ['ooni-lars']
+                    inPlay: ['oŏni-lars']
                 },
                 player2: {}
             });
         });
 
         it("pays opponent 1 and increases opponent's key cost by 4 next turn", function () {
-            this.player1.reap(this.ooniLars);
-            this.player1.clickCard(this.ooniLars);
-            expect(this.player1.amber).toBe(3); // 3 - 1 paid + 1 reap
+            this.player1.reap(this.oŏniLars);
+            this.player1.clickCard(this.oŏniLars);
+            expect(this.player1.amber).toBe(3);
             expect(this.player2.amber).toBe(1);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
             this.player1.endTurn();
             expect(this.player2.player.getCurrentKeyCost()).toBe(10);
             this.player2.clickPrompt('untamed');
@@ -26,7 +27,7 @@ describe('OoniLars', function () {
         });
 
         it('does nothing extra when player declines', function () {
-            this.player1.reap(this.ooniLars);
+            this.player1.reap(this.oŏniLars);
             this.player1.clickPrompt('Done');
             expect(this.player1.amber).toBe(4);
             expect(this.player2.amber).toBe(0);

--- a/test/server/cards/14-DM/OoniLars.spec.js
+++ b/test/server/cards/14-DM/OoniLars.spec.js
@@ -1,0 +1,39 @@
+describe('OoniLars', function () {
+    describe("Ooni-Lars's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    amber: 3,
+                    inPlay: ['ooni-lars']
+                },
+                player2: {}
+            });
+        });
+
+        it("pays opponent 1 and increases opponent's key cost by 4 next turn", function () {
+            this.player1.reap(this.ooniLars);
+            this.player1.clickCard(this.ooniLars);
+            expect(this.player1.amber).toBe(3); // 3 - 1 paid + 1 reap
+            expect(this.player2.amber).toBe(1);
+            this.player1.endTurn();
+            expect(this.player2.player.getCurrentKeyCost()).toBe(10);
+            this.player2.clickPrompt('untamed');
+            this.player2.endTurn();
+            this.player1.clickPrompt('ekwidon');
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does nothing extra when player declines', function () {
+            this.player1.reap(this.ooniLars);
+            this.player1.clickPrompt('Done');
+            expect(this.player1.amber).toBe(4);
+            expect(this.player2.amber).toBe(0);
+            this.player1.endTurn();
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+            this.player2.clickPrompt('untamed');
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/TheGoldenQueen.spec.js
+++ b/test/server/cards/14-DM/TheGoldenQueen.spec.js
@@ -1,0 +1,143 @@
+describe('The Golden Queen', function () {
+    describe("The Golden Queen's persistent hand size effect", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['the-golden-queen', 'the-golden-queen2']
+                },
+                player2: {}
+            });
+        });
+
+        it("should increase each player's max hand size by 1 while in play", function () {
+            expect(this.player1.player.maxHandSize).toBe(6);
+            expect(this.player2.player.maxHandSize).toBe(6);
+            this.player1.play(this.theGoldenQueen);
+            expect(this.player1.player.maxHandSize).toBe(7);
+            expect(this.player2.player.maxHandSize).toBe(7);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("The Golden Queen's after-reap ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['the-golden-queen', 'the-golden-queen2', 'pen-pal']
+                },
+                player2: {
+                    hand: ['troll']
+                }
+            });
+            this.player1.play(this.theGoldenQueen);
+            this.theGoldenQueen.ready();
+        });
+
+        it('should discard a random card from each player and gain 1A per non-Ekwidon discard', function () {
+            this.player1.reap(this.theGoldenQueen);
+            this.player1.clickPrompt('Me');
+            expect(this.penPal.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should let the controller choose opponent discards first', function () {
+            this.player1.reap(this.theGoldenQueen);
+            this.player1.clickPrompt('Opponent');
+            expect(this.penPal.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should not prompt for choice when orderForcedAbilities is disabled but still confirm', function () {
+            this.player1.player.optionSettings.orderForcedAbilities = false;
+            this.player1.reap(this.theGoldenQueen);
+            this.player1.clickPrompt('Me');
+            expect(this.penPal.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("The Golden Queen's after-reap ability with two non-Ekwidon discards", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['the-golden-queen', 'the-golden-queen2', 'mack-the-knife']
+                },
+                player2: {
+                    hand: ['troll']
+                }
+            });
+            this.player1.play(this.theGoldenQueen);
+            this.theGoldenQueen.ready();
+        });
+
+        it('should gain 2A when both discarded cards are non-Ekwidon', function () {
+            this.player1.reap(this.theGoldenQueen);
+            this.player1.clickPrompt('Me');
+            expect(this.mackTheKnife.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.player1.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("The Golden Queen's after-reap ability with only Ekwidon discards", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['the-golden-queen', 'the-golden-queen2', 'pen-pal']
+                },
+                player2: {
+                    hand: ['change-agent']
+                }
+            });
+            this.player1.play(this.theGoldenQueen);
+            this.theGoldenQueen.ready();
+        });
+
+        it('should not gain bonus amber when both discards are Ekwidon', function () {
+            this.player1.reap(this.theGoldenQueen);
+            this.player1.clickPrompt('Me');
+            expect(this.penPal.location).toBe('discard');
+            expect(this.changeAgent.location).toBe('discard');
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("The Golden Queen's after-fight ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['the-golden-queen', 'the-golden-queen2', 'mack-the-knife']
+                },
+                player2: {
+                    hand: ['troll'],
+                    inPlay: ['narp']
+                }
+            });
+            this.player1.play(this.theGoldenQueen);
+            this.theGoldenQueen.ready();
+        });
+
+        it('should discard a random card from each player on fight and gain 1A per non-Ekwidon', function () {
+            this.player1.fightWith(this.theGoldenQueen, this.narp);
+            this.player1.clickPrompt('Me');
+            expect(this.mackTheKnife.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.narp.location).toBe('discard');
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/VastStoik.spec.js
+++ b/test/server/cards/14-DM/VastStoik.spec.js
@@ -4,7 +4,7 @@ describe('VastStoik', function () {
             this.setupTest({
                 player1: {
                     house: 'ekwidon',
-                    inPlay: ['vast-stoik'],
+                    inPlay: ['văst-stŏik'],
                     deck: ['troll', 'mack-the-knife']
                 },
                 player2: {
@@ -17,12 +17,12 @@ describe('VastStoik', function () {
         it('moves 1 amber from a creature to common supply and draws a card', function () {
             this.urchin.amber = 2;
             const handSize = this.player1.hand.length;
-            this.player1.fightWith(this.vastStoik, this.urchin);
-            expect(this.player1).toBeAbleToSelect(this.vastStoik);
+            this.player1.fightWith(this.văstStŏik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.văstStŏik);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.krump);
             this.player1.clickCard(this.urchin);
-            expect(this.vastStoik.amber).toBe(0);
+            expect(this.văstStŏik.amber).toBe(0);
             expect(this.urchin.amber).toBe(1);
             expect(this.krump.amber).toBe(0);
             expect(this.player1.amber).toBe(0);
@@ -33,12 +33,12 @@ describe('VastStoik', function () {
 
         it('any creature is selectable, including those without amber', function () {
             const handSize = this.player1.hand.length;
-            this.player1.fightWith(this.vastStoik, this.urchin);
-            expect(this.player1).toBeAbleToSelect(this.vastStoik);
+            this.player1.fightWith(this.văstStŏik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.văstStŏik);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.krump);
             this.player1.clickCard(this.krump);
-            expect(this.vastStoik.amber).toBe(0);
+            expect(this.văstStŏik.amber).toBe(0);
             expect(this.urchin.amber).toBe(2);
             expect(this.krump.amber).toBe(0);
             expect(this.player1.amber).toBe(0);

--- a/test/server/cards/14-DM/VastStoik.spec.js
+++ b/test/server/cards/14-DM/VastStoik.spec.js
@@ -11,17 +11,20 @@ describe('VastStoik', function () {
                     inPlay: ['urchin', 'krump']
                 }
             });
+            this.urchin.amber = 2;
         });
 
         it('moves 1 amber from a creature to common supply and draws a card', function () {
             this.urchin.amber = 2;
             const handSize = this.player1.hand.length;
             this.player1.fightWith(this.vastStoik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.vastStoik);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.krump);
             this.player1.clickCard(this.urchin);
+            expect(this.vastStoik.amber).toBe(0);
             expect(this.urchin.amber).toBe(1);
-            expect(this.krump.amber).toBe(1);
+            expect(this.krump.amber).toBe(0);
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(0);
             expect(this.player1.hand.length).toBe(handSize + 1);
@@ -29,13 +32,14 @@ describe('VastStoik', function () {
         });
 
         it('any creature is selectable, including those without amber', function () {
-            this.urchin.amber = 1;
             const handSize = this.player1.hand.length;
             this.player1.fightWith(this.vastStoik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.vastStoik);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.krump);
             this.player1.clickCard(this.krump);
-            expect(this.urchin.amber).toBe(1);
+            expect(this.vastStoik.amber).toBe(0);
+            expect(this.urchin.amber).toBe(2);
             expect(this.krump.amber).toBe(0);
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(0);

--- a/test/server/cards/14-DM/VastStoik.spec.js
+++ b/test/server/cards/14-DM/VastStoik.spec.js
@@ -1,0 +1,46 @@
+describe('VastStoik', function () {
+    describe("Vast Stoik's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['vast-stoik'],
+                    deck: ['troll', 'mack-the-knife']
+                },
+                player2: {
+                    inPlay: ['urchin', 'krump']
+                }
+            });
+        });
+
+        it('moves 1 amber from a creature to common supply and draws a card', function () {
+            this.urchin.amber = 2;
+            const handSize = this.player1.hand.length;
+            this.player1.fightWith(this.vastStoik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.krump);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.amber).toBe(1);
+            expect(this.krump.amber).toBe(1);
+            expect(this.player1.amber).toBe(0);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1.hand.length).toBe(handSize + 1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('any creature is selectable, including those without amber', function () {
+            this.urchin.amber = 1;
+            const handSize = this.player1.hand.length;
+            this.player1.fightWith(this.vastStoik, this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.krump);
+            this.player1.clickCard(this.krump);
+            expect(this.urchin.amber).toBe(1);
+            expect(this.krump.amber).toBe(0);
+            expect(this.player1.amber).toBe(0);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1.hand.length).toBe(handSize);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/Waspscream.spec.js
+++ b/test/server/cards/14-DM/Waspscream.spec.js
@@ -1,0 +1,39 @@
+describe('Waspscream', function () {
+    describe("Waspscream's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['waspscream']
+                },
+                player2: {
+                    inPlay: ['snufflegator', 'urchin']
+                }
+            });
+        });
+
+        it('takes control of an enemy creature at start of turn when exhausted', function () {
+            this.waspscream.exhaust();
+            this.player1.endTurn();
+            this.player1.clickPrompt('Done'); // entrench prompt
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('Left');
+            expect(this.snufflegator.controller).toBe(this.player1.player);
+            this.player1.clickPrompt('ekwidon');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not trigger when ready', function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            expect(this.player1).toHavePrompt('Choose which house you want to activate this turn');
+            this.player1.clickPrompt('ekwidon');
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});

--- a/test/server/cards/14-DM/Waspscream.spec.js
+++ b/test/server/cards/14-DM/Waspscream.spec.js
@@ -15,13 +15,25 @@ describe('Waspscream', function () {
         it('takes control of an enemy creature at start of turn when exhausted', function () {
             this.waspscream.exhaust();
             this.player1.endTurn();
-            this.player1.clickPrompt('Done'); // entrench prompt
+            this.player1.clickPrompt('Done');
             this.player2.clickPrompt('shadows');
             this.player2.endTurn();
             expect(this.player1).toHavePrompt('Choose a creature');
             this.player1.clickCard(this.snufflegator);
             this.player1.clickPrompt('Left');
             expect(this.snufflegator.controller).toBe(this.player1.player);
+            this.player1.clickPrompt('ekwidon');
+            expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player1.clickPrompt('Done');
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            expect(this.player1).toHavePrompt('Choose a creature');
+            this.player1.clickCard(this.urchin);
+            this.player1.clickPrompt('Left');
+            expect(this.snufflegator.controller).toBe(this.player1.player);
+            expect(this.urchin.controller).toBe(this.player1.player);
             this.player1.clickPrompt('ekwidon');
             expect(this.player1).isReadyToTakeAction();
         });
@@ -33,6 +45,14 @@ describe('Waspscream', function () {
             expect(this.player1).toHavePrompt('Choose which house you want to activate this turn');
             this.player1.clickPrompt('ekwidon');
             expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.player1).isReadyToTakeAction();
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.endTurn();
+            expect(this.snufflegator.controller).toBe(this.player2.player);
+            expect(this.urchin.controller).toBe(this.player2.player);
+            this.player1.clickPrompt('ekwidon');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/messages/destroy.spec.js
+++ b/test/server/messages/destroy.spec.js
@@ -73,4 +73,36 @@ describe('Destroy Messages', function () {
             ]);
         });
     });
+
+    describe('chained destroys from Harbinger of Doom with a warded creature', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'saurian',
+                    hand: ['saury-about-that'],
+                    inPlay: ['ember-imp']
+                },
+                player2: {
+                    inPlay: ['harbinger-of-doom', 'dextre', 'troll']
+                }
+            });
+            this.dextre.ward();
+        });
+
+        it('logs repeated destroy messages and ward prevention', function () {
+            this.player1.play(this.sauryAboutThat);
+            this.player1.clickCard(this.harbingerOfDoom);
+            expect(this.player1).isReadyToTakeAction();
+            expect(this).toHaveAllChatMessagesBe([
+                'player1 plays Saury About That',
+                'player1 uses Saury About That to destroy Harbinger of Doom',
+                'Harbinger of Doom is destroyed',
+                'player2 uses Harbinger of Doom to destroy Ember Imp, Dextre, and Troll',
+                'player2 uses Dextre to remove its ward token',
+                'Ember Imp is destroyed',
+                'Troll is destroyed',
+                'player2 gains 1 amber from Saury About That'
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a large batch of new card scripts with complex interactions (control-changing, forging, conditional multi-step effects) that could surface edge-case engine bugs despite being mostly additive. Includes new destruction log coverage that may reveal or require tweaks to existing destroy/ward sequencing.
> 
> **Overview**
> Implements a batch of new `14-DM` Ekwidon card behaviors (play/fight/reap/action/reaction/persistent effects), including conditional and multi-step resolutions like control swaps (`even-swap`), key-cost modification during the opponent’s next turn (`oŏni-lars`), and forging with cost reduction based on counters/amber moved (`forged-currency`).
> 
> Adds comprehensive card-level test coverage for these new behaviors and edge cases (empty selections, optional prompts, changed control/ownership), plus a new `destroy` message test to validate chained destruction logging with ward prevention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51869476a435c3008639ad2d895abef55b28e130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->