### PR TITLE
fix: guard effectArgs against undefined context.target with optional chaining

### DIFF
--- a/docs/card-messages.md
+++ b/docs/card-messages.md
@@ -90,6 +90,21 @@ The values map to placeholders as follows:
 -   `{2}` - Second value in effectArgs array
 -   `{3}`, `{4}`, etc. - Continue in order
 
+> **Guard against undefined `context.target`.** Unlike `gameAction` factories — which the framework only invokes when there is a legal target — `effectArgs` is evaluated unconditionally to produce the chat message, even when no target was chosen (optional targets, no legal targets in play, etc.). Dereferencing `context.target.X` directly will crash with `TypeError: Cannot read properties of undefined`. Use optional chaining and a sensible fallback so the args array shape stays stable:
+>
+> ```javascript
+> // Bad - crashes when target is undefined
+> effectArgs: (context) => [context.target.amber];
+>
+> // Good - returns [0] when target is undefined
+> effectArgs: (context) => [context.target?.amber ?? 0];
+>
+> // Good - returns [[]] when target is undefined (array placeholders)
+> effectArgs: (context) => [context.target?.neighbors.concat(context.target) ?? []];
+> ```
+>
+> Pick the fallback to match the placeholder's role: `?? 0` for numeric/`.length` slots, `?? []` for array slots, omit entirely for slots that just print a card/player name (`undefined` renders fine there).
+
 ```javascript
 // Output: "{player1} uses Effervescent Principle to gain 1 chain and make {player1} lose 3 amber and {player2} lose 2 amber"
 this.play({
@@ -369,7 +384,7 @@ this.reap({
     }))
   },
   effect: 'move all {2} amber from {0} to their pool and give control of {0} to {1}',
-  effectArgs: (context) =} [context.player.opponent, context.target.tokens.amber || 0]
+  effectArgs: (context) =} [context.player.opponent, context.target?.amber ?? 0]
   // ...
 });
 ```

--- a/server/game/cards/02-AoA/TheFlex.js
+++ b/server/game/cards/02-AoA/TheFlex.js
@@ -5,7 +5,7 @@ class TheFlex extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'exhaust {1} and gain {2} amber',
-            effectArgs: (context) => [context.target, Math.floor(context.target.power / 2)],
+            effectArgs: (context) => [context.target, Math.floor((context.target?.power ?? 0) / 2)],
             target: {
                 cardType: 'creature',
                 controller: 'self',

--- a/server/game/cards/03-WC/ThoriumPlasmate.js
+++ b/server/game/cards/03-WC/ThoriumPlasmate.js
@@ -5,7 +5,7 @@ class ThoriumPlasmate extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: "move {1} on {2}'s battleline and deal 2 damage to it for each neighbor that shares a house with it",
-            effectArgs: (context) => [context.target, context.target.controller],
+            effectArgs: (context) => [context.target, context.target?.controller],
             target: {
                 cardType: 'creature',
                 controller: 'opponent',

--- a/server/game/cards/04-MM/Humble.js
+++ b/server/game/cards/04-MM/Humble.js
@@ -5,7 +5,7 @@ class Humble extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'to exhaust {0} and move {1} amber from {0} to common supply',
-            effectArgs: (context) => [context.target.amber],
+            effectArgs: (context) => [context.target?.amber ?? 0],
             target: {
                 controller: 'any',
                 cardType: 'creature',

--- a/server/game/cards/05-DT/BlatantThievery.js
+++ b/server/game/cards/05-DT/BlatantThievery.js
@@ -10,7 +10,7 @@ class BlatantThievery extends Card {
                 gameAction: ability.actions.enrage()
             },
             effect: 'enrage {1} and move all {2} amber from {1} to their pool',
-            effectArgs: (context) => [context.target, context.target.amber],
+            effectArgs: (context) => [context.target, context.target?.amber ?? 0],
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.removeAmber((context) => ({

--- a/server/game/cards/06-WoE/AuctionOff.js
+++ b/server/game/cards/06-WoE/AuctionOff.js
@@ -5,7 +5,7 @@ class AuctionOff extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'purge {0} and have {1} gain 1 amber',
-            effectArgs: (context) => [context.target.controller],
+            effectArgs: (context) => [context.target?.controller],
             target: {
                 cardType: 'artifact',
                 location: 'play area',

--- a/server/game/cards/06-WoE/ShakedownSullivan.js
+++ b/server/game/cards/06-WoE/ShakedownSullivan.js
@@ -16,7 +16,7 @@ class ShakedownSullivan extends Card {
                 }))
             },
             effect: 'choose {1} and discard {2}',
-            effectArgs: (context) => [context.target, context.target.controller.deck[0]],
+            effectArgs: (context) => [context.target, context.target?.controller.deck[0]],
             then: (preThenContext) => ({
                 alwaysTriggers: true,
                 gameAction: ability.actions.conditional((context) => ({

--- a/server/game/cards/07-GR/Azuretooth.js
+++ b/server/game/cards/07-GR/Azuretooth.js
@@ -15,7 +15,7 @@ class Azuretooth extends Card {
                 }))
             },
             effect: 'move all {2} amber from {0} to their pool and give control of {0} to {1}',
-            effectArgs: (context) => [context.player.opponent, context.target.amber],
+            effectArgs: (context) => [context.player.opponent, context.target?.amber ?? 0],
             then: (preThenContext) => ({
                 alwaysTriggers: true,
                 condition: (context) => !!context.player.opponent,

--- a/server/game/cards/07-GR/BondedAuctioneer.js
+++ b/server/game/cards/07-GR/BondedAuctioneer.js
@@ -7,7 +7,7 @@ class BondedAuctioneer extends Card {
     setupCardAbilities(ability) {
         this.reap({
             effect: 'destroy {0} and have {1} gain 1 amber',
-            effectArgs: (context) => [context.target.controller],
+            effectArgs: (context) => [context.target?.controller],
             target: {
                 cardType: 'artifact',
                 location: 'play area',

--- a/server/game/cards/07-GR/CacophonousRiot.js
+++ b/server/game/cards/07-GR/CacophonousRiot.js
@@ -16,7 +16,7 @@ class CacophonousRiot extends Card {
                 ])
             },
             effect: 'ready and enrage {1}',
-            effectArgs: (context) => [context.target.neighbors.concat(context.target)]
+            effectArgs: (context) => [context.target?.neighbors.concat(context.target) ?? []]
         });
     }
 }

--- a/server/game/cards/07-GR/SecurityDetail.js
+++ b/server/game/cards/07-GR/SecurityDetail.js
@@ -12,7 +12,7 @@ class SecurityDetail extends Card {
                 }))
             },
             effect: 'capture 1 amber onto {1}',
-            effectArgs: (context) => [context.target.neighbors.concat(context.target)]
+            effectArgs: (context) => [context.target?.neighbors.concat(context.target) ?? []]
         });
     }
 }

