### PR TITLE
fix: handle Illegal constructor error for Notification API

### DIFF
--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -20,10 +20,23 @@ import ChargeMp3 from '../../assets/sound/charge.mp3';
 import ChargeOgg from '../../assets/sound/charge.ogg';
 
 function showNotification(notification) {
-    if (window.Notification && Notification.permission === 'granted') {
+    if (!window.Notification || Notification.permission !== 'granted') {
+        return;
+    }
+
+    try {
         const windowNotification = new Notification('The Crucible Online', notification);
 
         setTimeout(() => windowNotification.close(), 5000);
+    } catch {
+        // Some browsers (e.g. Chrome on Linux/Android, or any context with an active service
+        // worker) disallow the direct `Notification` constructor and throw "Illegal constructor".
+        // Fall back to ServiceWorkerRegistration.showNotification when available.
+        if (navigator.serviceWorker?.ready) {
+            navigator.serviceWorker.ready
+                .then((reg) => reg.showNotification('The Crucible Online', notification))
+                .catch(() => {});
+        }
     }
 }
 


### PR DESCRIPTION
Some browsers (Chrome on Linux/Android, and any context with an active service worker) disallow the direct `new Notification()` constructor and throw an "Illegal constructor" error.

This change wraps the notification call in a try/catch and falls back to `ServiceWorkerRegistration.showNotification()` when available.

Fixes Sentry issue #7249816547

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to client-side lobby notifications and only changes error handling/fallback behavior when browser notification APIs are restricted.
> 
> **Overview**
> Prevents lobby join notifications from crashing in browsers where `new Notification()` throws ("Illegal constructor").
> 
> `showNotification` now exits early unless permission is granted, wraps the constructor in `try/catch`, and falls back to `navigator.serviceWorker.ready.then(reg.showNotification)` when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750283152995f7dfd8ae5fb57931996b280f4732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->