### PR TITLE
DM: add new set, new house, and new gigantics

### DIFF
--- a/client/Components/Games/GameFormats.jsx
+++ b/client/Components/Games/GameFormats.jsx
@@ -35,7 +35,8 @@ const GameFormats = ({
         { name: 'vm2024', label: t('Vault Masters 2024') },
         { name: 'vm2025', label: t('Vault Masters 2025') },
         { name: 'pv', label: t('Prophetic Visions') },
-        { name: 'cc', label: t('Crucible Clash') }
+        { name: 'cc', label: t('Crucible Clash') },
+        { name: 'dm', label: t('Draconian Measures') }
     ];
     const expansionNames = expansions.map((expansion) => expansion.name);
 

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -104,6 +104,7 @@ const NewGame = ({
                         as: values.as,
                         cc: values.cc,
                         cota: values.cota,
+                        dm: values.dm,
                         disc: values.disc,
                         dt: values.dt,
                         gr: values.gr,
@@ -175,7 +176,8 @@ const NewGame = ({
                                 !formProps.values.vm2024 &&
                                 !formProps.values.vm2025 &&
                                 !formProps.values.pv &&
-                                !formProps.values.cc
+                                !formProps.values.cc &&
+                                !formProps.values.dm
                             ) {
                                 formProps.setFieldError(
                                     'gameFormat',

--- a/client/archonMaker.js
+++ b/client/archonMaker.js
@@ -78,7 +78,13 @@ const gigantic2s = [
     'j43g3r-v2',
     'titanic-bumblebird2',
     'ascendant-hester2',
-    'horizon-saber2'
+    'horizon-saber2',
+    'the-golden-queen2',
+    'gigantor2',
+    'monster-zero2',
+    'kulsha2',
+    'zomok2',
+    'hydrogan2'
 ];
 
 const skybeasts = [

--- a/client/constants.js
+++ b/client/constants.js
@@ -17,6 +17,7 @@ export const Constants = {
         'geistoid',
         'logos',
         'mars',
+        'ouboros',
         'redemption',
         'sanctum',
         'saurian',
@@ -33,6 +34,7 @@ export const Constants = {
         'Geistoid',
         'Logos',
         'Mars',
+        'Ouboros',
         'Redemption',
         'Sanctum',
         'Saurian',
@@ -159,6 +161,13 @@ export const Constants = {
         {
             value: '918',
             label: 'CC',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            value: '928',
+            label: 'DM',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false

--- a/server/constants.js
+++ b/server/constants.js
@@ -7,6 +7,7 @@ Constants.Houses = [
     'geistoid',
     'logos',
     'mars',
+    'ouboros',
     'redemption',
     'sanctum',
     'saurian',
@@ -23,6 +24,7 @@ Constants.HousesNames = [
     'Geistoid',
     'Logos',
     'Mars',
+    'Ouboros',
     'Redemption',
     'Sanctum',
     'Saurian',
@@ -52,7 +54,8 @@ Constants.Expansions = [
         prophecySupported: false
     },
     { id: 886, label: 'PV', tideRequired: false, tokenRequired: false, prophecySupported: true },
-    { id: 918, label: 'CC', tideRequired: false, tokenRequired: false, prophecySupported: false }
+    { id: 918, label: 'CC', tideRequired: false, tokenRequired: false, prophecySupported: false },
+    { id: 928, label: 'DM', tideRequired: false, tokenRequired: false, prophecySupported: false }
 ];
 Constants.Tide = Object.freeze({
     HIGH: 'high',

--- a/server/db/schema/99 - Data.sql
+++ b/server/db/schema/99 - Data.sql
@@ -12,6 +12,7 @@ INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (11, 'ekwidon', 'Ekwid
 INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (12, 'geistoid', 'Geistoid');
 INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (13, 'skyborn', 'Skyborn');
 INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (14, 'redemption', 'Redemption');
+INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (15, 'ouboros', 'Ouboros');
 -- Leave these last
 INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (997, 'archonpower', 'Archon Power');
 INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (998, 'prophecy', 'Prophecy');
@@ -21,7 +22,7 @@ INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (999, 'thetide', 'The 
 -- Name: Houses_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: keyteki
 --
 
-SELECT pg_catalog.setval('public."Houses_Id_seq"', 9, true);
+SELECT pg_catalog.setval('public."Houses_Id_seq"', 15, true);
 
 INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (1, 453, 'WC', 'Worlds Collide (Anomoly)');
 INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (2, 452, 'WC', 'Worlds Collide');
@@ -41,12 +42,13 @@ INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (15
 INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (16, 939, 'VM2025', 'Vault Masters 2025');
 INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (17, 886, 'PV', 'Prophetic Visions');
 INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (18, 918, 'CC', 'Crucible Clash');
+INSERT INTO public."Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (19, 928, 'DM', 'Draconian Measures');
 
 --
 -- Name: Expansions_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: keyteki
 --
 
-SELECT pg_catalog.setval('public."Expansions_Id_seq"', 4, true);
+SELECT pg_catalog.setval('public."Expansions_Id_seq"', 19, true);
 
 INSERT INTO public."Roles" ("Id", "Name") VALUES (1, 'UserManager');
 INSERT INTO public."Roles" ("Id", "Name") VALUES (2, 'BanListManager');

--- a/server/db/schema/migrations/20 - DM.sql
+++ b/server/db/schema/migrations/20 - DM.sql
@@ -1,0 +1,2 @@
+INSERT INTO public."Houses" ("Id", "Code", "Name") VALUES (15, 'ouboros', 'Ouboros');
+INSERT INTO "Expansions" ("Id", "ExpansionId", "Code", "Name") VALUES (19, 928, 'DM', 'Draconian Measures')

--- a/server/scripts/fetchdata/CardImport.js
+++ b/server/scripts/fetchdata/CardImport.js
@@ -137,7 +137,13 @@ class CardImport {
             'j43g3r-v',
             'titanic-bumblebird',
             'ascendant-hester',
-            'horizon-saber'
+            'horizon-saber',
+            'the-golden-queen',
+            'gigantor',
+            'monster-zero',
+            'kulsha',
+            'zomok',
+            'hydrogan'
         ];
         const skipMkdir = {};
 

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -298,6 +298,10 @@ class DeckService {
             dbExpansions.push(918);
         }
 
+        if (expansions.dm) {
+            dbExpansions.push(928);
+        }
+
         let deck;
         let expansionStr = dbExpansions.join(',');
         try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared constants and DB seed/migrations for houses/expansions and updates sealed deck selection logic; incorrect IDs or missing data could break deck import/sealed game creation across the app.
> 
> **Overview**
> Adds support for the new **Draconian Measures (DM)** set end-to-end: it becomes selectable in the sealed/new-game UI and is included in the expansions payload/validation.
> 
> Updates client/server constants and DB seed/migration data to register the new `DM` expansion (`928`) and the new house `ouboros`/"Ouboros".
> 
> Extends deck tooling and import/image pipelines by adding newly supported gigantic card IDs, and updates `DeckService.getSealedDeck` to allow sealed deck selection from `DM`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42803a1489a806c8371c72ab2f40df0f7e0ba79f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->