### PR TITLE
fix: null-safe opponent access in BlankCheck, TrojanSauropod, EddyOfDis

### DIFF
--- a/server/game/cards/05-DT/TrojanSauropod.js
+++ b/server/game/cards/05-DT/TrojanSauropod.js
@@ -17,11 +17,10 @@ class TrojanSauropod extends Card {
             then: {
                 condition: (context) => context.player.opponent,
                 gameAction: ability.actions.sequentialPutIntoPlay((context) => {
-                    const creatures = context.player.opponent.hand.filter(
-                        (card) => card.type === 'creature'
-                    );
+                    const hand = context.player.opponent ? context.player.opponent.hand : [];
+                    const creatures = hand.filter((card) => card.type === 'creature');
                     return {
-                        revealList: context.player.opponent.hand,
+                        revealList: hand,
                         forEach: creatures,
                         ready: true,
                         numPlayAllowances: creatures.length

--- a/server/game/cards/12-PV/EddyOfDis.js
+++ b/server/game/cards/12-PV/EddyOfDis.js
@@ -17,12 +17,15 @@ class EddyOfDis extends Card {
         });
 
         this.fate({
+            condition: (context) => !!context.game.activePlayer.opponent,
             effect: "shuffle {1}'s discard into their deck and have them draw a card",
             effectArgs: (context) => [context.game.activePlayer.opponent],
             gameAction: ability.actions.sequential([
                 ability.actions.returnToDeck((context) => ({
                     shuffle: true,
-                    target: context.game.activePlayer.opponent.discard
+                    target: context.game.activePlayer.opponent
+                        ? context.game.activePlayer.opponent.discard
+                        : []
                 })),
                 ability.actions.draw((context) => ({
                     target: context.game.activePlayer.opponent

--- a/server/game/cards/14-DM/BlankCheck.js
+++ b/server/game/cards/14-DM/BlankCheck.js
@@ -16,41 +16,66 @@ class BlankCheck extends Card {
                 shuffleDiscardIntoDeck: true,
                 target: context.player.opponent.archives.concat(context.player.opponent.discard)
             });
+
+        const shuffleStep = (context) => {
+            // No opponent: just shuffle the active player's archives/discard.
+            if (!context.player.opponent) {
+                return {
+                    condition: false,
+                    falseGameAction: playerShuffle(context)
+                };
+            }
+            // Order-forced: prompt the active player for who shuffles first.
+            if (context.player.optionSettings.orderForcedAbilities) {
+                return {
+                    condition: true,
+                    trueGameAction: ability.actions.chooseAction({
+                        activePromptTitle:
+                            'Choose which player shuffles their archives and discard pile first',
+                        choices: {
+                            Me: [playerShuffle(context), opponentShuffle(context)],
+                            Opponent: [opponentShuffle(context), playerShuffle(context)]
+                        }
+                    })
+                };
+            }
+            // Default: active player shuffles first, then opponent.
+            return {
+                condition: true,
+                trueGameAction: ability.actions.sequential([
+                    playerShuffle(context),
+                    opponentShuffle(context)
+                ])
+            };
+        };
+
+        const discardAndPlayStep = (context) => {
+            // No opponent: nothing to discard or play.
+            if (!context.player.opponent) {
+                return { condition: false };
+            }
+            return {
+                condition: true,
+                trueGameAction: ability.actions.sequential([
+                    ability.actions.discardTopOfDeck((context) => ({
+                        target: context.player.opponent,
+                        amount: 5
+                    })),
+                    ability.actions.playCard((context) => ({
+                        revealOnIllegalTarget: true,
+                        target: context.player.opponent.deck[0]
+                    }))
+                ])
+            };
+        };
+
         this.play({
             effect: 'have each player shuffle their archives and discard pile into their deck',
-            gameAction: ability.actions.conditional((context) => ({
-                condition: !!context.player.opponent,
-                trueGameAction: context.player.optionSettings.orderForcedAbilities
-                    ? ability.actions.chooseAction({
-                          activePromptTitle:
-                              'Choose which player shuffles their archives and discard pile first',
-                          choices: {
-                              Me: [playerShuffle(context), opponentShuffle(context)],
-                              Opponent: [opponentShuffle(context), playerShuffle(context)]
-                          }
-                      })
-                    : ability.actions.sequential([
-                          playerShuffle(context),
-                          opponentShuffle(context)
-                      ]),
-                falseGameAction: playerShuffle(context)
-            })),
-            then: () => ({
+            gameAction: ability.actions.conditional(shuffleStep),
+            then: {
                 alwaysTriggers: true,
-                gameAction: ability.actions.conditional((context) => ({
-                    condition: !!context.player.opponent,
-                    trueGameAction: ability.actions.sequential([
-                        ability.actions.discardTopOfDeck((context) => ({
-                            target: context.player.opponent,
-                            amount: 5
-                        })),
-                        ability.actions.playCard((context) => ({
-                            revealOnIllegalTarget: true,
-                            target: context.player.opponent.deck[0]
-                        }))
-                    ])
-                }))
-            })
+                gameAction: ability.actions.conditional(discardAndPlayStep)
+            }
         });
     }
 }


### PR DESCRIPTION
Guard against missing opponent in BlankCheck, TrojanSauropod, and EddyOfDis to prevent crashes in solo/practice games.

- **BlankCheck**: refactors conditional logic into named step functions and guards all opponent accesses
- **TrojanSauropod**: null-checks opponent before accessing hand
- **EddyOfDis**: adds `condition` guard and null-safe discard access

Fixes Sentry issue #7487962838

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding null-safety/conditional guards around opponent-dependent card effects to prevent runtime errors in solo/practice games.
> 
> **Overview**
> Prevents crashes when a card effect references an absent opponent (e.g., solo/practice games) by adding **null-safe opponent checks** across three card scripts.
> 
> `TrojanSauropod` now derives `hand`/`revealList` from a guarded opponent reference, `EddyOfDis` adds a `fate` condition and guards discard access, and `BlankCheck` refactors its play resolution into named conditional steps that skip opponent-only shuffle/discard/play actions when no opponent exists (while preserving the order-forced prompt behavior when applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518ef0758af6e8c899dbc3aa3e5d393b526d5381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->