### PR TITLE
fix(05-DT): Deep Priest Glebe triggers on play, not enters play

### DIFF
--- a/server/game/cards/05-DT/DeepPriestGlebe.js
+++ b/server/game/cards/05-DT/DeepPriestGlebe.js
@@ -5,10 +5,10 @@ class DeepPriestGlebe extends Card {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, context) =>
+                onCardPlayed: (event, context) =>
                     event.card.type === 'creature' &&
                     event.card.hasTrait('aquan') &&
-                    event.context.player === context.player
+                    event.player === context.player
             },
             target: {
                 cardType: 'creature',

--- a/test/server/cards/05-DT/DeepPriestGlebe.spec.js
+++ b/test/server/cards/05-DT/DeepPriestGlebe.spec.js
@@ -66,4 +66,57 @@ describe('Deep Priest Glebe', function () {
             expect(this.deepPriestGlebe.exhausted).toBe(false);
         });
     });
+
+    describe('Deep Priest Glebe triggering on itself', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'unfathomable',
+                    hand: ['deep-priest-glebe']
+                },
+                player2: {
+                    inPlay: ['gub', 'krump']
+                }
+            });
+        });
+
+        it('should trigger when Deep Priest Glebe itself is played', function () {
+            this.player1.play(this.deepPriestGlebe);
+            expect(this.player1).toBeAbleToSelect(this.gub);
+            expect(this.player1).toBeAbleToSelect(this.krump);
+            this.player1.clickCard(this.gub);
+            expect(this.gub.exhausted).toBe(true);
+            expect(this.krump.exhausted).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+
+    describe('Deep Priest Glebe with a put-into-play effect', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    inPlay: ['lightbearer-kelvin', 'deep-priest-glebe'],
+                    discard: ['portalmonger']
+                },
+                player2: {
+                    inPlay: ['gub', 'krump']
+                }
+            });
+        });
+
+        it('should not trigger when an Aquan creature is put into play (not played)', function () {
+            this.player1.moveCard(this.portalmonger, 'deck bottom');
+            this.player1.fightWith(this.lightbearerKelvin, this.gub);
+            this.player1.clickPrompt('My Deck');
+            this.player1.clickPrompt('Right');
+            expect(this.portalmonger.location).toBe('play area');
+            expect(this.portalmonger.hasTrait('aquan')).toBe(true);
+
+            // No exhaust prompt should appear.
+            expect(this.gub.exhausted).toBe(false);
+            expect(this.krump.exhausted).toBe(false);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #5012 - Deep Priest Glebe was using `onCardEntersPlay` which triggers for any method a card enters play (including put-into-play effects). This fixes it to use `onCardPlayed` so it only triggers when an Aquan creature is actually played from hand.

Also fixes the player check: `event.context.player` → `event.player` (correct property for `onCardPlayed` events).

## Changes

- `DeepPriestGlebe.js`: Switch trigger from `onCardEntersPlay` to `onCardPlayed`, fix player property
- `DeepPriestGlebe.spec.js`: Add tests for Glebe triggering on itself and for not triggering on put-into-play effects (e.g. Lightbearer Kelvin)

## Tests

All 5 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 40e04cfd7780452177b5c0ff68eb69085e7598d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->