### PR TITLE
DM: fix deploy keyword on Monster Zero's top half

### DIFF
--- a/server/game/BaseActions/PlayCreatureAction.js
+++ b/server/game/BaseActions/PlayCreatureAction.js
@@ -25,7 +25,11 @@ class PlayCreatureAction extends BasePlayAction {
     }
 
     executeHandler(context) {
-        if (context.source.gigantic && !context.source.composedPart) {
+        if (
+            context.source.gigantic &&
+            !context.source.composedPart &&
+            context.source.location === 'hand'
+        ) {
             const parts = context.source.controller
                 .getSourceList(context.source.location)
                 .filter((part) => context.source.compositeId === part.id);

--- a/server/game/BaseActions/PlayCreatureAction.js
+++ b/server/game/BaseActions/PlayCreatureAction.js
@@ -25,12 +25,12 @@ class PlayCreatureAction extends BasePlayAction {
     }
 
     executeHandler(context) {
-        if (context.source.giganticBottom && !context.source.composedPart) {
-            let parts = context.source.controller
+        if (context.source.gigantic && !context.source.composedPart) {
+            const parts = context.source.controller
                 .getSourceList(context.source.location)
                 .filter((part) => context.source.compositeId === part.id);
 
-            if (parts.length > 1) {
+            if (context.source.giganticBottom && parts.length > 1) {
                 // if there are two gigantic top parts, it could be relevant to choose among them
                 // if they have different enhancements
                 context.game.promptForSelect(context.game.activePlayer, {
@@ -46,6 +46,9 @@ class PlayCreatureAction extends BasePlayAction {
                     }
                 });
             } else {
+                if (parts.length > 0) {
+                    context.source.composedPart = parts[0];
+                }
                 super.executeHandler(context);
             }
         } else {

--- a/server/game/GiganticCard.js
+++ b/server/game/GiganticCard.js
@@ -52,22 +52,6 @@ class GiganticCard extends Card {
         return powerPrinted;
     }
 
-    getKeywordValue(keyword) {
-        const value = super.getKeywordValue(keyword);
-        const normalizedKeyword = keyword.toLowerCase();
-
-        if (
-            this.giganticBottom ||
-            this.composedPart ||
-            this.getEffects('removeKeyword').includes(normalizedKeyword)
-        ) {
-            return value;
-        }
-
-        const bottomCard = this.controller.allCards.find((card) => card.id === this.compositeId);
-        return value + (bottomCard ? bottomCard.printedKeywords[normalizedKeyword] || 0 : 0);
-    }
-
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',

--- a/server/game/GiganticCard.js
+++ b/server/game/GiganticCard.js
@@ -52,6 +52,22 @@ class GiganticCard extends Card {
         return powerPrinted;
     }
 
+    getKeywordValue(keyword) {
+        const value = super.getKeywordValue(keyword);
+        const normalizedKeyword = keyword.toLowerCase();
+
+        if (
+            this.giganticBottom ||
+            this.composedPart ||
+            this.getEffects('removeKeyword').includes(normalizedKeyword)
+        ) {
+            return value;
+        }
+
+        const bottomCard = this.controller.allCards.find((card) => card.id === this.compositeId);
+        return value + (bottomCard ? bottomCard.printedKeywords[normalizedKeyword] || 0 : 0);
+    }
+
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',

--- a/test/server/cards/14-DM/MonsterZero.spec.js
+++ b/test/server/cards/14-DM/MonsterZero.spec.js
@@ -1,4 +1,31 @@
 describe('Monster Zero', function () {
+    describe("Monster Zero's deploy keyword", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['monster-zero', 'monster-zero2'],
+                    inPlay: ['troll', 'urchin']
+                },
+                player2: {}
+            });
+        });
+
+        it('can deploy when played by clicking the bottom half', function () {
+            this.player1.clickCard(this.monsterZero);
+            this.player1.clickPrompt('Play this creature');
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+        });
+
+        it('can deploy when played by clicking the top half', function () {
+            this.player1.clickCard(this.monsterZero2);
+            this.player1.clickPrompt('Play this creature');
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+        });
+    });
+
     describe("Monster Zero's persistent effect", function () {
         beforeEach(function () {
             this.setupTest({


### PR DESCRIPTION
Closes: #5006

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core creature-play logic for all gigantic cards, which could affect how other gigantic creatures choose/attach their counterpart when played from hand.
> 
> **Overview**
> Fixes playing *gigantic* creatures so that clicking either half in hand correctly sets `composedPart` before resolving the play, ensuring keywords like **Deploy** are available on the top half as well.
> 
> Keeps the existing selection prompt when the bottom half is played and multiple matching top halves are in hand, and adds regression tests for Monster Zero confirming deploy prompts appear whether the top or bottom half is clicked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd532bd417790daeba2aa2e1e2d890f511abde4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->