### PR TITLE
fix: Deep Blue Bryn then condition uses context instead of closure

### DIFF
--- a/server/game/cards/14-DM/DeepBlueBryn.js
+++ b/server/game/cards/14-DM/DeepBlueBryn.js
@@ -5,13 +5,13 @@ class DeepBlueBryn extends Card {
     setupCardAbilities(ability) {
         this.fight({
             gameAction: ability.actions.steal({ amount: 1 }),
-            then: (preThenContext) => ({
+            then: {
                 alwaysTriggers: true,
-                condition: () => preThenContext.game.isKeyForged('blue'),
+                condition: (context) => context.game.isKeyForged('blue'),
                 gameAction: ability.actions.ward((context) => ({
                     target: context.source
                 }))
-            })
+            }
         });
     }
 }

--- a/server/game/cards/14-DM/EmperorMemrox.js
+++ b/server/game/cards/14-DM/EmperorMemrox.js
@@ -17,14 +17,14 @@ class EmperorMemrox extends Card {
                 }
             }),
             effect: 'archive a card',
-            then: () => ({
+            then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.gainAmber((context) => ({
                     amount: context.player.archives.length
                 })),
                 message: '{0} uses {1} to gain {3} amber',
                 messageArgs: (context) => [context.player.archives.length]
-            })
+            }
         });
     }
 }

--- a/test/server/cards/14-DM/DeepBlueBryn.spec.js
+++ b/test/server/cards/14-DM/DeepBlueBryn.spec.js
@@ -69,4 +69,28 @@ describe('Deep Blue Bryn', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe('Deep Blue Bryn after fight when opponent has no amber and blue key is forged', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'skyborn',
+                    inPlay: ['deep-blue-bryn']
+                },
+                player2: {
+                    amber: 0,
+                    inPlay: ['bad-penny']
+                }
+            });
+            this.player1.player.keys.blue = true;
+        });
+
+        it('wards Deep Blue Bryn even though steal had no effect', function () {
+            this.player1.fightWith(this.deepBlueBryn, this.badPenny);
+            expect(this.player1.amber).toBe(0);
+            expect(this.player2.amber).toBe(0);
+            expect(this.deepBlueBryn.warded).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });

--- a/test/server/cards/14-DM/EmperorMemrox.spec.js
+++ b/test/server/cards/14-DM/EmperorMemrox.spec.js
@@ -40,6 +40,18 @@ describe('Emperor Memrox', function () {
             expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
+
+        it('still gains 1 amber per archived card when no cards are in hand to archive', function () {
+            this.player1.moveCard(this.troll, 'archives');
+            for (const card of this.player1.player.hand.slice()) {
+                this.player1.moveCard(card, 'discard');
+            }
+            expect(this.player1.player.archives.length).toBe(1);
+            this.player1.reap(this.emperorMemrox);
+            // 1 reap amber + 1 amber for the card already in archives
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
     });
 
     describe("Emperor Memrox's invulnerable in center", function () {


### PR DESCRIPTION
Fix Deep Blue Bryn's `then` condition to use the standard `context` parameter pattern instead of closing over `preThenContext`. Also converts the `then` from a function to an object (consistent with how other cards use `then` with `alwaysTriggers`).

Adds a test case covering the case where the blue key is forged but the opponent has no amber (steal has no effect), verifying Bryn still wards herself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rules-engine adjustment limited to two card scripts, with added tests covering previously missed edge cases where the primary action has no effect.
> 
> **Overview**
> Fixes `DeepBlueBryn` and `EmperorMemrox` follow-up (`then`) effects to use the standard `context` parameter (and `then` object form) so their conditional/always-trigger behavior is evaluated consistently even when the initial action doesn’t change game state.
> 
> Adds regression tests for Deep Blue Bryn warding when a blue key is forged but stealing fails due to 0 amber, and for Emperor Memrox still awarding amber based on existing archives when no card can be archived from hand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a63ac445bc388e1e0938ef1731afc68a4b8062eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->