--- a/server/game/cards/08-AS/CrepuscularRays.js
+++ b/server/game/cards/08-AS/CrepuscularRays.js
@@ -17,7 +17,7 @@ class CrepuscularRays extends Card {
                 ]
             },
             effect: 'to move all {1} amber from {0} to their pool and destroy {0}',
-            effectArgs: (context) => [context.target.amber]
+            effectArgs: (context) => [context.target?.amber ?? 0]
         });
     }
 }

--- a/server/game/cards/09-ToC/Savant.js
+++ b/server/game/cards/09-ToC/Savant.js
@@ -18,7 +18,7 @@ class Savant extends Card {
                 })
             },
             effect: 'put a card into their {1}',
-            effectArgs: (context) => [context.target.location === 'archives' ? 'hand' : 'archives']
+            effectArgs: (context) => [context.target?.location === 'archives' ? 'hand' : 'archives']
         });
     }
 }


### PR DESCRIPTION
## Summary

Use optional chaining (`?.`) and nullish coalescing (`?? 0` / `?? []`) in `effectArgs` callbacks to prevent crashes when `context.target` is undefined (e.g. optional targets, no legal targets in play).

## Cards fixed

- TheFlex, ThoriumPlasmate, Humble, BlatantThievery
- AuctionOff, ShakedownSullivan
- Azuretooth, BondedAuctioneer, CacophonousRiot, SecurityDetail
- CrepuscularRays, Savant

## Docs

Added a note to `docs/card-messages.md` documenting the pattern and when to use each fallback (`?? 0`, `?? []`, or none).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how chat message arguments are computed, adding null-safe access and fallbacks; gameplay actions are largely unchanged but messaging could show 0/empty values when no target exists.
> 
> **Overview**
> Prevents runtime `TypeError` crashes in card log message generation by updating multiple cards’ `effectArgs` callbacks to tolerate missing `context.target` via optional chaining and sensible defaults (`?? 0` / `?? []`).
> 
> Updates `docs/card-messages.md` to document that `effectArgs` is evaluated even when no legal/selected target exists and shows the recommended guard patterns and fallback selection guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05e4d844e6cf36e9376fb82107d7bc98711e857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->