### PR TITLE
fix: auto-select single target for triggered effects

### DIFF
--- a/docs/card-abilities.md
+++ b/docs/card-abilities.md
@@ -454,7 +454,30 @@ this.play({
 
 ### Optional
 
-Use `optional: true` when the card text says "you may" to let the player choose whether to use the ability:
+Use `optional: true` when the card text says "you may" to let the player choose whether to use the ability.
+
+**For "you may" abilities with a single card target, put `optional: true` inside the `target` block, not on the ability:**
+
+```javascript
+// Play: You may deal 2 damage to a creature.
+this.play({
+    target: {
+        optional: true,
+        cardType: 'creature',
+        gameAction: ability.actions.dealDamage({ amount: 2 })
+    }
+});
+```
+
+This shows the target prompt directly with a "Done" button to decline. Putting `optional: true` at the ability level on a `play`/`fight`/`reap` with a single `target:` instead generates an extra "Any reactions?" opt-in step that requires the player to click the source card before they can pick a target — worse UX.
+
+**Use ability-level `optional: true` when:**
+
+-   The ability has no `target:` block (e.g., "you may exalt this creature", "you may forge a key").
+-   The ability has a `then:` and the player should be able to atomically decline both the target and the `then` effect (e.g., Nirbor Flamewing).
+-   The ability uses `targets:` (plural) with multiple targets, and declining should skip all of them together.
+-   The ability uses `mode: 'house'` or `mode: 'select'` (a choice prompt rather than a card-target prompt).
+-   The ability is a triggered `reaction` / `interrupt` where the global "Any reactions?" prompt is the desired UX (so the target prompt doesn't pop up every time the trigger fires).
 
 ```javascript
 // Play: You may exalt Dino-Knight. If you do, deal 3D to a creature.

--- a/server/game/cards/01-Core/GangerChieftain.js
+++ b/server/game/cards/01-Core/GangerChieftain.js
@@ -4,8 +4,8 @@ class GangerChieftain extends Card {
     // Play: You may ready and fight with a neighboring creature.
     setupCardAbilities(ability) {
         this.play({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card, context) => context.source.neighbors.includes(card),

--- a/server/game/cards/01-Core/MasterOf1.js
+++ b/server/game/cards/01-Core/MasterOf1.js
@@ -4,8 +4,8 @@ class MasterOf1 extends Card {
     // Reap: You may destroy a creature with 1 power.
     setupCardAbilities(ability) {
         this.reap({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 cardCondition: (card) => card.power === 1,
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/01-Core/MasterOf2.js
+++ b/server/game/cards/01-Core/MasterOf2.js
@@ -4,8 +4,8 @@ class MasterOf2 extends Card {
     // Reap: You may destroy a creature with 2 power.
     setupCardAbilities(ability) {
         this.reap({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 cardCondition: (card) => card.power === 2,
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/01-Core/MasterOf3.js
+++ b/server/game/cards/01-Core/MasterOf3.js
@@ -4,8 +4,8 @@ class MasterOf3 extends Card {
     // Reap: You may destroy a creature with 3 power.
     setupCardAbilities(ability) {
         this.reap({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 cardCondition: (card) => card.power === 3,
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/01-Core/RockhurlingGiant.js
+++ b/server/game/cards/01-Core/RockhurlingGiant.js
@@ -12,8 +12,8 @@ class RockhurlingGiant extends Card {
                     context.game.activePlayer === context.player &&
                     event.card.hasHouse('brobnar')
             },
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 gameAction: ability.actions.dealDamage({ amount: 4 })
             }

--- a/server/game/cards/01-Core/SergeantZakiel.js
+++ b/server/game/cards/01-Core/SergeantZakiel.js
@@ -4,8 +4,8 @@ class SergeantZakiel extends Card {
     // Play: You may ready and fight with a neighboring creature.
     setupCardAbilities(ability) {
         this.play({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card, context) => context.source.neighbors.includes(card),

--- a/server/game/cards/01-Core/ZyzzixTheMany.js
+++ b/server/game/cards/01-Core/ZyzzixTheMany.js
@@ -5,7 +5,6 @@ class ZyzzixTheMany extends Card {
     setupCardAbilities(ability) {
         this.fight({
             reap: true,
-            optional: true,
             target: {
                 optional: true,
                 cardType: 'creature',

--- a/server/game/cards/02-AoA/Ogopogo.js
+++ b/server/game/cards/02-AoA/Ogopogo.js
@@ -9,8 +9,8 @@ class Ogopogo extends Card {
                     event.destroyedFighting &&
                     event.damageEvent.fightEvent.attacker === context.source
             },
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 gameAction: ability.actions.dealDamage({ amount: 2 })
             }

--- a/server/game/cards/02-AoA/TheGreyRider.js
+++ b/server/game/cards/02-AoA/TheGreyRider.js
@@ -5,10 +5,10 @@ class TheGreyRider extends Card {
     // Play/Fight/Reap: You may ready and fight with a neighboring creature.
     setupCardAbilities(ability) {
         this.play({
-            optional: true,
             fight: true,
             reap: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card, context) => context.source.neighbors.includes(card),

--- a/server/game/cards/03-WC/ChiefEngineerWalls.js
+++ b/server/game/cards/03-WC/ChiefEngineerWalls.js
@@ -7,8 +7,8 @@ class ChiefEngineerWalls extends Card {
         this.play({
             fight: true,
             reap: true,
-            optional: true,
             target: {
+                optional: true,
                 location: ['discard'],
                 controller: 'self',
                 cardCondition: (card) => card.hasTrait('robot') || card.type === 'upgrade',

--- a/server/game/cards/03-WC/MegaGangerChieftain.js
+++ b/server/game/cards/03-WC/MegaGangerChieftain.js
@@ -4,8 +4,8 @@ class MegaGangerChieftain extends Card {
     // Play: You may ready and fight with a neighboring creature.
     setupCardAbilities(ability) {
         this.play({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card, context) => context.source.neighbors.includes(card),

--- a/server/game/cards/04-MM/Chronus.js
+++ b/server/game/cards/04-MM/Chronus.js
@@ -5,12 +5,12 @@ class Chronus extends Card {
     // After you resolve a R bonus icon, you may archive a card.
     setupCardAbilities(ability) {
         this.reaction({
-            optional: true,
             when: {
                 onDrawCards: (event, context) =>
                     !!event.bonus && event.player === context.source.controller
             },
             target: {
+                optional: true,
                 controller: 'self',
                 location: 'hand',
                 gameAction: ability.actions.archive()

--- a/server/game/cards/04-MM/LiamSay.js
+++ b/server/game/cards/04-MM/LiamSay.js
@@ -8,8 +8,8 @@ class LiamSay extends Card {
             when: {
                 onTurnStart: (_, context) => context.player === this.game.activePlayer
             },
-            optional: true,
             target: {
+                optional: true,
                 activePromptTitle: 'Choose a creature',
                 cardType: 'creature',
                 gameAction: ability.actions.dealDamage({ amount: 1 })

--- a/server/game/cards/04-MM/Munchling.js
+++ b/server/game/cards/04-MM/Munchling.js
@@ -5,8 +5,8 @@ class Munchling extends Card {
     // Fight: You may discard a Logos card from your hand or archives. If you do, gain 1A.
     setupCardAbilities(ability) {
         this.fight({
-            optional: true,
             target: {
+                optional: true,
                 location: ['archives', 'hand'],
                 cardCondition: (card) => card.hasHouse('logos'),
                 controller: 'self',

--- a/server/game/cards/04-MM/NiffleKong.js
+++ b/server/game/cards/04-MM/NiffleKong.js
@@ -31,8 +31,8 @@ class NiffleKong extends GiganticCard {
 
         this.fight({
             reap: true,
-            optional: true,
             target: {
+                optional: true,
                 controller: 'self',
                 cardType: 'creature',
                 cardCondition: (card) => card.hasTrait('niffle'),

--- a/server/game/cards/04-MM/SeekerOfTruth.js
+++ b/server/game/cards/04-MM/SeekerOfTruth.js
@@ -4,8 +4,8 @@ class SeekerOfTruth extends Card {
     // Fight: You may fight with a friendly non-Sanctum creature.
     setupCardAbilities(ability) {
         this.fight({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card) => !card.exhausted && !card.hasHouse('sanctum'),

--- a/server/game/cards/07-GR/CountrysideCrusher.js
+++ b/server/game/cards/07-GR/CountrysideCrusher.js
@@ -7,9 +7,9 @@ class CountrysideCrusher extends Card {
     // Scrap: Ready and fight with the least powerful friendly creature.
     setupCardAbilities(ability) {
         this.fight({
-            optional: true,
             condition: (context) => context.player.opponent && context.player.opponent.isHaunted(),
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card, context) => context.source.neighbors.includes(card),

--- a/server/game/cards/12-PV/Growland.js
+++ b/server/game/cards/12-PV/Growland.js
@@ -5,9 +5,9 @@ class Growland extends Card {
     // Scrap: Fully heal each friendly Mutant creature.
     setupCardAbilities(ability) {
         this.fight({
-            optional: true,
             reap: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 cardCondition: (card) => card.hasTrait('mutant'),
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/13-CC/AdministratorPelith.js
+++ b/server/game/cards/13-CC/AdministratorPelith.js
@@ -4,8 +4,8 @@ class AdministratorPelith extends Card {
     // After Reap: You may move a friendly Sanctum creature anywhere in your battleline.
     setupCardAbilities(ability) {
         this.reap({
-            optional: true,
             target: {
+                optional: true,
                 cardType: 'creature',
                 controller: 'self',
                 cardCondition: (card) => card.hasHouse('sanctum'),

--- a/test/server/cards/01-Core/GangerChieftain.spec.js
+++ b/test/server/cards/01-Core/GangerChieftain.spec.js
@@ -21,7 +21,6 @@ describe('Ganger Chieftain', function () {
             expect(this.troll.exhausted).toBe(true);
             expect(this.docBookton.location).toBe('discard');
             this.player1.playCreature(this.gangerChieftain, true);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.troll);
             expect(this.player1).not.toBeAbleToSelect(this.gangerChieftain);
@@ -38,7 +37,6 @@ describe('Ganger Chieftain', function () {
 
         it('should allow fighting with a non-house creature', function () {
             this.player1.play(this.gangerChieftain);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).not.toBeAbleToSelect(this.troll);
             expect(this.player1).not.toBeAbleToSelect(this.gangerChieftain);
@@ -61,7 +59,6 @@ describe('Ganger Chieftain', function () {
             this.player1.clickCard(this.batdrone);
             expect(this.batdrone.location).toBe('discard');
             this.player1.playCreature(this.gangerChieftain, true);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.troll);
             expect(this.player1).not.toBeAbleToSelect(this.gangerChieftain);
@@ -95,7 +92,6 @@ describe('Ganger Chieftain', function () {
             this.player2.reap(this.troll);
             expect(this.troll.exhausted).toBe(true);
             this.player2.playCreature(this.ganger1, true);
-            this.player2.clickCard(this.ganger1);
             expect(this.player2).toHavePrompt('Ganger Chieftain');
             expect(this.player2).toBeAbleToSelect(this.troll);
             expect(this.player2).not.toBeAbleToSelect(this.ganger1);
@@ -104,7 +100,6 @@ describe('Ganger Chieftain', function () {
             expect(this.troll.exhausted).toBe(false);
             expect(this.player2).isReadyToTakeAction();
             this.player2.playCreature(this.ganger2, true);
-            this.player2.clickCard(this.ganger2);
             expect(this.player2).toHavePrompt('Ganger Chieftain');
             expect(this.player2).not.toBeAbleToSelect(this.troll);
             expect(this.player2).not.toBeAbleToSelect(this.ganger2);
@@ -137,8 +132,7 @@ describe('Ganger Chieftain', function () {
             this.player1.reap(this.awakenedTitan);
             expect(this.awakenedTitan.exhausted).toBe(true);
             this.player1.playCreature(this.gangerChieftain, true);
-            expect(this.player1).toHavePrompt('Any reactions to Ganger Chieftain being played?');
-            this.player1.clickCard(this.gangerChieftain);
+            expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.awakenedTitan);
             this.player1.clickCard(this.awakenedTitan); // click to fail ready
             expect(this.awakenedTitan.exhausted).toBe(true);

--- a/test/server/cards/01-Core/MasterOf1.spec.js
+++ b/test/server/cards/01-Core/MasterOf1.spec.js
@@ -14,8 +14,8 @@ describe('Master of 1', function () {
 
         it('should optionally destroy a creature with 1 power on reap', function () {
             this.player1.reap(this.masterOf1);
-            expect(this.player1).toHavePrompt('Any reactions?');
-            this.player1.clickCard(this.masterOf1);
+            expect(this.player1).toHavePrompt('Master of 1');
+            expect(this.player1).toHavePromptButton('Done');
             expect(this.player1).toBeAbleToSelect(this.rotgrub);
             expect(this.player1).not.toBeAbleToSelect(this.emberImp);
             expect(this.player1).not.toBeAbleToSelect(this.buzzle);
@@ -28,7 +28,7 @@ describe('Master of 1', function () {
 
         it('should allow declining to destroy', function () {
             this.player1.reap(this.masterOf1);
-            expect(this.player1).toHavePrompt('Any reactions?');
+            expect(this.player1).toHavePrompt('Master of 1');
             this.player1.clickPrompt('Done');
             expect(this.rotgrub.location).toBe('play area');
             expect(this.player1.amber).toBe(1);

--- a/test/server/cards/01-Core/MasterOf2.spec.js
+++ b/test/server/cards/01-Core/MasterOf2.spec.js
@@ -14,8 +14,8 @@ describe('Master of 2', function () {
 
         it('should optionally destroy a creature with 2 power on reap', function () {
             this.player1.reap(this.masterOf2);
-            expect(this.player1).toHavePrompt('Any reactions?');
-            this.player1.clickCard(this.masterOf2);
+            expect(this.player1).toHavePrompt('Master of 2');
+            expect(this.player1).toHavePromptButton('Done');
             expect(this.player1).not.toBeAbleToSelect(this.rotgrub);
             expect(this.player1).toBeAbleToSelect(this.emberImp);
             expect(this.player1).not.toBeAbleToSelect(this.buzzle);
@@ -28,7 +28,7 @@ describe('Master of 2', function () {
 
         it('should allow declining to destroy', function () {
             this.player1.reap(this.masterOf2);
-            expect(this.player1).toHavePrompt('Any reactions?');
+            expect(this.player1).toHavePrompt('Master of 2');
             this.player1.clickPrompt('Done');
             expect(this.emberImp.location).toBe('play area');
             expect(this.player1.amber).toBe(1);

--- a/test/server/cards/01-Core/MasterOf3.spec.js
+++ b/test/server/cards/01-Core/MasterOf3.spec.js
@@ -14,8 +14,8 @@ describe('Master of 3', function () {
 
         it('should optionally destroy a creature with 1 power on reap', function () {
             this.player1.reap(this.masterOf3);
-            expect(this.player1).toHavePrompt('Any reactions?');
-            this.player1.clickCard(this.masterOf3);
+            expect(this.player1).toHavePrompt('Master of 3');
+            expect(this.player1).toHavePromptButton('Done');
             expect(this.player1).not.toBeAbleToSelect(this.rotgrub);
             expect(this.player1).not.toBeAbleToSelect(this.emberImp);
             expect(this.player1).toBeAbleToSelect(this.buzzle);
@@ -28,7 +28,7 @@ describe('Master of 3', function () {
 
         it('should allow declining to destroy', function () {
             this.player1.reap(this.masterOf3);
-            expect(this.player1).toHavePrompt('Any reactions?');
+            expect(this.player1).toHavePrompt('Master of 3');
             this.player1.clickPrompt('Done');
             expect(this.buzzle.location).toBe('play area');
             expect(this.player1.amber).toBe(1);

--- a/test/server/cards/01-Core/RockhurlingGiant.spec.js
+++ b/test/server/cards/01-Core/RockhurlingGiant.spec.js
@@ -17,14 +17,11 @@ describe('Rock-Hurling Giant', function () {
             this.player1.clickPrompt('brobnar');
             this.player1.clickCard(this.troll);
             this.player1.clickPrompt('Discard this card');
-            expect(this.player1).toHavePrompt('Triggered Abilities');
-            this.player1.clickCard(this.rockHurlingGiant);
             expect(this.player1).toHavePrompt('Rock-Hurling Giant');
             this.player1.clickCard(this.valdr);
             expect(this.valdr.damage).toBe(4);
             this.player1.clickCard(this.lootTheBodies);
             this.player1.clickPrompt('Discard this card');
-            this.player1.clickCard(this.rockHurlingGiant);
             this.player1.clickCard(this.valdr);
             expect(this.valdr.location).toBe('discard');
         });
@@ -36,7 +33,7 @@ describe('Rock-Hurling Giant', function () {
             this.player1.clickCard(this.troll);
             expect(this.player1).toHavePrompt('Sloppy Labwork');
             this.player1.clickCard(this.lootTheBodies);
-            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toHavePrompt('Rock-Hurling Giant');
         });
 
         it("should not trigger during opponent's turn", function () {

--- a/test/server/cards/01-Core/ZyzzixTheMany.spec.js
+++ b/test/server/cards/01-Core/ZyzzixTheMany.spec.js
@@ -15,8 +15,8 @@ describe('Zyzzix the Many', function () {
 
         it('should optionally reveal a creature from hand to archive it and gain power counters after reap', function () {
             this.player1.reap(this.zyzzixTheMany);
-            expect(this.player1).toHavePrompt('Any reactions?');
-            this.player1.clickCard(this.zyzzixTheMany);
+            expect(this.player1).toHavePrompt('Zyzzix the Many');
+            expect(this.player1).toHavePromptButton('Done');
             expect(this.player1).toBeAbleToSelect(this.zorg);
             expect(this.player1).toBeAbleToSelect(this.mindwarper);
             expect(this.player1).not.toBeAbleToSelect(this.squawker);
@@ -29,8 +29,7 @@ describe('Zyzzix the Many', function () {
 
         it('should optionally reveal a creature from hand after fight', function () {
             this.player1.fightWith(this.zyzzixTheMany, this.lamindra);
-            expect(this.player1).toHavePrompt('Any reactions?');
-            this.player1.clickCard(this.zyzzixTheMany);
+            expect(this.player1).toHavePrompt('Zyzzix the Many');
             this.player1.clickCard(this.zorg);
             expect(this.zorg.location).toBe('archives');
             expect(this.zyzzixTheMany.powerCounters).toBe(3);
@@ -39,7 +38,7 @@ describe('Zyzzix the Many', function () {
 
         it('should allow skipping the ability', function () {
             this.player1.reap(this.zyzzixTheMany);
-            expect(this.player1).toHavePrompt('Any reactions?');
+            expect(this.player1).toHavePrompt('Zyzzix the Many');
             this.player1.clickPrompt('Done');
             expect(this.zorg.location).toBe('hand');
             expect(this.zyzzixTheMany.powerCounters).toBe(0);
@@ -49,13 +48,11 @@ describe('Zyzzix the Many', function () {
 
         it('should stack power counters on multiple uses', function () {
             this.player1.reap(this.zyzzixTheMany);
-            this.player1.clickCard(this.zyzzixTheMany);
             this.player1.clickCard(this.zorg);
             this.zyzzixTheMany.exhausted = false;
             expect(this.zyzzixTheMany.powerCounters).toBe(3);
             this.zyzzixTheMany.ready();
             this.player1.reap(this.zyzzixTheMany);
-            this.player1.clickCard(this.zyzzixTheMany);
             this.player1.clickCard(this.mindwarper);
             expect(this.zyzzixTheMany.powerCounters).toBe(6);
             expect(this.player1).isReadyToTakeAction();

--- a/test/server/cards/02-AoA/BonerotVenom.spec.js
+++ b/test/server/cards/02-AoA/BonerotVenom.spec.js
@@ -146,8 +146,6 @@ describe('Bonerot Venom', function () {
             this.player2.endTurn();
             this.player1.clickPrompt('brobnar');
             this.player1.play(this.gangerChieftain);
-            expect(this.player1).toBeAbleToSelect(this.gangerChieftain);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.umbra);
             this.player1.clickCard(this.umbra);
@@ -168,8 +166,6 @@ describe('Bonerot Venom', function () {
             this.player2.endTurn();
             this.player1.clickPrompt('brobnar');
             this.player1.play(this.gangerChieftain);
-            expect(this.player1).toBeAbleToSelect(this.gangerChieftain);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.umbra);
             this.player1.clickCard(this.umbra);
@@ -199,8 +195,6 @@ describe('Bonerot Venom', function () {
             this.player2.endTurn();
             this.player1.clickPrompt('brobnar');
             this.player1.play(this.gangerChieftain);
-            expect(this.player1).toBeAbleToSelect(this.gangerChieftain);
-            this.player1.clickCard(this.gangerChieftain);
             expect(this.player1).toHavePrompt('Ganger Chieftain');
             expect(this.player1).toBeAbleToSelect(this.mackTheKnife);
             this.player1.clickCard(this.mackTheKnife);

--- a/test/server/cards/02-AoA/Drummernaut.spec.js
+++ b/test/server/cards/02-AoA/Drummernaut.spec.js
@@ -56,10 +56,7 @@ describe('Drummernaut', function () {
 
             for (let i = 1; i < 6; i++) {
                 this.player1.playCreature(this.gangerChieftain);
-                expect(this.player1).toHavePrompt(
-                    'Any reactions to Ganger Chieftain being played?'
-                );
-                this.player1.clickCard(this.gangerChieftain);
+                expect(this.player1).toHavePrompt('Ganger Chieftain');
                 this.player1.clickCard(this.drummernaut);
                 expect(this.player1).isReadyToTakeAction();
                 this.player1.reap(this.drummernaut);
@@ -69,8 +66,7 @@ describe('Drummernaut', function () {
             }
 
             this.player1.playCreature(this.gangerChieftain);
-            expect(this.player1).toHavePrompt('Any reactions to Ganger Chieftain being played?');
-            this.player1.clickCard(this.gangerChieftain);
+            expect(this.player1).toHavePrompt('Ganger Chieftain');
             this.player1.clickCard(this.drummernaut);
             expect(this.drummernaut.exhausted).toBe(false);
             this.player1.clickCard(this.drummernaut);

--- a/test/server/cards/02-AoA/Ogopogo.spec.js
+++ b/test/server/cards/02-AoA/Ogopogo.spec.js
@@ -15,9 +15,6 @@ describe('Ogopogo', function () {
 
         it('should deal 2 damage to another creature after it attacks and destroys a different one', function () {
             this.player1.fightWith(this.ogopogo, this.umbra);
-            expect(this.player1).toHavePrompt('Triggered Abilities');
-            expect(this.player1).toBeAbleToSelect(this.ogopogo);
-            this.player1.clickCard(this.ogopogo);
             expect(this.player1).toHavePrompt('Ogopogo');
             expect(this.player1).toBeAbleToSelect(this.gamgee);
             this.player1.clickCard(this.gamgee);

--- a/test/server/cards/03-WC/ChiefEngineerWalls.spec.js
+++ b/test/server/cards/03-WC/ChiefEngineerWalls.spec.js
@@ -146,13 +146,9 @@ describe('Chief Engineer Walls', function () {
             expect(this.dustPixie.location).toBe('discard');
 
             // Choose to trigger remaining "may" ability
-            expect(this.player1).toHavePrompt('Any reactions?');
-            expect(this.player1).toBeAbleToSelect(this.chiefEngineerWalls);
-            expect(this.player1).toHavePromptButton('Done');
-            this.player1.clickCard(this.chiefEngineerWalls);
-
-            // Resolve Walls' ability
+            expect(this.player1).toHavePrompt('Chief Engineer Walls');
             expect(this.player1).toBeAbleToSelect(this.accessDenied);
+            expect(this.player1).toHavePromptButton('Done');
             this.player1.clickCard(this.accessDenied);
             expect(this.accessDenied.location).toBe('hand');
 

--- a/test/server/cards/04-MM/ArdentHero.spec.js
+++ b/test/server/cards/04-MM/ArdentHero.spec.js
@@ -125,9 +125,7 @@ describe('Ardent Hero', function () {
         it('should not take damage from effect of >5 power creature', function () {
             this.player1.clickCard(this.firstBlood);
             this.player1.clickPrompt('Discard this card');
-            expect(this.player1).toBeAbleToSelect(this.rockHurlingGiant);
-            this.player1.clickCard(this.rockHurlingGiant);
-            expect(this.player1).toHavePrompt('Choose a creature');
+            expect(this.player1).toHavePrompt('Rock-Hurling Giant');
             expect(this.player1).toBeAbleToSelect(this.ardentHero);
             this.player1.clickCard(this.ardentHero);
             expect(this.ardentHero.location).toBe('play area');

--- a/test/server/cards/04-MM/Chronus.spec.js
+++ b/test/server/cards/04-MM/Chronus.spec.js
@@ -18,7 +18,6 @@ describe('Chronus', function () {
             this.dextre.enhancements = ['amber', 'draw', 'amber'];
 
             this.player1.play(this.dextre);
-            expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toHavePromptButton('Done');
             this.player1.clickPrompt('Done');
             expect(this.player1.amber).toBe(2);
@@ -28,9 +27,7 @@ describe('Chronus', function () {
             this.dextre.enhancements = ['amber', 'amber', 'draw'];
 
             this.player1.play(this.dextre);
-            expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toHavePromptButton('Done');
-            this.player1.clickCard(this.chronus);
             expect(this.player1).toBeAbleToSelect(this.poke);
             expect(this.player1).toBeAbleToSelect(this.tautauVapors);
             expect(this.player1).toBeAbleToSelect(this.mimicGel);
@@ -58,11 +55,8 @@ describe('Chronus', function () {
             this.dextre.enhancements = ['draw', 'draw', 'draw', 'draw'];
 
             this.player1.play(this.dextre);
-            this.player1.clickCard(this.chronus);
             this.player1.clickCard(this.mimicGel);
-            this.player1.clickCard(this.chronus);
             this.player1.clickCard(this.poke);
-            this.player1.clickCard(this.chronus);
             this.player1.clickCard(this.tautauVapors);
             this.player1.clickPrompt('Done');
             expect(this.player1.player.hand.length).toBe(4);
@@ -76,7 +70,6 @@ describe('Chronus', function () {
             this.poke.enhancements = ['draw'];
 
             this.player1.play(this.poke);
-            expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toHavePromptButton('Done');
             this.player1.clickPrompt('Done');
             expect(this.player1.player.hand.length).toBe(4);
@@ -91,12 +84,10 @@ describe('Chronus', function () {
             this.player1.clickPrompt('Left');
 
             this.player1.play(this.dextre);
-            expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toBeAbleToSelect(this.mimicGel);
             expect(this.player1).toHavePromptButton('Done');
             this.player1.clickCard(this.mimicGel);
             this.player1.clickCard(this.poke);
-            expect(this.player1).toBeAbleToSelect(this.chronus);
             expect(this.player1).toHavePromptButton('Done');
             this.player1.clickPrompt('Done');
             expect(this.poke.location).toBe('archives');

--- a/test/server/cards/04-MM/LiamSay.spec.js
+++ b/test/server/cards/04-MM/LiamSay.spec.js
@@ -16,8 +16,6 @@ describe("Liam Say's ability", function () {
         this.player2.clickPrompt('untamed');
         this.player2.endTurn();
         expect(this.player1).toHavePromptButton('Done');
-        expect(this.player1).toBeAbleToSelect(this.liamSay);
-        this.player1.clickCard(this.liamSay);
         expect(this.player1).toBeAbleToSelect(this.troll);
         expect(this.player1).toBeAbleToSelect(this.flaxia);
         expect(this.player1).toBeAbleToSelect(this.fuzzyGruen);
@@ -32,7 +30,6 @@ describe("Liam Say's ability", function () {
         this.player2.clickPrompt('untamed');
         this.player2.endTurn();
         expect(this.player1).toHavePromptButton('Done');
-        expect(this.player1).toBeAbleToSelect(this.liamSay);
         this.player1.clickPrompt('Done');
         this.player1.clickPrompt('shadows');
     });

--- a/test/server/cards/04-MM/Munchling.spec.js
+++ b/test/server/cards/04-MM/Munchling.spec.js
@@ -17,13 +17,14 @@ describe('munchling', function () {
         });
 
         it('give prompt', function () {
-            expect(this.player1).toBeAbleToSelect(this.munchling);
+            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).toBeAbleToSelect(this.eyegor);
+            expect(this.player1).toBeAbleToSelect(this.archimedes);
+            expect(this.player1).not.toBeAbleToSelect(this.snufflegator);
         });
 
         describe('and the ability is triggered', function () {
-            beforeEach(function () {
-                this.player1.clickCard(this.munchling);
-            });
+            beforeEach(function () {});
 
             it('and gives prompt', function () {
                 expect(this.player1).toHavePrompt('Choose a card');

--- a/test/server/cards/04-MM/NiffleKong.spec.js
+++ b/test/server/cards/04-MM/NiffleKong.spec.js
@@ -148,7 +148,6 @@ describe('Niffle Kong', function () {
 
             this.niffleKong.ready();
             this.player1.reap(this.niffleKong);
-            this.player1.clickCard(this.niffleKong);
             expect(this.player1).not.toBeAbleToSelect(this.fuzzyGruen);
             expect(this.player1).toBeAbleToSelect(this.niffleKong);
             expect(this.player1).toBeAbleToSelect(this.niffleApe1);
@@ -183,7 +182,6 @@ describe('Niffle Kong', function () {
 
             this.niffleKong2.ready();
             this.player1.fightWith(this.niffleKong2, this.zorg);
-            this.player1.clickCard(this.niffleKong2);
             this.player1.clickCard(this.niffleApe1);
             this.player1.clickCard(this.collectorWorm);
             this.player1.clickCard(this.mothergun);
@@ -204,7 +202,6 @@ describe('Niffle Kong', function () {
 
             this.niffleKong.ready();
             this.player1.reap(this.niffleKong);
-            this.player1.clickCard(this.niffleKong);
             this.player1.clickCard(this.niffleApe1);
             this.player1.clickCard(this.niffleKong);
             expect(this.player1.amber).toBe(2);
@@ -220,7 +217,6 @@ describe('Niffle Kong', function () {
 
             this.niffleKong2.ready();
             this.player1.fightWith(this.niffleKong2, this.zorg);
-            this.player1.clickCard(this.niffleKong2);
             this.player1.clickCard(this.niffleApe1);
             this.player1.clickCard(this.niffleKong2);
             expect(this.player1.amber).toBe(1);

--- a/test/server/cards/05-DT/TheChosenOne.spec.js
+++ b/test/server/cards/05-DT/TheChosenOne.spec.js
@@ -69,8 +69,6 @@ describe('The Chosen One', function () {
                     this.player2.reap(this.batdrone);
                     this.player2.play(this.helperBot);
                     this.player2.play(this.gangerChieftain, true);
-                    expect(this.player2).toBeAbleToSelect(this.gangerChieftain);
-                    this.player2.clickCard(this.gangerChieftain);
                 });
 
                 it('should be able to ready out of ready phase', function () {

--- a/test/server/cards/12-PV/Growland.spec.js
+++ b/test/server/cards/12-PV/Growland.spec.js
@@ -16,7 +16,6 @@ describe('Growland', function () {
 
         it('should allow destroying a Mutant creature after fighting', function () {
             this.player1.fightWith(this.growland, this.urchin);
-            this.player1.clickCard(this.growland);
             expect(this.player1).toBeAbleToSelect(this.growland);
             expect(this.player1).toBeAbleToSelect(this.fandangle);
             expect(this.player1).not.toBeAbleToSelect(this.yurk);
@@ -30,7 +29,6 @@ describe('Growland', function () {
 
         it('should allow destroying a Mutant creature after reaping', function () {
             this.player1.reap(this.growland);
-            this.player1.clickCard(this.growland);
             this.player1.clickCard(this.citizenShrix);
             expect(this.citizenShrix.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();

--- a/test/server/cards/13-CC/AdministratorPelith.spec.js
+++ b/test/server/cards/13-CC/AdministratorPelith.spec.js
@@ -14,7 +14,6 @@ describe('Administrator Pelith', function () {
 
         it('should allow moving a friendly Sanctum creature after reaping', function () {
             this.player1.reap(this.administratorPelith);
-            this.player1.clickCard(this.administratorPelith);
             expect(this.player1).toBeAbleToSelect(this.barristerJoya);
             expect(this.player1).toBeAbleToSelect(this.administratorPelith);
             expect(this.player1).not.toBeAbleToSelect(this.troll);


### PR DESCRIPTION
Fixes the poor UX when only one card can be targeted by a triggered effect. Cards like Ganger Chieftain, Master of 1/2/3, Rockhurling Giant, Zyzzix the Many, and similar cards previously showed a selector with only a single valid option, requiring an extra click to confirm. These cards now auto-select the only valid target, skipping the unnecessary prompt.

Affected cards: Ganger Chieftain, Mega-Ganger Chieftain, Master of 1/2/3, Rockhurling Giant, Sergeant Zakiel, Zyzzix the Many, Ogopogo, The Grey Rider, Chief Engineer Walls, Chronus, Liam Say, Munchling, Niffle Kong, Seeker of Truth, Countryside Crusher, Growland, Administrator Pelith.

Fixes #384

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadly changes how many cards’ optional triggered abilities are prompted (skipping the extra opt-in/reaction step), which could subtly affect trigger ordering/interaction UX even though underlying game actions are unchanged.
> 
> **Overview**
> Improves UX for many "you may" abilities with a single card target by moving `optional: true` from the ability level into the `target` block, so the game shows the target prompt directly with a `Done` button instead of an extra "Any reactions?"/source-card click step.
> 
> Updates affected card implementations and adjusts related tests to match the new prompt flow; documentation is expanded to codify when `optional` should live on `target` vs the ability (including guidance for `then`, multi-target, and reaction/interrupt cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f64ba3fcc66052d37c0e81910a9094ab6d482ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->