### PR TITLE
DM: anomaly fixes and house icon CSS

### DIFF
--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -1611,6 +1611,10 @@ pre {
   background-image: url("assets/img/house/geistoid.png");
 }
 
+.icon-ouboros {
+  background-image: url("assets/img/house/ouboros.png");
+}
+
 .icon-skyborn {
   background-image: url("assets/img/house/skyborn.png");
 }

--- a/server/scripts/fetchdata/CardImport.js
+++ b/server/scripts/fetchdata/CardImport.js
@@ -120,6 +120,10 @@ class CardImport {
                 'citizen-shrix': true,
                 'even-ivan': true,
                 'odd-clawde': true
+            },
+            928: {
+                ignitus: true,
+                'nizak-the-forgotten': true
             }
         };
 

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -1287,7 +1287,9 @@ class DeckService {
 
         let anomalies = {
             'ecto-charge': { anomalySet: 600, house: 'geistoid' },
+            ignitus: { anomalySet: 939, house: 'ouboros' },
             'near-future-lens': { anomalySet: 600, house: 'staralliance' },
+            'nizak-the-forgotten': { anomalySet: 453, house: 'ouboros' },
             'orb-of-wonder': { anomalySet: 453, house: 'sanctum' },
             'the-grim-reaper': { anomalySet: 453, house: 'geistoid' },
             'the-red-baron': { anomalySet: 453, house: 'skyborn' },
@@ -1385,7 +1387,8 @@ class DeckService {
             }
 
             if (anomalies[id] && anomalies[id].anomalySet !== card.expansion) {
-                // anomaly cards' real house
+                // Former anomaly cards use their printed house in regular sets.
+                delete retCard.anomaly;
                 retCard.house = anomalies[id].house;
                 retCard.image = `${retCard.id}-${retCard.house}`;
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized changes to CSS and deck/card import mapping; main risk is mislabeling house/image for affected cards if IDs/expansion numbers are wrong.
> 
> **Overview**
> Adds an `.icon-ouboros` CSS rule so the client can render the OuBorOS house icon.
> 
> Updates server-side card/deck ingestion to treat `ignitus` and `nizak-the-forgotten` as former anomaly cards when appearing in expansion `928`, ensuring the correct house/image is used and clearing the anomaly flag when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2778723ee93700d77dde6c3d877d0db6226c4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->