### PR TITLE
fix: add activePromptTitle to card target selectors

### DIFF
--- a/server/game/cards/03-WC/GreaterOxtet.js
+++ b/server/game/cards/03-WC/GreaterOxtet.js
@@ -10,6 +10,7 @@ class GreaterOxtet extends Card {
                     event.phase === 'ready' && this.game.activePlayer === context.player
             },
             target: {
+                activePromptTitle: 'Choose which card to purge',
                 controller: 'self',
                 location: 'hand',
                 gameAction: ability.actions.purge()

--- a/server/game/cards/03-WC/Hologrammophone.js
+++ b/server/game/cards/03-WC/Hologrammophone.js
@@ -5,6 +5,7 @@ class Hologrammophone extends Card {
     setupCardAbilities(ability) {
         this.action({
             target: {
+                activePromptTitle: 'Choose a creature to ward',
                 cardType: 'creature',
                 gameAction: ability.actions.ward()
             }

--- a/server/game/cards/03-WC/ObsidianForge.js
+++ b/server/game/cards/03-WC/ObsidianForge.js
@@ -5,6 +5,7 @@ class ObsidianForge extends Card {
     setupCardAbilities(ability) {
         this.action({
             target: {
+                activePromptTitle: 'Choose a creature to sacrifice',
                 mode: 'unlimited',
                 controller: 'self',
                 cardType: 'creature',

--- a/server/game/cards/03-WC/UniversalRecyclingBin.js
+++ b/server/game/cards/03-WC/UniversalRecyclingBin.js
@@ -5,6 +5,7 @@ class UniversalRecycleBin extends Card {
     setupCardAbilities(ability) {
         this.action({
             target: {
+                activePromptTitle: 'Choose which card to archive',
                 location: 'purged',
                 controller: 'self',
                 gameAction: ability.actions.archive()

--- a/server/game/cards/06-WoE/Aristotlmimus.js
+++ b/server/game/cards/06-WoE/Aristotlmimus.js
@@ -18,6 +18,7 @@ class Aristotlmimus extends Card {
             then: (preThenContext) => ({
                 alwaysTriggers: true,
                 target: {
+                    activePromptTitle: 'Choose a card to archive',
                     cardCondition: (_, context) => context.source.hasToken('wisdom'),
                     location: 'hand',
                     controller: 'self',

--- a/server/game/cards/06-WoE/TheOldTinker.js
+++ b/server/game/cards/06-WoE/TheOldTinker.js
@@ -5,6 +5,7 @@ class TheOldTinker extends Card {
     setupCardAbilities(ability) {
         this.reap({
             target: {
+                activePromptTitle: 'Choose a card to discard',
                 controller: 'self',
                 location: 'hand',
                 gameAction: ability.actions.discard()

--- a/server/game/cards/07-GR/ForgottenGuardian.js
+++ b/server/game/cards/07-GR/ForgottenGuardian.js
@@ -7,6 +7,7 @@ class ForgottenGuardian extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
+                activePromptTitle: 'Choose which card to purge',
                 location: 'discard',
                 mode: 'exactly',
                 numCards: 1,

--- a/server/game/cards/07-GR/QyxxlyxxGraveMaster.js
+++ b/server/game/cards/07-GR/QyxxlyxxGraveMaster.js
@@ -9,6 +9,7 @@ class QyxxlyxxGraveMaster extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
+                activePromptTitle: 'Choose a creature to purge',
                 cardType: 'creature',
                 controller: 'any',
                 location: 'discard',

--- a/server/game/cards/07-GR/TerribleTeammates.js
+++ b/server/game/cards/07-GR/TerribleTeammates.js
@@ -5,6 +5,7 @@ class TerribleTeammates extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
+                activePromptTitle: 'Choose a card to discard',
                 optional: true,
                 controller: 'self',
                 location: 'hand',

--- a/server/game/cards/08-AS/Aurascope.js
+++ b/server/game/cards/08-AS/Aurascope.js
@@ -6,6 +6,7 @@ class Aurascope extends Card {
     setupCardAbilities(ability) {
         this.action({
             target: {
+                activePromptTitle: 'Choose a card to discard',
                 mode: 'exactly',
                 numCards: 1,
                 location: 'hand',
@@ -14,6 +15,7 @@ class Aurascope extends Card {
             },
             then: (preThenContext) => ({
                 target: {
+                    activePromptTitle: 'Choose which card to purge',
                     mode: 'exactly',
                     numCards: 1,
                     location: 'discard',

--- a/server/game/cards/08-AS/HoistOperations.js
+++ b/server/game/cards/08-AS/HoistOperations.js
@@ -5,6 +5,7 @@ class HoistOperations extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
+                activePromptTitle: 'Choose a creature to archive',
                 cardType: 'creature',
                 controller: 'any',
                 gameAction: ability.actions.archive()

--- a/server/game/cards/08-AS/IntentionalDischarge.js
+++ b/server/game/cards/08-AS/IntentionalDischarge.js
@@ -11,6 +11,7 @@ class IntentionalDischarge extends Card {
             },
             then: {
                 target: {
+                    activePromptTitle: 'Choose a creature to ready',
                     controller: 'self',
                     cardType: 'creature',
                     cardCondition: (card) => card.hasHouse('mars'),

--- a/server/game/cards/08-AS/KyypaxEncapsulator.js
+++ b/server/game/cards/08-AS/KyypaxEncapsulator.js
@@ -5,6 +5,7 @@ class KyypaxEncapsulator extends Card {
     setupCardAbilities(ability) {
         this.reap({
             target: {
+                activePromptTitle: 'Choose a creature to archive',
                 cardType: 'creature',
                 controller: 'opponent',
                 gameAction: ability.actions.archive()

--- a/server/game/cards/08-AS/Stratowise.js
+++ b/server/game/cards/08-AS/Stratowise.js
@@ -6,6 +6,7 @@ class Stratowise extends Card {
         this.reap({
             fight: true,
             target: {
+                activePromptTitle: 'Choose a card to discard',
                 controller: 'self',
                 location: 'hand',
                 gameAction: ability.actions.discard()

--- a/server/game/cards/08-AS/TombOfAgony.js
+++ b/server/game/cards/08-AS/TombOfAgony.js
@@ -6,6 +6,7 @@ class TombOfAgony extends Card {
         this.whileAttached({
             effect: ability.effects.gainAbility('reap', {
                 target: {
+                    activePromptTitle: 'Choose an enemy creature to purge',
                     cardType: 'creature',
                     controller: 'opponent',
                     gameAction: ability.actions.purge()

--- a/server/game/cards/08-AS/VestedHarold.js
+++ b/server/game/cards/08-AS/VestedHarold.js
@@ -7,6 +7,7 @@ class VestedHarold extends Card {
         this.scrap({
             targets: {
                 friendly: {
+                    activePromptTitle: 'Choose a creature to archive',
                     mode: 'exactly',
                     numCards: 1,
                     cardType: 'creature',
@@ -14,6 +15,7 @@ class VestedHarold extends Card {
                     gameAction: ability.actions.archive()
                 },
                 enemy: {
+                    activePromptTitle: 'Choose a creature to archive',
                     mode: 'exactly',
                     numCards: 1,
                     cardType: 'creature',

--- a/server/game/cards/08-AS/WeighTheAnchor.js
+++ b/server/game/cards/08-AS/WeighTheAnchor.js
@@ -10,6 +10,7 @@ class WeighTheAnchor extends Card {
                 context.player.opponent.creaturesInPlay.length >
                     context.player.creaturesInPlay.length,
             target: {
+                activePromptTitle: 'Choose a creature to stun',
                 mode: 'exactly',
                 controller: 'opponent',
                 numCards: (context) =>

--- a/server/game/cards/08-AS/WeighTheAnchor.js
+++ b/server/game/cards/08-AS/WeighTheAnchor.js
@@ -10,7 +10,6 @@ class WeighTheAnchor extends Card {
                 context.player.opponent.creaturesInPlay.length >
                     context.player.creaturesInPlay.length,
             target: {
-                activePromptTitle: 'Choose a creature to stun',
                 mode: 'exactly',
                 controller: 'opponent',
                 numCards: (context) =>

--- a/server/game/cards/08-AS/Yandylinx.js
+++ b/server/game/cards/08-AS/Yandylinx.js
@@ -6,6 +6,7 @@ class Yandylinx extends Card {
     setupCardAbilities(ability) {
         this.reap({
             target: {
+                activePromptTitle: 'Choose a card to discard',
                 controller: 'self',
                 location: 'hand',
                 gameAction: ability.actions.discard()

--- a/server/game/cards/11-VM25/ThermalDepletion.js
+++ b/server/game/cards/11-VM25/ThermalDepletion.js
@@ -5,6 +5,7 @@ class ThermalDepletion extends Card {
     setupCardAbilities(ability) {
         this.play({
             effect: 'prevent creatures from readying until the start of their next turn',
+            effectAlert: true,
             gameAction: ability.actions.untilPlayerNextTurnStart({
                 targetController: 'any',
                 effect: ability.effects.cardCannot('ready')

--- a/server/game/cards/12-PV/DigitalSignal.js
+++ b/server/game/cards/12-PV/DigitalSignal.js
@@ -13,7 +13,6 @@ class DigitalSignal extends Card {
             condition: (context) =>
                 context.player.opponent && context.player.opponent.archives.length > 0,
             target: {
-                activePromptTitle: 'Choose which card to archive',
                 mode: 'exactly',
                 numCards: (context) =>
                     context.player.opponent ? context.player.opponent.archives.length : 0,

--- a/server/game/cards/12-PV/DigitalSignal.js
+++ b/server/game/cards/12-PV/DigitalSignal.js
@@ -13,6 +13,7 @@ class DigitalSignal extends Card {
             condition: (context) =>
                 context.player.opponent && context.player.opponent.archives.length > 0,
             target: {
+                activePromptTitle: 'Choose which card to archive',
                 mode: 'exactly',
                 numCards: (context) =>
                     context.player.opponent ? context.player.opponent.archives.length : 0,

--- a/server/game/cards/14-DM/Apoptosis.js
+++ b/server/game/cards/14-DM/Apoptosis.js
@@ -5,6 +5,7 @@ class Apoptosis extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
+                activePromptTitle: 'Choose which card to purge',
                 location: 'discard',
                 controller: 'self',
                 gameAction: ability.actions.purge()

--- a/server/game/cards/14-DM/Dammater.js
+++ b/server/game/cards/14-DM/Dammater.js
@@ -8,7 +8,10 @@ class Dammater extends Card {
             then: {
                 alwaysTriggers: true,
                 target: {
-                    activePromptTitle: 'Choose {{amount}} cards to discard',
+                    activePromptTitle: {
+                        text: 'Choose {{amount}} cards to discard',
+                        values: { amount: 2 }
+                    },
                     location: 'hand',
                     controller: 'self',
                     mode: 'exactly',

--- a/server/game/cards/14-DM/Dammater.js
+++ b/server/game/cards/14-DM/Dammater.js
@@ -8,6 +8,7 @@ class Dammater extends Card {
             then: {
                 alwaysTriggers: true,
                 target: {
+                    activePromptTitle: 'Choose {{amount}} cards to discard',
                     location: 'hand',
                     controller: 'self',
                     mode: 'exactly',
@@ -19,6 +20,7 @@ class Dammater extends Card {
                     message: '{0} uses {1} to archive a card',
                     messageArgs: (context) => [context.player, context.source],
                     target: {
+                        activePromptTitle: 'Choose a card to archive',
                         location: 'hand',
                         controller: 'self',
                         gameAction: ability.actions.archive()

--- a/server/game/cards/14-DM/Gigantor.js
+++ b/server/game/cards/14-DM/Gigantor.js
@@ -22,6 +22,7 @@ class Gigantor extends GiganticCard {
                 },
                 cards: {
                     dependsOn: 'select',
+                    activePromptTitle: 'Choose which cards to purge',
                     mode: 'upTo',
                     numCards: 3,
                     cardCondition: (card, context) =>

--- a/test/server/cards/07-GR/TerribleTeammates.spec.js
+++ b/test/server/cards/07-GR/TerribleTeammates.spec.js
@@ -18,7 +18,7 @@ describe('Terrible Teammates', function () {
 
         it('should allow selecting only non-mars cards from hand to discard', function () {
             this.player1.play(this.terribleTeammates);
-            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).toHavePrompt('Choose a card to discard');
             expect(this.player1).not.toBeAbleToSelect(this.airlock);
             expect(this.player1).not.toBeAbleToSelect(this.flaxia);
             expect(this.player1).toBeAbleToSelect(this.keyfrog);
@@ -32,7 +32,7 @@ describe('Terrible Teammates', function () {
 
         it('should allow you to discard nothing', function () {
             this.player1.play(this.terribleTeammates);
-            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).toHavePrompt('Choose a card to discard');
             this.player1.clickPrompt('Done');
             this.player1.endTurn();
         });

--- a/test/server/cards/14-DM/Dammater.spec.js
+++ b/test/server/cards/14-DM/Dammater.spec.js
@@ -14,7 +14,7 @@ describe('Dammater', function () {
             const startingHand = this.player1.player.hand.length;
             this.player1.play(this.dammater);
             expect(this.player1.player.hand.length).toBe(startingHand - 1 + 3);
-            expect(this.player1).toHavePrompt('Choose {{amount}} cards to discard');
+            expect(this.player1).toHavePrompt('Choose 2 cards to discard');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }
@@ -49,7 +49,7 @@ describe('Dammater', function () {
 
         it('still requires discarding 2 and archiving 1 when no cards are drawn', function () {
             this.player1.play(this.dammater);
-            expect(this.player1).toHavePrompt('Choose {{amount}} cards to discard');
+            expect(this.player1).toHavePrompt('Choose 2 cards to discard');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }

--- a/test/server/cards/14-DM/Dammater.spec.js
+++ b/test/server/cards/14-DM/Dammater.spec.js
@@ -14,7 +14,7 @@ describe('Dammater', function () {
             const startingHand = this.player1.player.hand.length;
             this.player1.play(this.dammater);
             expect(this.player1.player.hand.length).toBe(startingHand - 1 + 3);
-            expect(this.player1).toHavePrompt('Choose 2 cards');
+            expect(this.player1).toHavePrompt('Choose {{amount}} cards to discard');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }
@@ -23,7 +23,7 @@ describe('Dammater', function () {
             this.player1.clickPrompt('Done');
             expect(this.troll.location).toBe('discard');
             expect(this.lamindra.location).toBe('discard');
-            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).toHavePrompt('Choose a card to archive');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }
@@ -49,7 +49,7 @@ describe('Dammater', function () {
 
         it('still requires discarding 2 and archiving 1 when no cards are drawn', function () {
             this.player1.play(this.dammater);
-            expect(this.player1).toHavePrompt('Choose 2 cards');
+            expect(this.player1).toHavePrompt('Choose {{amount}} cards to discard');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }
@@ -58,7 +58,7 @@ describe('Dammater', function () {
             this.player1.clickPrompt('Done');
             expect(this.troll.location).toBe('discard');
             expect(this.lamindra.location).toBe('discard');
-            expect(this.player1).toHavePrompt('Choose a card');
+            expect(this.player1).toHavePrompt('Choose a card to archive');
             for (const card of this.player1.player.hand) {
                 expect(this.player1).toBeAbleToSelect(card);
             }


### PR DESCRIPTION
Many card targets were missing `activePromptTitle`, leaving the player with a generic 'Choose a card' prompt with no context about what action they're performing.

## Cards updated

Sets 03-WC, 06-WoE, 07-GR, 08-AS, 11-VM25, 12-PV, 14-DM:
GreaterOxtet, Hologrammophone, ObsidianForge, UniversalRecyclingBin, Aristotlmimus, TheOldTinker, ForgottenGuardian, QyxxlyxxGraveMaster, TerribleTeammates, Aurascope, HoistOperations, IntentionalDischarge, KyypaxEncapsulator, Stratowise, TombOfAgony, VestedHarold, WeighTheAnchor, Yandylinx, ThermalDepletion (also gains `effectAlert: true`), DigitalSignal, Apoptosis, Gigantor, Dammater

Test expectations updated to assert the new prompt titles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/prompt text changes on card targeting with minimal gameplay impact; small risk of mismatched prompt expectations or unintended prompt formatting on affected cards.
> 
> **Overview**
> Improves in-game targeting UX by adding `activePromptTitle` to many card `target`/`targets` selectors so players see contextual prompts (e.g., *discard*, *purge*, *archive*, *ready*) instead of a generic “Choose a card.”
> 
> Also enables `effectAlert: true` on `ThermalDepletion` so its lasting effect is surfaced to players, and updates affected specs (`TerribleTeammates`, `Dammater`) to assert the new prompt titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1e768050b0c7c574af94b60ce1461d2ea0742d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->