### PR TITLE
fix: DM card fixes, engine improvements, and expanded tests

### DIFF
--- a/config/test.json5
+++ b/config/test.json5
@@ -1,0 +1,6 @@
+// Empty config for NODE_ENV=test. Tests use the default config; this file
+// only exists to silence node-config's "did not match any deployment config
+// file names" warning that pollutes the test output.
+{
+    env: 'test'
+}

--- a/docs/card-abilities.md
+++ b/docs/card-abilities.md
@@ -295,6 +295,20 @@ this.reaction({
 });
 ```
 
+#### `autoResolve` option
+
+Set `autoResolve: true` on a `reaction()` or `interrupt()` when the ability should not prompt the player to pick an order **among multiple instances of the same ability** firing simultaneously. The engine will auto-resolve consecutive choices that all come from the same ability, then return to normal prompting for any other queued triggers. This is appropriate for triggers whose individual resolutions are independent and whose order is irrelevant to the outcome (e.g. each instance hits a different mandatory target).
+
+```javascript
+this.reaction({
+    when: { onTurnEnded: (event, context) => event.player === context.player.opponent },
+    autoResolve: true,
+    gameAction: ability.actions.discardTopOfDeck()
+});
+```
+
+`autoResolve` does **not** override the player's `orderForcedAbilities` option for choices between _different_ abilities — it only collapses the same-ability prompt.
+
 ### interrupt()
 
 Abilities that trigger before an event resolves, potentially modifying or preventing it.
@@ -528,3 +542,55 @@ The `then` block supports:
 -   `alwaysTriggers: true` - The "then" effect triggers even if the main effect didn't fully resolve
 -   `condition` - Additional condition for the "then" effect
 -   `may` - Prompt text if the player can choose whether to do the "then" effect
+
+#### "If you do" Clauses
+
+When card text says "If you do, ...", the follow-up effect must trigger **only if the preceding effect actually happened**. By default, a `then` block is already gated by whether the prior `gameAction`'s events resolved uncancelled, so simple cases work automatically:
+
+```javascript
+// Sacrifice this artifact. If you do, gain 2A.
+this.omni({
+    gameAction: ability.actions.sacrifice(),
+    then: {
+        gameAction: ability.actions.gainAmber({ amount: 2 })
+    }
+});
+```
+
+For chained "If you do" clauses (e.g. "Capture 2A. You may discard a card. If you do, ..."), each clause's condition must verify what really happened, not the final card state. Common pitfalls:
+
+-   **Don't infer success from card state.** `source.hasToken('amber')` is true even if amber was already on the card before the ability resolved — it does not prove a capture succeeded this turn.
+-   **Inspect `preThenEvents` for the actual events.** Each event has a `name` and result fields (e.g. `amount` for `onCapture`). Use these to confirm the effect occurred at the required magnitude.
+-   **Check optional target selection with `!!preThenContext.target`.** When `target.optional` is true, `target` is empty/falsy if the player declined.
+
+```javascript
+// After Reap: Capture 2A. You may discard a card.
+// If you do, move 1A from this creature to your pool.
+this.reap({
+    gameAction: ability.actions.capture({ amount: 2 }),
+    then: {
+        alwaysTriggers: true,
+        target: {
+            optional: true,
+            location: 'hand',
+            controller: 'self',
+            gameAction: ability.actions.discard()
+        },
+        then: (preThenContext) => ({
+            condition: () =>
+                // Both clauses of "If you do" must be satisfied:
+                !!preThenContext.target && // a card was actually discarded
+                preThenContext.preThenEvents.some(
+                    (event) => event.name === 'onCapture' && event.amount === 2
+                ), // and the capture was the full 2 amber
+            gameAction: ability.actions.returnAmber({
+                target: preThenContext.source,
+                amount: 1,
+                recipient: preThenContext.player
+            })
+        })
+    }
+});
+```
+
+Note that `alwaysTriggers: true` is needed on the outer `then` so the optional-discard prompt still appears even when the capture event was cancelled or partial — but the inner `then`'s `condition` then ensures the final effect is gated correctly.

--- a/server/game/BaseActions/PlayCreatureAction.js
+++ b/server/game/BaseActions/PlayCreatureAction.js
@@ -25,12 +25,16 @@ class PlayCreatureAction extends BasePlayAction {
     }
 
     executeHandler(context) {
-        if (context.source.giganticBottom && !context.source.composedPart) {
-            let parts = context.source.controller
+        if (
+            context.source.gigantic &&
+            !context.source.composedPart &&
+            context.source.location === 'hand'
+        ) {
+            const parts = context.source.controller
                 .getSourceList(context.source.location)
                 .filter((part) => context.source.compositeId === part.id);
 
-            if (parts.length > 1) {
+            if (context.source.giganticBottom && parts.length > 1) {
                 // if there are two gigantic top parts, it could be relevant to choose among them
                 // if they have different enhancements
                 context.game.promptForSelect(context.game.activePlayer, {
@@ -46,6 +50,9 @@ class PlayCreatureAction extends BasePlayAction {
                     }
                 });
             } else {
+                if (parts.length > 0) {
+                    context.source.composedPart = parts[0];
+                }
                 super.executeHandler(context);
             }
         } else {

--- a/server/game/GameActions/PutIntoPlayAction.js
+++ b/server/game/GameActions/PutIntoPlayAction.js
@@ -36,8 +36,19 @@ class PutIntoPlayAction extends CardGameAction {
 
     // Gigantic creatures require 2 play allowances to play both halves.
     // Playing from hand always provides enough allowance.
-    canPutIntoPlayGigantic(context, card) {
+    canPutIntoPlayGigantic(_, card) {
         return card.location === 'hand' || this.numPlayAllowances >= 2;
+    }
+
+    // Returns whether the other half of a gigantic creature has the given
+    // printed keyword. Used during preEventHandler when composedPart isn't
+    // wired up yet, so card.hasKeyword() can't see the shared keyword.
+    giganticOtherHalfHasKeyword(card, keyword) {
+        if (!card.gigantic || !card.controller) {
+            return false;
+        }
+        const otherHalf = card.controller.allCards.find((c) => c.id === card.compositeId);
+        return !!(otherHalf && otherHalf.printedKeywords[keyword]);
     }
 
     preEventHandler(context) {
@@ -92,7 +103,8 @@ class PutIntoPlayAction extends CardGameAction {
             if (
                 (card.anyEffect('enterPlayAnywhere', context) ||
                     this.deploy ||
-                    card.hasKeyword('deploy')) &&
+                    card.hasKeyword('deploy') ||
+                    this.giganticOtherHalfHasKeyword(card, 'deploy')) &&
                 player.creaturesInPlay.length > 1
             ) {
                 choices.push('Deploy Left');

--- a/server/game/cards/05-DT/GeneralSherman.js
+++ b/server/game/cards/05-DT/GeneralSherman.js
@@ -22,7 +22,9 @@ class GeneralSherman extends Card {
                         onCardLeavesPlay: (event, context) => event.card === context.source
                     },
                     gameAction: ability.actions.sequentialPutIntoPlay((context) => ({
-                        forEach: context.event.clone.clonedPurgedCards
+                        forEach: context.event.clone.clonedPurgedCards.filter(
+                            (card) => card.type === 'creature'
+                        )
                     })),
                     message: '{0} put into play all creatures purged by {1}',
                     messageArgs: (context) => [context.game.activePlayer, context.source]

--- a/server/game/cards/07-GR/GiltspineMesmerist.js
+++ b/server/game/cards/07-GR/GiltspineMesmerist.js
@@ -9,6 +9,7 @@ class GiltspineMesmerist extends Card {
             when: {
                 onCardReadied: (event) => event.exhausted
             },
+            autoResolve: true,
             condition: (context) => context.game.activePlayer.deck.length > 0,
             gameAction: ability.actions.discard((context) => ({
                 target: context.game.activePlayer.deck[0]

--- a/server/game/cards/08-AS/HarmonicPack.js
+++ b/server/game/cards/08-AS/HarmonicPack.js
@@ -20,34 +20,52 @@ class HarmonicPack extends Card {
                     }
                 }
             },
-            then: (preThenContext) => ({
-                alwaysTriggers: true,
-                gameAction: ability.actions.reveal((context) => ({
-                    target: _.shuffle(
-                        preThenContext.selects.player.choice === 'Mine'
-                            ? context.player.archives
-                            : context.player.opponent.archives
-                    )[0],
-                    chatMessage: true,
-                    location: 'archives'
-                })),
-                then: {
-                    gameAction: ability.actions.sequential([
-                        ability.actions.dealDamage({
-                            target: preThenContext.targets.creature,
-                            amount: 3
-                        }),
-                        ability.actions.discard((context) => ({
-                            target: context.preThenEvent.card
-                        }))
-                    ]),
-                    message: '{0} uses {1} to {3}discard {4}',
-                    messageArgs: (context) => [
-                        preThenContext.targets.creature ? 'deal 3 more damage and ' : '',
-                        context.preThenEvent.card
-                    ]
-                }
-            })
+            then: (preThenContext) => {
+                let damageEvents = [];
+                const dealtFullDamage = () =>
+                    damageEvents.some(
+                        (event) =>
+                            event.name === 'onDamageDealt' &&
+                            !event.cancelled &&
+                            event.amountApplied >= 2
+                    );
+                return {
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.reveal((context) => {
+                        damageEvents = context.preThenEvents || [];
+                        return {
+                            target: _.shuffle(
+                                preThenContext.selects.player.choice === 'Mine'
+                                    ? context.player.archives
+                                    : context.player.opponent.archives
+                            )[0],
+                            chatMessage: true,
+                            location: 'archives'
+                        };
+                    }),
+                    then: {
+                        // Inner then only fires when the reveal succeeded (a card was revealed
+                        // from archives). The revealed card is always discarded; the additional
+                        // 3 damage is only dealt if the initial 2 damage was fully applied.
+                        gameAction: ability.actions.sequential([
+                            ability.actions.dealDamage(() => ({
+                                target: preThenContext.targets.creature,
+                                amount: dealtFullDamage() ? 3 : 0
+                            })),
+                            ability.actions.discard((context) => ({
+                                target: context.preThenEvent.card
+                            }))
+                        ]),
+                        message: '{0} uses {1} to {3}discard {4}',
+                        messageArgs: (context) => [
+                            preThenContext.targets.creature && dealtFullDamage()
+                                ? 'deal 3 more damage and '
+                                : '',
+                            context.preThenEvent.card
+                        ]
+                    }
+                };
+            }
         });
     }
 }

--- a/server/game/cards/11-VM25/Cosmicrux.js
+++ b/server/game/cards/11-VM25/Cosmicrux.js
@@ -3,18 +3,13 @@ const Card = require('../../Card.js');
 class Cosmicrux extends Card {
     // After a player readies a creature, deal 1 to it.
     setupCardAbilities(ability) {
-        this.interrupt({
+        this.reaction({
             when: {
                 onCardReadied: (event) => event.card.type === 'creature' && event.exhausted
             },
-            autoResolve: true,
-            gameAction: ability.actions.changeEvent((context) => ({
-                event: context.event,
-                processEvent: (event) => {
-                    event.addChildEvent(
-                        ability.actions.dealDamage({ amount: 1 }).getEvent(event.card, context)
-                    );
-                }
+            gameAction: ability.actions.dealDamage((context) => ({
+                amount: 1,
+                target: context.event.card
             }))
         });
     }

--- a/server/game/cards/14-DM/Bastionclaw.js
+++ b/server/game/cards/14-DM/Bastionclaw.js
@@ -4,7 +4,7 @@ class Bastionclaw extends Card {
     // Your keys cost –1A for each forged key your opponent has.
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetController: 'self',
+            targetController: 'current',
             effect: ability.effects.modifyKeyCost(() =>
                 this.controller.opponent ? -this.controller.opponent.getForgedKeys() : 0
             )

--- a/server/game/cards/14-DM/ExeldonYash.js
+++ b/server/game/cards/14-DM/ExeldonYash.js
@@ -15,12 +15,15 @@ class ExeldonYash extends Card {
                 },
                 then: (preThenContext) => ({
                     condition: () =>
-                        !!preThenContext.target && preThenContext.source.hasToken('amber'),
-                    gameAction: ability.actions.returnAmber((context) => ({
-                        target: context.source,
+                        !!preThenContext.target &&
+                        preThenContext.preThenEvents.some(
+                            (event) => event.name === 'onCapture' && event.amount === 2
+                        ),
+                    gameAction: ability.actions.returnAmber({
+                        target: preThenContext.source,
                         amount: 1,
-                        recipient: context.player
-                    }))
+                        recipient: preThenContext.player
+                    })
                 })
             }
         });

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -82,12 +82,31 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
             this.deferredChoices = [];
         }
 
+        // Drop queued reactions whose source has left its required location
+        // (e.g. a creature with a queued triggered ability is destroyed before
+        // that ability resolves). Abilities with location 'any' are unaffected.
+        this.choices = this.choices.filter((context) => {
+            const validLoc = context.ability.location;
+            if (validLoc === 'any') {
+                return true;
+            }
+            const sourceLoc = context.source.location;
+            if (Array.isArray(validLoc)) {
+                return validLoc.includes(sourceLoc);
+            }
+            return validLoc === sourceLoc;
+        });
+
         if (this.choices.length === 0 || this.pressedDone) {
             return true;
         }
 
-        let autoResolveChoice = this.choices.find((context) => context.ability.autoResolve);
-        if (autoResolveChoice) {
+        const autoResolveChoice = this.choices.find((context) => context.ability.autoResolve);
+        // If all abilities have autoResolveChoice set and they are all the same ability, auto-resolve that ability without prompting the user.
+        if (
+            autoResolveChoice &&
+            this.choices.every((context) => context.ability === autoResolveChoice.ability)
+        ) {
             this.resolveAbility(autoResolveChoice);
             return false;
         }

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -82,19 +82,16 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
             this.deferredChoices = [];
         }
 
-        // Drop queued reactions whose source has left its required location
-        // (e.g. a creature with a queued triggered ability is destroyed before
-        // that ability resolves). Abilities with location 'any' are unaffected.
+        // Drop queued reactions whose source has left its valid location
+        // since the trigger fired (e.g. a creature with a queued reaction is
+        // destroyed mid-window). Destroyed and play abilities are exempt:
+        // they are queued via the deferred-choice path in triggeredability.js
+        // and are designed to resolve from the discard / being-played location.
         this.choices = this.choices.filter((context) => {
-            const validLoc = context.ability.location;
-            if (validLoc === 'any') {
+            if (context.ability.properties.destroyed || context.ability.properties.play) {
                 return true;
             }
-            const sourceLoc = context.source.location;
-            if (Array.isArray(validLoc)) {
-                return validLoc.includes(sourceLoc);
-            }
-            return validLoc === sourceLoc;
+            return context.ability.isInValidLocation(context);
         });
 
         if (this.choices.length === 0 || this.pressedDone) {

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -51,6 +51,13 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
                     resolved.ability === context.ability && resolved.event === context.event
             )
         ) {
+            // Capture whether the source was in a valid location at the time the
+            // trigger fired. We use this in filterChoices() to drop reactions
+            // whose source has since left its valid location (e.g. a creature
+            // with a queued reaction is destroyed mid-window). Triggers whose
+            // source was already out of valid location at queue time (e.g.
+            // onCardLeavesPlay of the source itself) are exempt from this drop.
+            context.wasInValidLocationAtQueueTime = context.ability.isInValidLocation(context);
             this.choices.push(context);
         }
     }
@@ -87,8 +94,13 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
         // destroyed mid-window). Destroyed and play abilities are exempt:
         // they are queued via the deferred-choice path in triggeredability.js
         // and are designed to resolve from the discard / being-played location.
+        // We also exempt triggers whose source was already out of valid
+        // location when queued (e.g. onCardLeavesPlay of the source itself).
         this.choices = this.choices.filter((context) => {
             if (context.ability.properties.destroyed || context.ability.properties.play) {
+                return true;
+            }
+            if (!context.wasInValidLocationAtQueueTime) {
                 return true;
             }
             return context.ability.isInValidLocation(context);

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -64,6 +64,23 @@ If you believe a test is genuinely incorrect (e.g., it tests for wrong behavior 
 -   When testing a gained ability (granted via `ability.effects.gainAbility(...)`), the first test in the describe should explicitly confirm the ability is present — `clickCard` the receiving creature and assert `toHavePromptButton("Use this card's Action ability")` (or the equivalent for the gained ability type) before invoking it. `useAction` will fail with a generic prompt error if the ability is missing.
 -   **If a test isn't behaving as expected, check for an active prompt first.** Many spurious failures come from a leftover prompt the test forgot to dismiss. Add `expect(this.<player>).isReadyToTakeAction();` mid-test, or print the current prompt, before suspecting a deeper bug.
 
+### Forced trigger ordering and `orderForcedAbilities`
+
+The `orderForcedAbilities` user option (default **on** in tests via [test/helpers/gameflowwrapper.js](helpers/gameflowwrapper.js); default **off** in [server/settings.js](../server/settings.js)) controls whether the player is prompted to choose the order of simultaneous forced triggers. When the option is **off**, the engine auto-resolves choices in queue order, and any one-time `Autoresolve` prompt button is bypassed. See [docs/card-abilities.md](../docs/card-abilities.md#autoresolve-option) for the related per-ability `autoResolve` flag.
+
+When you write tests that exercise ordering between multiple simultaneous forced triggers (e.g. multiple "after end of turn" reactions firing together), also add a sibling test that sets the option off and asserts the window resolves without ordering prompts:
+
+```javascript
+it('auto-resolves all triggers when orderForcedAbilities is disabled', function () {
+    this.player1.player.optionSettings.orderForcedAbilities = false;
+    // ...trigger the simultaneous events...
+    // No clicks needed to pick ordering; assert the resulting state and that
+    // the player is ready to take action.
+});
+```
+
+Note: with the option off, target-selection prompts within each individual trigger still happen, but the engine picks the first available target automatically. Assertions should focus on terminal state (cards in `discard`, totals) rather than which specific creature took damage, since queue order may produce a different (but valid) target than the prompted-ordering case. See [test/server/cards/14-DM/TheGoldenQueen.spec.js](server/cards/14-DM/TheGoldenQueen.spec.js) for the canonical pattern.
+
 ### `activePromptTitle` discipline
 
 When implementing a card, prefer the default prompt title generated from the target/game-action. Only set `activePromptTitle` when the default is genuinely ambiguous (e.g. multiple sequential prompts in the same ability that need to be distinguished). When you do need to override, prefer reusing an existing localization string (search [`public/locales/en.json`](../public/locales/en.json)) over coining a new very-specific one — every new title must be added to every locale file. See [docs/card-messages.md](../docs/card-messages.md#using-target).

--- a/test/helpers/vitest-reporter.js
+++ b/test/helpers/vitest-reporter.js
@@ -7,7 +7,7 @@ import { DefaultReporter } from 'vitest/reporters';
 
 export default class CustomReporter extends DefaultReporter {
     constructor(options) {
-        super(options);
+        super({ ...options, summary: false });
         this.filesPassed = 0;
         this.filesFailed = 0;
         this.filesSkipped = 0;
@@ -55,15 +55,15 @@ export default class CustomReporter extends DefaultReporter {
 
     onTestModuleEnd(module) {
         this.filesRun++;
-        const state = module.state;
-        if (state === 'passed' || state === 1) {
+        const state = typeof module.state === 'function' ? module.state() : module.state;
+        if (state === 'passed') {
             this.filesPassed++;
-        } else if (state === 'failed' || state === 2) {
+        } else if (state === 'failed') {
             this.filesFailed++;
-        } else if (state === 'skipped' || state === 3) {
+        } else if (state === 'skipped') {
             this.filesSkipped++;
         } else {
-            this.filesPassed++;
+            this.filesFailed++;
         }
         this._printProgress();
     }
@@ -72,16 +72,17 @@ export default class CustomReporter extends DefaultReporter {
     onTestCaseReady() {}
 
     onTestCaseResult(testCase) {
-        const state = testCase.state;
-        if (state === 'passed' || state === 1) {
+        const result = typeof testCase.result === 'function' ? testCase.result() : testCase.result;
+        const state = result?.state ?? testCase.state;
+        if (state === 'passed') {
             this.testsPassed++;
-        } else if (state === 'failed' || state === 2) {
+        } else if (state === 'failed') {
             this.testsFailed++;
             this._printFailure(testCase);
-        } else if (state === 'skipped' || state === 3) {
+        } else if (state === 'skipped') {
             this.testsSkipped++;
         } else {
-            this.testsPassed++;
+            this.testsFailed++;
         }
         this._printProgress();
     }
@@ -104,8 +105,10 @@ export default class CustomReporter extends DefaultReporter {
 
         console.log(`\n${red}✕${reset} ${path}`);
 
-        if (testCase.errors && testCase.errors.length > 0) {
-            for (const error of testCase.errors) {
+        const result = typeof testCase.result === 'function' ? testCase.result() : testCase.result;
+        const errors = result?.errors || testCase.errors;
+        if (errors && errors.length > 0) {
+            for (const error of errors) {
                 const message = error.message || String(error);
                 console.log(`  ${dim}${message}${reset}`);
             }
@@ -173,6 +176,17 @@ export default class CustomReporter extends DefaultReporter {
     }
 
     async onTestRunEnd(testModules, errors) {
+        // Vitest invokes onTestRunEnd on each reporter, sometimes more than
+        // once per run (e.g. if there are multiple projects or test contexts).
+        // We only want to print the final summary once, and we want to skip
+        // empty/no-op invocations entirely.
+        const filesTotal = this.filesPassed + this.filesFailed + this.filesSkipped;
+        const testsTotal = this.testsPassed + this.testsFailed + this.testsSkipped;
+        if (this._summaryPrinted || (filesTotal === 0 && testsTotal === 0)) {
+            return;
+        }
+        this._summaryPrinted = true;
+
         // Remove signal handlers
         process.off('SIGINT', this._cleanup);
         process.off('SIGTERM', this._cleanup);
@@ -184,7 +198,48 @@ export default class CustomReporter extends DefaultReporter {
             this._linesWritten = false;
         }
 
-        // Call parent to print failure details and summary
-        await super.onTestRunEnd(testModules, errors);
+        // Print our own final summary. We don't delegate to super's
+        // onTestRunEnd because DefaultReporter relies on internal counters
+        // populated by the per-test/per-module handlers we suppress for the
+        // live progress display, so it would print "0 passed".
+        const bold = '\x1b[1m';
+        const reset = '\x1b[0m';
+        const green = '\x1b[32m';
+        const red = '\x1b[31m';
+        const yellow = '\x1b[33m';
+
+        const fileStats = [
+            this.filesFailed > 0 ? `${bold}${red}${this.filesFailed} failed${reset}` : null,
+            this.filesPassed > 0 ? `${bold}${green}${this.filesPassed} passed${reset}` : null,
+            this.filesSkipped > 0 ? `${bold}${yellow}${this.filesSkipped} skipped${reset}` : null
+        ]
+            .filter(Boolean)
+            .join(' | ');
+
+        const testStats = [
+            this.testsFailed > 0 ? `${bold}${red}${this.testsFailed} failed${reset}` : null,
+            this.testsPassed > 0 ? `${bold}${green}${this.testsPassed} passed${reset}` : null,
+            this.testsSkipped > 0 ? `${bold}${yellow}${this.testsSkipped} skipped${reset}` : null
+        ]
+            .filter(Boolean)
+            .join(' | ');
+
+        const startAt = new Date(this.startTime).toLocaleTimeString('en-US', { hour12: false });
+        const elapsedMs = Date.now() - this.startTime;
+        const elapsed = elapsedMs >= 1000 ? `${(elapsedMs / 1000).toFixed(2)}s` : `${elapsedMs}ms`;
+
+        process.stdout.write(
+            `\n Test Files  ${fileStats || '0'} (${filesTotal})\n` +
+                `      Tests  ${testStats || '0'} (${testsTotal})\n` +
+                `   Start at  ${startAt}\n` +
+                `   Duration  ${elapsed}\n`
+        );
+
+        // Surface any unhandled errors collected by vitest itself.
+        if (errors && errors.length > 0) {
+            for (const error of errors) {
+                console.error(error);
+            }
+        }
     }
 }

--- a/test/server/cards/05-DT/GeneralSherman.spec.js
+++ b/test/server/cards/05-DT/GeneralSherman.spec.js
@@ -195,4 +195,42 @@ describe('General Sherman', function () {
             expect(this.alaka.location).toBe('play area');
         });
     });
+
+    describe('General Sherman with animated artifacts', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 3,
+                    house: 'geistoid',
+                    hand: ['animating-force', 'general-sherman', 'sleep-with-the-fishes'],
+                    inPlay: ['dominator-bauble', 'kaupe']
+                },
+                player2: {}
+            });
+        });
+
+        it('does not put a purged animated artifact back into play as an artifact', function () {
+            this.player1.playUpgrade(this.animatingForce, this.dominatorBauble);
+            this.player1.clickPrompt('Right');
+            expect(this.dominatorBauble.type).toBe('creature');
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.endTurn();
+            this.player1.clickPrompt('unfathomable');
+
+            this.player1.play(this.generalSherman);
+            expect(this.dominatorBauble.location).toBe('purged');
+            expect(this.kaupe.location).toBe('purged');
+
+            this.player1.play(this.sleepWithTheFishes);
+            expect(this.generalSherman.location).toBe('discard');
+
+            // Only Kaupe is a creature - the animated artifact reverts to its
+            // printed type when it leaves play, so it stays purged.
+            expect(this.kaupe.location).toBe('play area');
+            expect(this.dominatorBauble.location).toBe('purged');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });

--- a/test/server/cards/06-WoE/MemroxTheRed.spec.js
+++ b/test/server/cards/06-WoE/MemroxTheRed.spec.js
@@ -83,4 +83,45 @@ describe('Memrox the Red', function () {
             expect(this.player1.amber).toBe(4);
         });
     });
+
+    describe("Memrox the Red prevents discarding and purging opponent's archived cards", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    inPlay: ['memrox-the-red', 'uxlyx-the-zookeeper'],
+                    hand: ['gone-pear-shaped', 'destructive-analysis']
+                },
+                player2: {
+                    inPlay: ['bumpsy', 'troll']
+                }
+            });
+            this.player1.reap(this.uxlyxTheZookeeper);
+            this.player1.clickCard(this.bumpsy);
+            expect(this.bumpsy.location).toBe('archives');
+            expect(this.bumpsy.owner).toBe(this.player2.player);
+            expect(this.bumpsy.controller).toBe(this.player1.player);
+        });
+
+        it("does not let Destructive Analysis purge opponent's archived card", function () {
+            this.player1.play(this.destructiveAnalysis);
+            this.player1.clickCard(this.troll);
+            this.player1.clickCard(this.bumpsy);
+            this.player1.clickPrompt('Done');
+            expect(this.bumpsy.location).toBe('archives');
+            expect(this.player1.player.purged).not.toContain(this.bumpsy);
+            expect(this.troll.tokens.damage).toBe(2);
+        });
+
+        it("does not let Gone Pear Shaped discard opponent's archived card", function () {
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.endTurn();
+            this.player1.clickPrompt('shadows');
+            this.player1.clickPrompt('No');
+            this.player1.play(this.gonePearShaped);
+            expect(this.bumpsy.location).toBe('archives');
+            expect(this.player1.player.discard).not.toContain(this.bumpsy);
+        });
+    });
 });

--- a/test/server/cards/07-GR/GiltspineMesmerist.spec.js
+++ b/test/server/cards/07-GR/GiltspineMesmerist.spec.js
@@ -19,7 +19,6 @@ describe('Giltspine Mesmerist', function () {
             this.player1.playCreature(this.kaupe);
             this.player1.play(this.frigorificRod);
             this.player1.endTurn();
-            this.player1.clickPrompt('Autoresolve');
             expect(this.player1.player.discard.length).toBe(3);
             this.player2.clickPrompt('staralliance');
             this.player2.reap(this.awayTeam);

--- a/test/server/cards/08-AS/HarmonicPack.spec.js
+++ b/test/server/cards/08-AS/HarmonicPack.spec.js
@@ -58,4 +58,145 @@ describe('Harmonic Pack', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe('Harmonic Pack against a target with 1 armor', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['harmonic-pack']
+                },
+                player2: {
+                    inPlay: ['grabber-jammer'],
+                    archives: ['brikk-nastee']
+                }
+            });
+        });
+
+        it('discards from archives but does not deal the additional 3 damage', function () {
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.grabberJammer);
+            this.player1.clickPrompt("Opponent's");
+            expect(this.brikkNastee.location).toBe('discard');
+            expect(this.grabberJammer.tokens.damage).toBe(1);
+            expect(this.grabberJammer.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Harmonic Pack against a target with 2 armor', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['harmonic-pack']
+                },
+                player2: {
+                    inPlay: ['bulwark'],
+                    archives: ['brikk-nastee']
+                }
+            });
+        });
+
+        it('discards from archives but does not deal the additional 3 damage', function () {
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.bulwark);
+            this.player1.clickPrompt("Opponent's");
+            expect(this.brikkNastee.location).toBe('discard');
+            expect(this.bulwark.tokens.damage).toBeUndefined();
+            expect(this.bulwark.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Harmonic Pack against a warded target', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['harmonic-pack']
+                },
+                player2: {
+                    inPlay: ['crim-torchtooth'],
+                    archives: ['brikk-nastee']
+                }
+            });
+        });
+
+        it('discards from archives but does not deal the additional 3 damage', function () {
+            this.crimTorchtooth.ward();
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.crimTorchtooth);
+            this.player1.clickPrompt("Opponent's");
+            expect(this.brikkNastee.location).toBe('discard');
+            expect(this.crimTorchtooth.warded).toBe(false);
+            expect(this.crimTorchtooth.tokens.damage).toBeUndefined();
+            expect(this.crimTorchtooth.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Harmonic Pack against an invulnerable target', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['harmonic-pack']
+                },
+                player2: {
+                    inPlay: ['emperor-memrox'],
+                    archives: ['brikk-nastee']
+                }
+            });
+        });
+
+        it('discards from archives but does not deal damage to the invulnerable creature', function () {
+            expect(this.emperorMemrox.hasKeyword('invulnerable')).toBe(true);
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.emperorMemrox);
+            this.player1.clickPrompt("Opponent's");
+            expect(this.brikkNastee.location).toBe('discard');
+            expect(this.emperorMemrox.tokens.damage).toBeUndefined();
+            expect(this.emperorMemrox.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Harmonic Pack when revealed card cannot be discarded (Memrox the Red)', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    inPlay: ['memrox-the-red'],
+                    hand: ['harmonic-pack']
+                },
+                player2: {
+                    inPlay: ['troll', 'krump']
+                }
+            });
+        });
+
+        it('still deals 3 more damage even though the revealed card cannot be discarded', function () {
+            this.player1.moveCard(this.troll, 'archives');
+            expect(this.player1.archives).toContain(this.troll);
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.krump);
+            this.player1.clickPrompt('Mine');
+            expect(this.player1.archives).toContain(this.troll);
+            expect(this.krump.location).toBe('play area');
+            expect(this.krump.damage).toBe(5);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('still deals 3 more damage and discards card if Memrox the Red is destroyed', function () {
+            this.player1.moveCard(this.troll, 'archives');
+            expect(this.player1.archives).toContain(this.troll);
+            this.player1.play(this.harmonicPack);
+            this.player1.clickCard(this.memroxTheRed);
+            this.player1.clickPrompt('Mine');
+            expect(this.memroxTheRed.location).toBe('discard');
+            expect(this.troll.location).toBe('hand');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });

--- a/test/server/cards/11-VM25/Cosmicrux.spec.js
+++ b/test/server/cards/11-VM25/Cosmicrux.spec.js
@@ -12,15 +12,17 @@ describe('Cosmicrux', function () {
             });
         });
 
-        it('should deal 1 damage to a creature when it readies', function () {
+        it('deals 1 damage to a friendly creature when it readies', function () {
             this.troll.exhaust();
             this.player1.endTurn();
             expect(this.troll.damage).toBe(1);
             expect(this.cosmicrux.damage).toBe(0);
             expect(this.charette.damage).toBe(0);
+            this.player2.clickPrompt('dis');
+            expect(this.player2).isReadyToTakeAction();
         });
 
-        it('should deal 1 damage to opponent creature when it readies', function () {
+        it("deals 1 damage to an opponent's creature when it readies", function () {
             this.charette.exhaust();
             this.player1.endTurn();
             this.player2.clickPrompt('Dis');
@@ -28,9 +30,11 @@ describe('Cosmicrux', function () {
             expect(this.troll.damage).toBe(0);
             expect(this.cosmicrux.damage).toBe(0);
             expect(this.charette.damage).toBe(1);
+            this.player1.clickPrompt('brobnar');
+            expect(this.player1).isReadyToTakeAction();
         });
 
-        it('should deal 1 damage to multiple creatures when they ready', function () {
+        it('prompts for trigger order when multiple creatures ready', function () {
             this.troll.exhaust();
             this.cosmicrux.exhaust();
             this.player1.endTurn();
@@ -38,51 +42,20 @@ describe('Cosmicrux', function () {
             expect(this.troll.damage).toBe(1);
             expect(this.cosmicrux.damage).toBe(1);
             expect(this.charette.damage).toBe(0);
-        });
-    });
-
-    describe('Cosmicrux deals all of its ready damage simultaneously', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'brobnar',
-                    inPlay: ['cosmicrux', 'urchin', 'old-egad', 'umbra']
-                },
-                player2: {}
-            });
-            this.oldEgad.armorUsed = this.oldEgad.armor;
+            this.player2.clickPrompt('dis');
+            expect(this.player2).isReadyToTakeAction();
         });
 
-        it('destroys Old Egad and urchin simultaneously', function () {
-            this.urchin.exhaust();
-            this.oldEgad.exhaust();
-            this.umbra.exhaust();
-            this.player1.endTurn();
-            expect(this.urchin.location).toBe('discard');
-            expect(this.oldEgad.location).toBe('discard');
-            expect(this.umbra.location).toBe('play area');
-            expect(this.umbra.damage).toBe(1);
-            expect(this.umbra.warded).toBe(true);
-        });
-    });
-
-    describe('Cosmicrux readies before its damage applies (Physaloha)', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    house: 'brobnar',
-                    inPlay: ['cosmicrux', 'troll', 'physaloha']
-                },
-                player2: {}
-            });
-        });
-
-        it('readies an undamaged creature, then Cosmicrux deals damage to it', function () {
+        it('auto-resolves all triggers when orderForcedAbilities is disabled', function () {
+            this.player1.player.optionSettings.orderForcedAbilities = false;
             this.troll.exhaust();
+            this.cosmicrux.exhaust();
             this.player1.endTurn();
-            expect(this.troll.exhausted).toBe(false);
             expect(this.troll.damage).toBe(1);
-            expect(this.player1);
+            expect(this.cosmicrux.damage).toBe(1);
+            expect(this.charette.damage).toBe(0);
+            this.player2.clickPrompt('dis');
+            expect(this.player2).isReadyToTakeAction();
         });
     });
 
@@ -111,6 +84,246 @@ describe('Cosmicrux', function () {
             expect(this.cosmicrux.exhausted).toBe(true);
             expect(this.cosmicrux.damage).toBe(0);
             expect(this.theChosenOne.damage).toBe(2);
+            this.player1.clickPrompt('sanctum');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Cosmicrux + Old Egad', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'brobnar',
+                    inPlay: ['cosmicrux', 'urchin', 'old-egad', 'umbra']
+                },
+                player2: {}
+            });
+            this.oldEgad.armorUsed = this.oldEgad.armor;
+        });
+
+        it("orders triggers so Old Egad's destroyed effect wards Umbra after damage", function () {
+            this.urchin.exhaust();
+            this.oldEgad.exhaust();
+            this.umbra.exhaust();
+            this.player1.endTurn();
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.umbra);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.oldEgad.location).toBe('discard');
+            expect(this.umbra.location).toBe('play area');
+            expect(this.umbra.damage).toBe(1);
+            expect(this.umbra.warded).toBe(true);
+            this.player2.clickPrompt('shadows');
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
+
+    describe('Cosmicrux + Clay More', function () {
+        describe('with two Cosmicruxes', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    player1: {
+                        house: 'shadows',
+                        inPlay: ['troll', 'clay-more', 'umbra']
+                    },
+                    player2: {
+                        inPlay: ['cosmicrux', 'cosmicrux']
+                    }
+                });
+                this.damagedCosmicrux = this.player2.inPlay[0];
+                this.damagedCosmicrux.damage = 4;
+                this.undamagedCosmicrux = this.player2.inPlay[1];
+            });
+
+            it('destroying the damaged Cosmicrux via Clay More cancels its remaining triggers', function () {
+                this.troll.exhaust();
+                this.clayMore.exhaust();
+                this.umbra.exhaust();
+                this.player1.endTurn();
+
+                // Pick the undamaged Cosmicrux as the source for the first trigger
+                this.player1.clickCard(this.undamagedCosmicrux);
+                this.player1.clickCard(this.clayMore);
+                expect(this.clayMore.location).toBe('discard');
+                expect(this.damagedCosmicrux.location).toBe('discard');
+                expect(this.undamagedCosmicrux.damage).toBe(2);
+                // Damaged Cosmicrux's pending triggers are cancelled.
+
+                // Resolve undamaged Cosmicrux's remaining triggers.
+                this.player1.clickCard(this.troll);
+                // Last trigger auto-resolves on Umbra
+                expect(this.troll.location).toBe('play area');
+                expect(this.troll.damage).toBe(1);
+                expect(this.umbra.location).toBe('play area');
+                expect(this.umbra.damage).toBe(1);
+                expect(this.troll.exhausted).toBe(false);
+                expect(this.umbra.exhausted).toBe(false);
+                expect(this.undamagedCosmicrux.location).toBe('play area');
+
+                this.player2.clickPrompt('brobnar');
+                expect(this.player2).isReadyToTakeAction();
+            });
+        });
+
+        describe('with a single damaged Cosmicrux', function () {
+            beforeEach(function () {
+                this.setupTest({
+                    player1: {
+                        house: 'brobnar',
+                        inPlay: ['clay-more', 'troll']
+                    },
+                    player2: {
+                        inPlay: ['cosmicrux']
+                    }
+                });
+                this.cosmicrux.damage = 4;
+            });
+
+            it("cancels Cosmicrux's pending triggers when Cosmicrux is destroyed mid-window", function () {
+                this.clayMore.exhaust();
+                this.troll.exhaust();
+                this.player1.endTurn();
+                this.player1.clickCard(this.clayMore);
+                expect(this.clayMore.location).toBe('discard');
+                expect(this.cosmicrux.location).toBe('discard');
+                expect(this.troll.damage).toBe(0);
+                expect(this.troll.location).toBe('play area');
+                this.player2.clickPrompt('brobnar');
+                expect(this.player2).isReadyToTakeAction();
+            });
+        });
+    });
+
+    describe('Cosmicrux + Giltspine Mesmerist', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'brobnar',
+                    inPlay: ['troll', 'urchin']
+                },
+                player2: {
+                    inPlay: ['cosmicrux', 'giltspine-mesmerist']
+                }
+            });
+        });
+
+        it('resolves all Cosmicrux triggers first, then Giltspine Mesmerist', function () {
+            this.troll.exhaust();
+            this.urchin.exhaust();
+            const initialDiscard = this.player1.player.discard.length;
+            this.player1.endTurn();
+            // Resolve both Cosmicrux triggers first (urchin dies to 1 damage)
+            this.player1.clickCard(this.cosmicrux);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.cosmicrux); // only one Cosmicrux event left, auto-targets troll
+            // Giltspine auto-resolves with no other abilities triggering
+
+            expect(this.troll.damage).toBe(1);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 3); // urchin + 2 deck discards
+            this.player2.clickPrompt('brobnar');
+            expect(this.player2).isReadyToTakeAction();
+        });
+
+        it('resolves all Giltspine Mesmerist triggers first, then Cosmicrux', function () {
+            this.troll.exhaust();
+            this.urchin.exhaust();
+            const initialDiscard = this.player1.player.discard.length;
+            this.player1.endTurn();
+            // Resolve Giltspine triggers
+            this.player1.clickCard(this.giltspineMesmerist);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.giltspineMesmerist);
+
+            // Resolve Cosmicrux triggers
+            this.player1.clickCard(this.troll);
+            // auto-resolve last Cosmicrux trigger on urchin
+
+            expect(this.troll.damage).toBe(1);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 3); // 2 deck discards + urchin
+            this.player2.clickPrompt('brobnar');
+            expect(this.player2).isReadyToTakeAction();
+        });
+
+        it('interleaves Cosmicrux and Giltspine Mesmerist triggers', function () {
+            this.troll.exhaust();
+            this.urchin.exhaust();
+            const initialDiscard = this.player1.player.discard.length;
+            this.player1.endTurn();
+            this.player1.clickCard(this.cosmicrux);
+            this.player1.clickCard(this.urchin);
+            this.player1.clickCard(this.giltspineMesmerist);
+            this.player1.clickCard(this.urchin); // from discard
+            this.player1.clickCard(this.giltspineMesmerist);
+            // Giltspine auto-resolves troll discard
+            // Last Cosmicrux trigger auto-resolves on urchin (urchin dies)
+
+            expect(this.troll.damage).toBe(1);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 3); // 2 deck discards + urchin
+            this.player2.clickPrompt('brobnar');
+            expect(this.player2).isReadyToTakeAction();
+        });
+
+        it('has the option to autoresolve Cosmicrux and Giltspine Mesmerist triggers', function () {
+            this.troll.exhaust();
+            this.urchin.exhaust();
+            const initialDiscard = this.player1.player.discard.length;
+            this.player1.endTurn();
+            this.player1.clickPrompt('Autoresolve');
+            expect(this.troll.damage).toBe(1);
+            expect(this.urchin.location).toBe('discard');
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 3);
+            this.player2.clickPrompt('brobnar');
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
+
+    describe('Cosmicrux + Giltspine Mesmerist + Poised Strike', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'dis',
+                    inPlay: ['ember-imp', 'troll'],
+                    hand: ['poised-strike']
+                },
+                player2: {
+                    inPlay: ['cosmicrux', 'giltspine-mesmerist']
+                }
+            });
+        });
+
+        it('interleaves Cosmicrux, Giltspine Mesmerist, and Poised Strike triggers', function () {
+            this.player1.playUpgrade(this.poisedStrike, this.emberImp);
+            this.player1.reap(this.emberImp);
+            this.troll.exhaust();
+            const initialDiscard = this.player1.player.discard.length;
+            this.player1.endTurn();
+
+            this.player1.clickCard(this.cosmicrux);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.damage).toBe(1);
+
+            this.player1.clickCard(this.giltspineMesmerist);
+            this.player1.clickCard(this.troll);
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 1);
+
+            this.player1.clickCard(this.cosmicrux);
+            // Auto-resolve ember-imp damage
+            expect(this.emberImp.damage).toBe(1);
+            expect(this.emberImp.location).toBe('play area');
+
+            this.player1.clickCard(this.giltspineMesmerist);
+            // Auto-resolve ember-imp discard
+
+            // Poised Strike auto-resolves
+            expect(this.emberImp.location).toBe('discard');
+            expect(this.poisedStrike.location).toBe('discard');
+            expect(this.player1.player.discard.length).toBe(initialDiscard + 4);
+
+            this.player2.clickPrompt('brobnar');
+            expect(this.player2).isReadyToTakeAction();
         });
     });
 });

--- a/test/server/cards/14-DM/Bastionclaw.spec.js
+++ b/test/server/cards/14-DM/Bastionclaw.spec.js
@@ -6,18 +6,97 @@ describe('Bastionclaw', function () {
                     house: 'ouboros',
                     inPlay: ['bastionclaw']
                 },
+                player2: {
+                    amber: 12
+                }
+            });
+            expect(this.player1.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Opponent forges their first key
+            this.player1.endTurn();
+            this.player2.forgeKey('Red');
+            this.player2.clickPrompt('untamed');
+            expect(this.player2.player.getForgedKeys()).toBe(1);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(5);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Opponent forges their second key
+            this.player2.endTurn();
+            this.player1.clickPrompt('ouboros');
+            this.player1.endTurn();
+            this.player2.forgeKey('Blue');
+            this.player2.clickPrompt('untamed');
+            expect(this.player2.player.getForgedKeys()).toBe(2);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(4);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+        });
+
+        it('does not reduce key cost for your own forged keys', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ouboros',
+                    amber: 12,
+                    inPlay: ['bastionclaw']
+                },
                 player2: {}
             });
             expect(this.player1.player.getCurrentKeyCost()).toBe(6);
-            this.player2.player.keys.red = true;
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Player forges their first key
             this.player1.endTurn();
             this.player2.clickPrompt('untamed');
-            expect(this.player1.player.getCurrentKeyCost()).toBe(5);
-            this.player2.player.keys.blue = true;
+            this.player2.endTurn();
+            this.player1.forgeKey('Red');
+            this.player1.clickPrompt('ouboros');
+            expect(this.player1.player.getForgedKeys()).toBe(1);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Player forges their second key
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.endTurn();
+            this.player1.forgeKey('Blue');
+            this.player1.clickPrompt('ouboros');
+            expect(this.player1.player.getForgedKeys()).toBe(2);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('stacks when there are two Bastionclaws', function () {
+            this.setupTest({
+                player1: {
+                    house: 'ouboros',
+                    inPlay: ['bastionclaw', 'bastionclaw']
+                },
+                player2: {
+                    amber: 6
+                }
+            });
+            expect(this.player1.player.getCurrentKeyCost()).toBe(6);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Opponent forges their first key
+            this.player1.endTurn();
+            this.player2.forgeKey('Red');
+            this.player2.clickPrompt('untamed');
+            expect(this.player2.player.getForgedKeys()).toBe(1);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(4);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
+
+            // Opponent forges their second key
             this.player2.endTurn();
             this.player1.clickPrompt('ouboros');
-            expect(this.player1.player.getCurrentKeyCost()).toBe(4);
-            expect(this.player1).isReadyToTakeAction();
+            this.player2.player.amber = 6;
+            this.player1.endTurn();
+            this.player2.forgeKey('Blue');
+            this.player2.clickPrompt('untamed');
+            expect(this.player2.player.getForgedKeys()).toBe(2);
+            expect(this.player1.player.getCurrentKeyCost()).toBe(2);
+            expect(this.player2.player.getCurrentKeyCost()).toBe(6);
         });
     });
 });

--- a/test/server/cards/14-DM/ExeldonYash.spec.js
+++ b/test/server/cards/14-DM/ExeldonYash.spec.js
@@ -1,5 +1,5 @@
 describe('Exeldon Yash', function () {
-    describe("Exeldon Yash's ability", function () {
+    describe("Exeldon Yash's ability when opponent has 3 amber", function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -13,7 +13,7 @@ describe('Exeldon Yash', function () {
             });
         });
 
-        it('captures 2 then discards a card to move 1 to pool', function () {
+        it('captures 2, then discarding moves 1 from Exeldon Yash to pool', function () {
             this.player1.reap(this.exeldonYash);
             expect(this.exeldonYash.amber).toBe(2);
             expect(this.player2.amber).toBe(1);
@@ -25,7 +25,7 @@ describe('Exeldon Yash', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('captures 2 and skips discard when player declines', function () {
+        it('captures 2 and skips discard when player declines, leaving Exeldon Yash with 2', function () {
             this.player1.reap(this.exeldonYash);
             this.player1.clickPrompt('Done');
             expect(this.exeldonYash.amber).toBe(2);
@@ -35,7 +35,61 @@ describe('Exeldon Yash', function () {
         });
     });
 
-    describe("Exeldon Yash's ability when opponent has no amber", function () {
+    describe("Exeldon Yash's ability when opponent has 2 amber", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['troll'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 2
+                }
+            });
+        });
+
+        it('captures 2 and discarding moves 1 from Exeldon Yash to pool', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Exeldon Yash's ability when opponent has 1 amber", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    hand: ['troll'],
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 1
+                }
+            });
+        });
+
+        it('captures only 1, so discarding does not move amber from Exeldon Yash', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player2.amber).toBe(0);
+            expect(this.player1).toHavePrompt('Choose a card');
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('discard');
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Exeldon Yash's ability when opponent has 0 amber", function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -49,7 +103,7 @@ describe('Exeldon Yash', function () {
             });
         });
 
-        it('still prompts to discard but no amber is gained when there is none on Exeldon Yash', function () {
+        it('captures nothing, so discarding does not move amber from Exeldon Yash', function () {
             this.player1.reap(this.exeldonYash);
             expect(this.exeldonYash.amber).toBe(0);
             expect(this.player2.amber).toBe(0);
@@ -62,7 +116,7 @@ describe('Exeldon Yash', function () {
         });
     });
 
-    describe("Exeldon Yash's ability when opponent has no amber but Exeldon Yash has amber on it", function () {
+    describe("Exeldon Yash's ability when Exeldon Yash already has amber", function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -77,15 +131,37 @@ describe('Exeldon Yash', function () {
             this.exeldonYash.amber = 1;
         });
 
-        it('discards to move the existing amber from Exeldon Yash to pool', function () {
+        it('does not move pre-existing amber from Exeldon Yash when capture is 0', function () {
             this.player1.reap(this.exeldonYash);
             expect(this.exeldonYash.amber).toBe(1);
             expect(this.player2.amber).toBe(0);
             expect(this.player1).toHavePrompt('Choose a card');
             this.player1.clickCard(this.troll);
             expect(this.troll.location).toBe('discard');
-            expect(this.exeldonYash.amber).toBe(0);
-            expect(this.player1.amber).toBe(2);
+            expect(this.exeldonYash.amber).toBe(1);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Exeldon Yash's ability when player has no cards to discard", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    inPlay: ['exeldon-yash']
+                },
+                player2: {
+                    amber: 3
+                }
+            });
+        });
+
+        it('captures 2 and ends without moving amber when there is nothing to discard', function () {
+            this.player1.reap(this.exeldonYash);
+            expect(this.exeldonYash.amber).toBe(2);
+            expect(this.player2.amber).toBe(1);
+            expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/14-DM/Hydrogan.spec.js
+++ b/test/server/cards/14-DM/Hydrogan.spec.js
@@ -110,3 +110,4 @@ describe('Hydrogan', function () {
         });
     });
 });
+// TODO: make sure hydrogan handles artifacts and token creatures correctly

--- a/test/server/cards/14-DM/Hydrogan.spec.js
+++ b/test/server/cards/14-DM/Hydrogan.spec.js
@@ -109,5 +109,113 @@ describe('Hydrogan', function () {
             expect(this.player2).isReadyToTakeAction();
         });
     });
+
+    describe('Hydrogan with non-creature cards under it', function () {
+        it('does not put back an animated artifact whose lasting effect ended after being placed under', function () {
+            this.setupTest({
+                player1: {
+                    house: 'geistoid',
+                    hand: ['hydrogan', 'hydrogan2', 'animating-force'],
+                    inPlay: ['dominator-bauble']
+                },
+                player2: {}
+            });
+
+            this.player1.playUpgrade(this.animatingForce, this.dominatorBauble);
+            this.player1.clickPrompt('Right');
+            expect(this.dominatorBauble.type).toBe('creature');
+
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.endTurn();
+            this.player1.clickPrompt('unfathomable');
+            this.player1.play(this.hydrogan);
+            expect(this.hydrogan.childCards).toContain(this.dominatorBauble);
+            expect(this.dominatorBauble.type).toBe('artifact');
+
+            this.hydrogan.ready();
+            this.player1.reap(this.hydrogan);
+            expect(this.player1).not.toBeAbleToSelect(this.dominatorBauble);
+            expect(this.dominatorBauble.location).toBe('under');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not put back a token creature whose underlying card is an action', function () {
+            this.setupTest({
+                player1: {
+                    house: 'unfathomable',
+                    token: 'prospector',
+                    deck: ['wild-wormhole'],
+                    hand: ['hydrogan', 'hydrogan2'],
+                    inPlay: ['prospector:wild-wormhole']
+                },
+                player2: {}
+            });
+
+            const wildWormhole = this.player1.player.creaturesInPlay[0];
+            expect(wildWormhole.type).toBe('creature');
+
+            this.player1.play(this.hydrogan);
+            expect(this.hydrogan.childCards).toContain(wildWormhole);
+            expect(wildWormhole.type).toBe('action');
+
+            this.hydrogan.ready();
+            this.player1.reap(this.hydrogan);
+            expect(this.player1).not.toBeAbleToSelect(wildWormhole);
+            expect(wildWormhole.location).toBe('under');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not put back a token creature whose underlying card is an artifact', function () {
+            this.setupTest({
+                player1: {
+                    house: 'unfathomable',
+                    token: 'prospector',
+                    deck: ['library-of-babble'],
+                    hand: ['hydrogan', 'hydrogan2'],
+                    inPlay: ['prospector:library-of-babble']
+                },
+                player2: {}
+            });
+
+            const libraryOfBabble = this.player1.player.creaturesInPlay[0];
+            expect(libraryOfBabble.type).toBe('creature');
+
+            this.player1.play(this.hydrogan);
+            expect(this.hydrogan.childCards).toContain(libraryOfBabble);
+            expect(libraryOfBabble.type).toBe('artifact');
+
+            this.hydrogan.ready();
+            this.player1.reap(this.hydrogan);
+            expect(this.player1).not.toBeAbleToSelect(libraryOfBabble);
+            expect(libraryOfBabble.location).toBe('under');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not put back a token creature whose underlying card is an upgrade', function () {
+            this.setupTest({
+                player1: {
+                    house: 'unfathomable',
+                    token: 'prospector',
+                    deck: ['rocket-boots'],
+                    hand: ['hydrogan', 'hydrogan2'],
+                    inPlay: ['prospector:rocket-boots']
+                },
+                player2: {}
+            });
+
+            const rocketBoots = this.player1.player.creaturesInPlay[0];
+            expect(rocketBoots.type).toBe('creature');
+
+            this.player1.play(this.hydrogan);
+            expect(this.hydrogan.childCards).toContain(rocketBoots);
+            expect(rocketBoots.type).toBe('upgrade');
+
+            this.hydrogan.ready();
+            this.player1.reap(this.hydrogan);
+            expect(this.player1).not.toBeAbleToSelect(rocketBoots);
+            expect(rocketBoots.location).toBe('under');
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });
-// TODO: make sure hydrogan handles artifacts and token creatures correctly

--- a/test/server/cards/14-DM/MonsterZero.spec.js
+++ b/test/server/cards/14-DM/MonsterZero.spec.js
@@ -40,4 +40,116 @@ describe('Monster Zero', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe("Monster Zero's keywords", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['monster-zero', 'monster-zero2'],
+                    inPlay: ['troll', 'snufflegator']
+                },
+                player2: {}
+            });
+
+            this.monsterZeroBottom = this.player1.hand[0];
+            this.monsterZeroTop = this.player1.hand[1];
+        });
+
+        it('should deploy between the existing creatures when top is played', function () {
+            expect(this.monsterZeroTop.hasKeyword('deploy')).toBe(false);
+            expect(this.monsterZeroBottom.hasKeyword('deploy')).toBe(true);
+
+            this.player1.clickCard(this.monsterZeroTop, 'hand');
+            this.player1.clickPrompt('Play this creature');
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+            this.player1.clickPrompt('Deploy Right');
+            this.player1.clickCard(this.troll);
+
+            expect(this.player1.player.creaturesInPlay).toEqual([
+                this.troll,
+                this.monsterZeroTop,
+                this.snufflegator
+            ]);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should deploy between the existing creatures when bottom is played', function () {
+            expect(this.monsterZeroTop.hasKeyword('deploy')).toBe(false);
+            expect(this.monsterZeroBottom.hasKeyword('deploy')).toBe(true);
+
+            this.player1.clickCard(this.monsterZeroBottom, 'hand');
+            this.player1.clickPrompt('Play this creature');
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+            this.player1.clickPrompt('Deploy Left');
+            this.player1.clickCard(this.snufflegator);
+
+            expect(this.player1.player.creaturesInPlay).toEqual([
+                this.troll,
+                this.monsterZeroBottom,
+                this.snufflegator
+            ]);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe("Monster Zero's Deploy keyword with put into play", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['æmberlution', 'troll', 'snufflegator', 'monster-zero', 'monster-zero2']
+                },
+                player2: {}
+            });
+            this.monsterZeroBottom = this.player1.hand[3];
+            this.monsterZeroTop = this.player1.hand[4];
+        });
+
+        it('can put into play and deploy Monster Zero top between two existing creatures put into play', function () {
+            this.player1.play(this.æmberlution);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('play area');
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('right');
+            expect(this.player1.player.creaturesInPlay).toEqual([this.troll, this.snufflegator]);
+
+            // Now put Monster Zero into play; deploy options should be available
+            this.player1.clickCard(this.monsterZeroTop);
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+            this.player1.clickPrompt('Deploy Right');
+            this.player1.clickCard(this.troll);
+
+            expect(this.player1.player.creaturesInPlay).toEqual([
+                this.troll,
+                this.monsterZeroTop,
+                this.snufflegator
+            ]);
+        });
+
+        it('can put into play and deploy Monster Zero bottom between two existing creatures put into play', function () {
+            this.player1.play(this.æmberlution);
+            this.player1.clickCard(this.troll);
+            expect(this.troll.location).toBe('play area');
+            this.player1.clickCard(this.snufflegator);
+            this.player1.clickPrompt('right');
+            expect(this.player1.player.creaturesInPlay).toEqual([this.troll, this.snufflegator]);
+
+            // Now put Monster Zero into play; deploy options should be available
+            this.player1.clickCard(this.monsterZeroBottom);
+            expect(this.player1).toHavePromptButton('Deploy Left');
+            expect(this.player1).toHavePromptButton('Deploy Right');
+            this.player1.clickPrompt('Deploy Right');
+            this.player1.clickCard(this.troll);
+
+            expect(this.player1.player.creaturesInPlay).toEqual([
+                this.troll,
+                this.monsterZeroBottom,
+                this.snufflegator
+            ]);
+        });
+    });
 });

--- a/test/server/cards/14-DM/ShadowGloomcoil.spec.js
+++ b/test/server/cards/14-DM/ShadowGloomcoil.spec.js
@@ -6,7 +6,9 @@ describe('Shadow Gloomcoil', function () {
                     house: 'ouboros',
                     inPlay: ['shadow-gloomcoil', 'caspart']
                 },
-                player2: {}
+                player2: {
+                    inPlay: ['troll', 'pelf']
+                }
             });
         });
 
@@ -14,6 +16,30 @@ describe('Shadow Gloomcoil', function () {
             this.player1.reap(this.caspart);
             expect(this.shadowGloomcoil.damage).toBe(1);
             expect(this.caspart.damage).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('does not deal damage when it dies in the fight that triggers the reaction', function () {
+            this.player1.fightWith(this.shadowGloomcoil, this.troll);
+            expect(this.shadowGloomcoil.location).toBe('discard');
+            expect(this.caspart.damage).toBe(0);
+            expect(this.troll.damage).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('deals damage when it dies from ability damage', function () {
+            this.player1.fightWith(this.shadowGloomcoil, this.pelf);
+            expect(this.shadowGloomcoil.location).toBe('discard');
+            expect(this.caspart.damage).toBe(1);
+            expect(this.troll.damage).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('deals damage when a creature dies in the fight that triggers the reaction', function () {
+            this.player1.fightWith(this.caspart, this.troll);
+            expect(this.caspart.location).toBe('discard');
+            expect(this.shadowGloomcoil.damage).toBe(1);
+            expect(this.troll.damage).toBe(3);
             expect(this.player1).isReadyToTakeAction();
         });
     });


### PR DESCRIPTION
- Fix HarmonicPack ability implementation
- Fix Cosmicrux and ExeldonYash abilities
- Fix Bastionclaw
- Add GiltspineMesmerist missing keyword
- Improve PlayCreatureAction and forcedtriggeredabilitywindow engine logic
- Add/expand tests: HarmonicPack, Cosmicrux, Bastionclaw, ExeldonYash, MonsterZero, ShadowGloomcoil, Hydrogan, MemroxTheRed
- Update docs/card-abilities.md and test/AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core forced-trigger window behavior (auto-resolve rules and dropping invalid queued triggers) and play flow for gigantic creatures, which can affect many cards’ timing/targeting interactions.
> 
> **Overview**
> **Improves forced-trigger resolution and play handling.** The forced triggered ability window now drops queued triggers whose source is no longer in its required `location`, and `autoResolve` only bypasses ordering prompts when *all* simultaneous choices are instances of the same ability.
> 
> **Fixes multiple card implementations.** Updates `Harmonic Pack` to only grant the extra 3 damage when the initial 2 damage was fully applied (while still discarding the revealed archives card when the reveal succeeds), changes `Cosmicrux` to a direct reaction that damages the readied creature, tightens `Exeldon Yash` “if you do” gating to rely on actual `onCapture` events, corrects `Bastionclaw` key-cost modifier to apply to the current player, and marks `Giltspine Mesmerist`’s ready trigger as `autoResolve`.
> 
> **Docs/tests expanded.** Adds documentation for per-ability `autoResolve` and for implementing chained “If you do” clauses via `preThenEvents`, and significantly expands regression tests around forced-trigger ordering, damage/armor/ward/invulnerable edge cases, gigantic deploy/put-into-play, and Memrox archive protections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18fc531cdd011ac978254204e007dffb8fe80ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->