### PR TITLE
DM: card translation data

### DIFF
--- a/server/game/cards/14-DM/LuisCompere.js
+++ b/server/game/cards/14-DM/LuisCompere.js
@@ -62,6 +62,6 @@ class LuisCompere extends Card {
     }
 }
 
-LuisCompere.id = 'luis-compere';
+LuisCompere.id = 'luis-compère';
 
 module.exports = LuisCompere;

--- a/test/server/cards/14-DM/LuisCompere.spec.js
+++ b/test/server/cards/14-DM/LuisCompere.spec.js
@@ -4,7 +4,7 @@ describe('Luis Compere', function () {
             this.setupTest({
                 player1: {
                     house: 'shadows',
-                    inPlay: ['luis-compere']
+                    inPlay: ['luis-compère']
                 },
                 player2: {
                     amber: 5
@@ -54,7 +54,7 @@ describe('Luis Compere', function () {
             this.setupTest({
                 player1: {
                     house: 'shadows',
-                    inPlay: ['luis-compere']
+                    inPlay: ['luis-compère']
                 },
                 player2: {
                     amber: 3,
@@ -67,7 +67,7 @@ describe('Luis Compere', function () {
         });
 
         it('can resolve Luis Compere first, then Malifi Dragon', function () {
-            this.player2.clickCard(this.luisCompere);
+            this.player2.clickCard(this.luisCompère);
             this.player1.clickPrompt('shadows');
             expect(this.player1.amber).toBe(2);
             expect(this.player2.amber).toBe(3);
@@ -89,7 +89,7 @@ describe('Luis Compere', function () {
                 player1: {
                     house: 'shadows',
                     inPlay: [
-                        'luis-compere',
+                        'luis-compère',
                         'ven-omawk',
                         'ven-omawk',
                         'ven-omawk',
@@ -123,7 +123,7 @@ describe('Luis Compere', function () {
             this.setupTest({
                 player1: {
                     house: 'shadows',
-                    inPlay: ['luis-compere']
+                    inPlay: ['luis-compère']
                 },
                 player2: {
                     amber: 5,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk string identifier change, but it may affect any decklists/save data or lookups still referencing the old `luis-compere` id.
> 
> **Overview**
> Updates the `LuisCompere` card identifier from `luis-compere` to `luis-compère` and adjusts all related card tests to reference the new id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07be330e51fa933c80ad66c5fc9e6df5c4431266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->