### PR TITLE
DM: Lateral Shift and Timequake are no longer anomalies

### DIFF
--- a/server/scripts/fetchdata/CardImport.js
+++ b/server/scripts/fetchdata/CardImport.js
@@ -123,7 +123,9 @@ class CardImport {
             },
             928: {
                 ignitus: true,
-                'nizak-the-forgotten': true
+                'nizak-the-forgotten': true,
+                'lateral-shift': true,
+                timequake: true
             }
         };
 

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -1286,16 +1286,16 @@ class DeckService {
         };
 
         let anomalies = {
-            'ecto-charge': { anomalySet: 600, house: 'geistoid' },
-            ignitus: { anomalySet: 939, house: 'ouboros' },
-            'lateral-shift': { anomalySet: 453, house: 'unfathomable' },
-            'near-future-lens': { anomalySet: 600, house: 'staralliance' },
-            'nizak-the-forgotten': { anomalySet: 453, house: 'ouboros' },
-            'orb-of-wonder': { anomalySet: 453, house: 'sanctum' },
-            timequake: { anomalySet: 453, house: 'ouboros' },
-            'the-grim-reaper': { anomalySet: 453, house: 'geistoid' },
-            'the-red-baron': { anomalySet: 453, house: 'skyborn' },
-            valoocanth: { anomalySet: 453, house: 'unfathomable' }
+            'ecto-charge': { anomalySets: [600], house: 'geistoid' },
+            ignitus: { anomalySets: [939], house: 'ouboros' },
+            'lateral-shift': { anomalySets: [452, 453, 600, 886], house: 'unfathomable' },
+            'near-future-lens': { anomalySets: [600], house: 'staralliance' },
+            'nizak-the-forgotten': { anomalySets: [452, 453, 600, 886, 939], house: 'ouboros' },
+            'orb-of-wonder': { anomalySets: [453], house: 'sanctum' },
+            timequake: { anomalySets: [452, 453, 600, 886, 939], house: 'ouboros' },
+            'the-grim-reaper': { anomalySets: [453], house: 'geistoid' },
+            'the-red-baron': { anomalySets: [453], house: 'skyborn' },
+            valoocanth: { anomalySets: [453], house: 'unfathomable' }
         };
 
         let deckCards = deckResponse._linked.cards;
@@ -1388,7 +1388,7 @@ class DeckService {
                 retCard.image = `${retCard.id}-${retCard.house}`;
             }
 
-            if (anomalies[id] && anomalies[id].anomalySet !== card.expansion) {
+            if (anomalies[id] && !anomalies[id].anomalySets.includes(card.expansion)) {
                 // Former anomaly cards use their printed house in regular sets.
                 delete retCard.anomaly;
                 retCard.house = anomalies[id].house;

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -1288,9 +1288,11 @@ class DeckService {
         let anomalies = {
             'ecto-charge': { anomalySet: 600, house: 'geistoid' },
             ignitus: { anomalySet: 939, house: 'ouboros' },
+            'lateral-shift': { anomalySet: 453, house: 'unfathomable' },
             'near-future-lens': { anomalySet: 600, house: 'staralliance' },
             'nizak-the-forgotten': { anomalySet: 453, house: 'ouboros' },
             'orb-of-wonder': { anomalySet: 453, house: 'sanctum' },
+            timequake: { anomalySet: 453, house: 'ouboros' },
             'the-grim-reaper': { anomalySet: 453, house: 'geistoid' },
             'the-red-baron': { anomalySet: 453, house: 'skyborn' },
             valoocanth: { anomalySet: 453, house: 'unfathomable' }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates anomaly handling during deck import and image fetching, which can affect card house/image assignment across multiple expansions. Risk is moderate because incorrect set lists could misclassify anomaly status and break imported deck data/display for these cards.
> 
> **Overview**
> Adjusts handling of former anomaly cards so anomaly status is determined against a *list* of valid anomaly expansions rather than a single `anomalySet`.
> 
> Adds `lateral-shift` and `timequake` to the special-case image list for expansion `928`, and updates `DeckService.parseDeckResponse` to treat `lateral-shift`, `timequake`, and `nizak-the-forgotten` as anomalies only in specific expansions (via `anomalySets`), ensuring their printed house/image is used when they appear outside those anomaly sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba801ff27af3b7115714492d8153c7516785982f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->