### PR TITLE
fix: facedown card zoom and houseless card detection

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -165,14 +165,6 @@ const Card = ({
         return true;
     };
 
-    const isFacedown = () => {
-        // Hover/zoom is allowed whenever the server sent us full card data
-        // (i.e. a name). Cards under our own permanents (Masterplan, Jargogle,
-        // etc.) are facedown to opponents but visible to the controller, so
-        // the controller's summary includes the name and we should preview it.
-        return !card.name;
-    };
-
     const getDragFrame = (image) => {
         if (!isDragging) {
             return null;
@@ -252,14 +244,16 @@ const Card = ({
                 <div
                     className={cardClass}
                     onMouseOver={
-                        !disableMouseOver && !isFacedown() && onMouseOver
+                        !disableMouseOver && onMouseOver
                             ? () =>
                                   onMouseOver({
                                       image: (
                                           <CardImage
                                               card={{
                                                   ...(card.versusCard || card),
-                                                  facedown: false,
+                                                  // Opponent's facedown cards have no name in the
+                                                  // summary; render the cardback in that case.
+                                                  facedown: !card.name,
                                                   location: 'zoom'
                                               }}
                                               cardBack={cardBack}
@@ -269,7 +263,7 @@ const Card = ({
                                   })
                             : undefined
                     }
-                    onMouseOut={!disableMouseOver && !isFacedown() ? onMouseOut : undefined}
+                    onMouseOut={!disableMouseOver ? onMouseOut : undefined}
                     onClick={(event) => onCardClicked(event, card)}
                 >
                     <div>

--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -119,6 +119,14 @@ const Card = ({
         }
 
         let maxCards = 1 + (underneathCards.length - 1) / 6;
+        // Each upgrade adds an effective -15px to the wrapper's vertical flow,
+        // which would pull the underneath panel up by 15px per upgrade and eat
+        // into the bottom peek. Visually translate it back down so the peek is
+        // preserved regardless of upgrade count.
+        const upgradeOffset = (card.upgrades?.length || 0) * 15 * getCardSizeMultiplier();
+        const underneathStyle = upgradeOffset
+            ? { transform: `translateY(${upgradeOffset}px)` }
+            : undefined;
         return (
             <SquishableCardPanel
                 cardBack={cardBack}
@@ -132,6 +140,7 @@ const Card = ({
                 hasActiveHouse={hasActiveHouse}
                 isMe={isMe}
                 source='underneath'
+                style={underneathStyle}
             />
         );
     };
@@ -157,7 +166,11 @@ const Card = ({
     };
 
     const isFacedown = () => {
-        return card.facedown || !card.name;
+        // Hover/zoom is allowed whenever the server sent us full card data
+        // (i.e. a name). Cards under our own permanents (Masterplan, Jargogle,
+        // etc.) are facedown to opponents but visible to the controller, so
+        // the controller's summary includes the name and we should preview it.
+        return !card.name;
     };
 
     const getDragFrame = (image) => {
@@ -246,6 +259,7 @@ const Card = ({
                                           <CardImage
                                               card={{
                                                   ...(card.versusCard || card),
+                                                  facedown: false,
                                                   location: 'zoom'
                                               }}
                                               cardBack={cardBack}

--- a/client/Components/GameBoard/CardImage.jsx
+++ b/client/Components/GameBoard/CardImage.jsx
@@ -72,10 +72,12 @@ const CardImage = ({ card, cardBack, size, halfSize, onMouseOver, onMouseOut }) 
     const englishImageUrl = `/img/cards/${
         halfSize ? 'halfSize/' : ''
     }${imageName}.${imageExtension}`;
+    const isHouselessByNumber = /^[ARS]/.test(String(card?.number ?? ''));
     const shouldRenderCanvas =
         Boolean(card?.maverick) ||
         Boolean(card?.anomaly) ||
         (card?.id && houselessCards.includes(card.id)) ||
+        isHouselessByNumber ||
         (Array.isArray(card?.enhancements) && card.enhancements.length > 0) ||
         card?.location === 'play area' ||
         card?.location === 'zoom';

--- a/client/Components/GameBoard/SquishableCardPanel.jsx
+++ b/client/Components/GameBoard/SquishableCardPanel.jsx
@@ -83,7 +83,8 @@ const SquishableCardPanel = (props) => {
 
     const style = {
         width: `${overallDimensions.width}px`,
-        height: `${overallDimensions.height}px`
+        height: `${overallDimensions.height}px`,
+        ...(props.style || {})
     };
 
     return (
@@ -111,6 +112,7 @@ SquishableCardPanel.propTypes = {
     isMe: PropTypes.bool,
     isSpectating: PropTypes.bool,
     source: PropTypes.string,
+    style: PropTypes.object,
     title: PropTypes.string
 };
 

--- a/client/Components/GameBoard/SquishableCardPanel.jsx
+++ b/client/Components/GameBoard/SquishableCardPanel.jsx
@@ -60,7 +60,7 @@ const SquishableCardPanel = (props) => {
                 key={card.uuid}
                 card={card}
                 cardBack={props.cardBack}
-                disableMouseOver={!card.name}
+                disableMouseOver={false}
                 canDrag={props.manualMode}
                 onClick={props.onCardClick}
                 onMouseOver={props.onMouseOver}

--- a/client/archonMaker.js
+++ b/client/archonMaker.js
@@ -768,7 +768,7 @@ export const buildCard = async (
         maverick ||
         anomaly ||
         houselessCards.includes(card.id) ||
-        (number && (number[0] === 'R' || number[0] === 'S'))
+        /^[ARS]/.test(String(number ?? ''))
     ) {
         let house;
         if (maverick) {

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -1121,12 +1121,17 @@ pre {
 }
 
 .card-zoom > img,
-.card-zoom > canvas {
+.card-zoom > canvas,
+.card-zoom canvas {
   width: 100% !important;
   height: 100% !important;
   max-width: 100% !important;
   max-height: 100% !important;
   display: block;
+}
+.card-zoom > div {
+  width: 100%;
+  height: 100%;
 }
 
 .overlay {

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -1130,8 +1130,8 @@ pre {
   display: block;
 }
 .card-zoom > div {
-  width: 100%;
-  height: 100%;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .overlay {


### PR DESCRIPTION
Fixes #3532

## Changes

- Fix `card-zoom` CSS to properly size wrapper `div` and support nested `canvas` elements (facedown cards rendered via canvas weren't sized correctly in zoom)
- Add `isHouselessByNumber` check in `CardImage` to trigger canvas rendering for cards with A/R/S prefixed numbers
- Normalize houseless number check to a regex in `archonMaker.js` (consistent with CardImage, now also handles A prefix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI rendering/CSS tweaks and small conditional logic changes; low risk but could affect card hover/zoom and stacking layout across card sizes.
> 
> **Overview**
> Fixes card zoom/hover rendering for facedown and houseless cards. Hover zoom now forces the cardback when an opponent card has no name (treating it as facedown), and `card-zoom` CSS is updated to correctly size wrapper `div`s and nested `canvas` elements.
> 
> Improves houseless-card detection by treating cards with `A`/`R`/`S`-prefixed numbers as houseless in both `CardImage` and `archonMaker` (using a shared regex), ensuring these cards render via canvas overlays consistently.
> 
> Adjusts play-area layout so “underneath” child-card panels keep their bottom peek when the parent has upgrades (applying a size-aware translate), and allows passing custom `style` into `SquishableCardPanel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f519ea7d3f39cbb58d0911b178884eef3f7e125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->