### PR TITLE
DM: fix gigantic armor

### DIFF
--- a/test/server/cards/14-DM/Zomok.spec.js
+++ b/test/server/cards/14-DM/Zomok.spec.js
@@ -24,7 +24,8 @@ describe('Zomok', function () {
             this.player1.fightWith(this.zomok, this.urchin);
             expect(this.urchin.location).toBe('discard');
             expect(this.zomok.location).toBe('play area');
-            expect(this.zomok.damage).toBe(1);
+            expect(this.zomok.damage).toBe(0);
+            expect(this.zomok.armor).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
 
@@ -36,7 +37,8 @@ describe('Zomok', function () {
 
         it('ignores hazardous while attacking', function () {
             this.player1.fightWith(this.zomok, this.mickeyTheCarver);
-            expect(this.zomok.damage).toBe(this.mickeyTheCarver.power);
+            expect(this.zomok.damage).toBe(this.mickeyTheCarver.power - 2);
+            expect(this.zomok.armor).toBe(0);
             expect(this.mickeyTheCarver.location).toBe('discard');
         });
 
@@ -67,7 +69,8 @@ describe('Zomok', function () {
             this.player2.fightWith(this.emperorMemrox, this.zomok);
             expect(this.emperorMemrox.location).toBe('play area');
             expect(this.emperorMemrox.damage).toBe(0);
-            expect(this.zomok.damage).toBe(this.emperorMemrox.power);
+            expect(this.zomok.damage).toBe(this.emperorMemrox.power - 2);
+            expect(this.zomok.armor).toBe(0);
             expect(this.player2).isReadyToTakeAction();
         });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes updating combat assertions around armor absorption; low risk beyond potentially masking gameplay regressions if the expectations are incorrect.
> 
> **Overview**
> Adjusts `Zomok.spec.js` expectations to reflect **gigantic armor being applied during fights**: Zomok now takes reduced/zero damage in several scenarios and the tests explicitly assert the remaining `armor`/consumed armor after combat (including hazardous and defending cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46645186e242d8261efd8daa202fd4928a64f746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->