### PR TITLE
fix: card under card no longer stacks

### DIFF
--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -2076,7 +2076,8 @@ pre {
 .squishable-card-panel {
   display: flex;
   justify-content: flex-start;
-  margin: 0px 5px;
+  margin-left: 5px;
+  margin-right: 5px;
   min-height: 0;
   padding: 0px;
   position: relative;


### PR DESCRIPTION
Fixes #5018

The `squishable-card-panel` was using `margin: 0px 5px` which sets top/bottom margins too. Splitting into explicit `margin-left` and `margin-right` restores the stacked card display for cards under other cards (e.g. Graft, Masterplan, Hydrogan).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts margins for `SquishableCardPanel` layout; potential impact is limited to spacing/stacking visuals in the game board UI.
> 
> **Overview**
> Fixes `SquishableCardPanel` stacking by changing `.squishable-card-panel` from `margin: 0 5px` to explicit `margin-left`/`margin-right`, avoiding unintended top/bottom margins that interfered with cards rendered underneath others.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad952a0ded7fc5f5e129c2711647577139d6710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->