### PR TITLE
fix: suppress unhandled ViewTransition rejection from HeroUI toast queue

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,6 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import './styles/tailwind.css';
+import './setupToastQueue';
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';

--- a/client/setupToastQueue.js
+++ b/client/setupToastQueue.js
@@ -1,0 +1,17 @@
+import { toastQueue } from '@heroui/react';
+
+// HeroUI's default ToastQueue wraps every add/close/update in
+// `document.startViewTransition(() => flushSync(fn))`. When toasts overlap
+// (rapid successive add/close), Chrome aborts the in-flight transition and
+// rejects its `.finished` / `.ready` promise with:
+//   InvalidStateError: Transition was aborted because of invalid state
+// HeroUI throws the ViewTransition away without catching, so the rejection
+// escapes and is reported by Sentry's `onunhandledrejection` handler.
+//
+// Drop the `wrapUpdate` on the singleton's underlying react-stately queue so
+// it falls back to the library default (plain `fn()` invocation, no view
+// transitions). Toasts still appear and dismiss; the slide animation comes
+// from heroui's CSS, not from the View Transitions API.
+if (toastQueue?.queue) {
+    toastQueue.queue.wrapUpdate = undefined;
+}


### PR DESCRIPTION
## Problem

HeroUI's `ToastQueue` wraps every add/close/update in `document.startViewTransition(() => flushSync(fn))`. When toasts overlap (rapid successive add/close), Chrome aborts the in-flight transition and rejects its promise with:

```
InvalidStateError: Transition was aborted because of invalid state
```

HeroUI does not catch this rejection, so it escapes and is reported by Sentry as issue [7331246564](https://keyteki.sentry.io/issues/7331246564/).

## Fix

Nulls out `wrapUpdate` on the singleton queue in a one-time setup module imported at app entry. This causes react-stately to fall back to plain `fn()` invocation with no view transitions. Toasts still appear and animate via HeroUI's CSS.

Fixes Sentry issue 7331246564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks toast update behavior globally by removing HeroUI’s View Transitions wrapper; main impact is potentially losing ViewTransition-based animations for toasts.
> 
> **Overview**
> Prevents Sentry-reported `InvalidStateError` unhandled promise rejections caused by overlapping HeroUI toast updates.
> 
> Adds a one-time `client/setupToastQueue.js` initializer imported from `client/index.jsx` that clears `toastQueue.queue.wrapUpdate`, forcing toast add/close/update to run without `document.startViewTransition` wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9546f713fb3613329f7f43bea26151ca32d248d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->