### PR TITLE
fix: tide background expands when scrolling horizontally

### DIFF
--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -209,12 +209,12 @@ export const GameBoard = () => {
     const renderBoard = () => [
         <div key='board-middle' className='board-middle'>
             <div className='board-inner'>
-                <div
-                    className={classNames('board-atmosphere-overlay', {
-                        dense: highDensity
-                    })}
-                />
                 <div className='play-area'>
+                    <div
+                        className={classNames('board-atmosphere-overlay', {
+                            dense: highDensity
+                        })}
+                    />
                     <PlayerBoard
                         cardBack={
                             <CardBack

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -1194,7 +1194,7 @@ pre {
   flex: 1;
   display: flex;
   min-height: 0;
-  overflow-x: hidden;
+  overflow-x: auto;
 }
 
 .board-atmosphere-overlay {
@@ -1227,12 +1227,6 @@ pre {
   overflow: hidden;
 }
 
-.play-area {
-  position: relative;
-  z-index: 2;
-  overflow-x: auto;
-}
-
 .play-area .drop-target,
 .player-board .drop-target {
   flex: 1;
@@ -1247,6 +1241,14 @@ pre {
   flex-direction: column;
   justify-content: space-between;
   min-height: 0;
+}
+.play-area {
+    position: relative;
+    z-index: 2;
+    flex: none;
+    width: max-content;
+    min-width: 100%;
+    height: 100%;
 }
 
 .player-board {


### PR DESCRIPTION
Fixes #2744

Moves the atmosphere overlay inside .play-area and updates .play-area CSS so the tide background stretches with the content when scrolling horizontally.

Notice that unlike in the issue, once the battleline scrolls, the tide gradient extends into that whole area
<img width="1233" height="833" alt="image" src="https://github.com/user-attachments/assets/f1e8f3a6-3818-4143-8912-3d2ff212f5fd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts DOM nesting and CSS overflow/sizing; main risk is unintended layout/scroll regressions on different screen sizes.
> 
> **Overview**
> Fixes the game board “tide”/atmosphere background not stretching with horizontal scroll by moving `board-atmosphere-overlay` inside `.play-area` so it sizes with the scrolled content.
> 
> Updates layout CSS so horizontal scrolling is handled by `.board-inner` and `.play-area` becomes a `max-content`-width container (with a `min-width: 100%`) to ensure the overlay/background expands to match the board content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4950f694f2013ca73a2f14f1daba5874bffbf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->