### PR TITLE
fix: resolve infinite loop between Blossom Drake and De-Animator (#4986)

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -81,13 +81,84 @@ class EffectEngine {
             (stateChanged, effect) => effect.checkCondition(stateChanged),
             stateChanged
         );
+        // Record a snapshot of each effect's current target set so we can detect
+        // persistent effects whose target set is oscillating between passes
+        // (the signature of an infinite loop between two card abilities).
+        this.recordTargetSnapshots();
         if (loops === 10) {
-            throw new Error('EffectEngine.checkEffects looped 10 times');
+            // Per the rules, an infinite loop is resolved by removing the
+            // affected card from play to its owner's discard pile (it is not
+            // considered destroyed). Detect the oscillating effect(s) and
+            // discard their source(s) to settle game state.
+            const removed = this.resolveInfiniteLoop();
+            if (!removed) {
+                throw new Error('EffectEngine.checkEffects looped 10 times');
+            }
+            this.newEffect = true;
+            return true;
         } else {
             this.checkEffects(stateChanged, loops + 1);
         }
 
         return stateChanged;
+    }
+
+    recordTargetSnapshots() {
+        for (const effect of this.effects) {
+            if (effect.duration !== 'persistentEffect') {
+                continue;
+            }
+            const snapshot = effect.targets
+                .map((t) => (t && t.uuid) || '')
+                .sort()
+                .join('|');
+            if (!effect._targetHistory) {
+                effect._targetHistory = [];
+            }
+            effect._targetHistory.push(snapshot);
+            if (effect._targetHistory.length > 4) {
+                effect._targetHistory.shift();
+            }
+        }
+    }
+
+    resolveInfiniteLoop() {
+        // An effect is "oscillating" if its target set in the last 4 passes
+        // alternates between two distinct states (A, B, A, B).
+        const oscillating = this.effects.filter((effect) => {
+            const history = effect._targetHistory;
+            if (!history || history.length < 4) {
+                return false;
+            }
+            const [a, b, c, d] = history.slice(-4);
+            return a !== b && a === c && b === d;
+        });
+
+        const sourcesToDiscard = new Set();
+        for (const effect of oscillating) {
+            const source = effect.source;
+            if (source && source.location === 'play area' && source.owner) {
+                sourcesToDiscard.add(source);
+            }
+        }
+
+        if (sourcesToDiscard.size === 0) {
+            return false;
+        }
+
+        for (const source of sourcesToDiscard) {
+            this.game.addMessage(
+                '{0} is removed from play and placed in its owner’s discard pile to resolve an infinite loop',
+                source
+            );
+            source.owner.moveCard(source, 'discard');
+        }
+
+        // Reset history so subsequent checks start fresh.
+        for (const effect of this.effects) {
+            effect._targetHistory = [];
+        }
+        return true;
     }
 
     onPhaseEnd() {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -148,7 +148,7 @@ class EffectEngine {
 
         for (const source of sourcesToDiscard) {
             this.game.addMessage(
-                '{0} is removed from play and placed in its owner’s discard pile to resolve an infinite loop',
+                "{0} is removed from play and placed in its owner's discard pile to resolve an infinite loop",
                 source
             );
             source.owner.moveCard(source, 'discard');

--- a/test/server/cards/08-AS/DeAnimator.spec.js
+++ b/test/server/cards/08-AS/DeAnimator.spec.js
@@ -242,4 +242,61 @@ describe('De-Animator', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe('De-Animator with Blossom Drake', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'logos',
+                    hand: ['de-animator']
+                },
+                player2: {
+                    inPlay: ['blossom-drake', 'troll']
+                }
+            });
+        });
+
+        // De-Animator mineralizing itself loops: De-Animator's own persistent
+        // effect is what makes it an artifact, but Blossom Drake then blanks
+        // it, suppressing that very effect — which restores it, etc.
+        it('removes De-Animator from play when it mineralizes itself', function () {
+            this.player1.playCreature(this.deAnimator);
+            this.player1.clickCard(this.deAnimator);
+            while (
+                this.player1.currentPrompt() &&
+                this.player1.currentPrompt().menuTitle ===
+                    'Which flank do you want to move this creature to?'
+            ) {
+                this.player1.clickPrompt('Left');
+            }
+            expect(this.deAnimator.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        // De-Animator changes Blossom Drake's type to artifact,
+        // which causes Blossom Drake's persistent effect to blank itself, which
+        // removes the blank, which restores it, etc.
+        it('removes Blossom Drake from play when De-Animator mineralizes it', function () {
+            this.player1.playCreature(this.deAnimator);
+            this.player1.clickCard(this.blossomDrake);
+            expect(this.blossomDrake.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        // Mineralizing another creature in the presence of Blossom Drake does
+        // not loop: De-Animator's effect on the mineralized card persists even
+        // after Blossom Drake blanks it, which only suppresses the card's
+        // own abilities. The blanked card is an artifact but lacks the granted
+        // "Action: Destroy" ability.
+        it('does not loop when mineralizing a non-Blossom-Drake creature', function () {
+            this.player1.playCreature(this.deAnimator);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('play area');
+            expect(this.troll.type).toBe('artifact');
+            expect(this.troll.isBlank()).toBe(true);
+            expect(this.troll.actions).toEqual([]);
+            expect(this.blossomDrake.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
Fixes #4986

When Blossom Drake and De-Animator are in play together, their persistent effects can oscillate indefinitely, causing the effect engine to loop without resolving.

## Changes

- **`server/game/effectengine.js`**: Detect oscillating persistent effects (A→B→A→B target-set pattern) after 10 passes. When detected, discard the source card(s) to their owner's discard pile per the rules for resolving infinite loops, rather than throwing an unhandled error.
- **`test/server/cards/08-AS/DeAnimator.spec.js`**: Tests covering the infinite-loop scenario and the discard resolution.
- **`keyteki-json-data`**: Submodule bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `EffectEngine.checkEffects` loop-handling to mutate game state (discarding cards) instead of erroring, which could impact other persistent-effect interactions if the oscillation heuristic misfires.
> 
> **Overview**
> Resolves persistent-effect infinite loops by tracking recent target-set snapshots for each `persistentEffect` and, after 10 evaluation passes, detecting A/B/A/B oscillations.
> 
> When such an oscillation is found, the engine now removes the source card(s) from play by moving them to their owner’s discard pile (with a game message) and resets effect history, rather than throwing an unhandled loop error.
> 
> Adds De-Animator/Blossom Drake regression tests covering both looping cases (self-mineralize and mineralizing Blossom Drake) and a non-looping control case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d5b2947090d9f13cee1995b066e3ed798d61be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->