### PR TITLE
fix: guard preThenContext.target against undefined in then blocks

### DIFF
--- a/docs/card-abilities.md
+++ b/docs/card-abilities.md
@@ -26,6 +26,7 @@ This document describes how card abilities are defined in Keyteki. All card abil
     -   [Optional](#optional)
     -   [Targeting](#targeting)
     -   [Chaining Effects with "then"](#chaining-effects-with-then)
+    -   [Guarding `preThenContext.target` access](#guarding-prethencontexttarget-access)
 
 ## Basic Structure
 
@@ -617,3 +618,97 @@ this.reap({
 ```
 
 Note that `alwaysTriggers: true` is needed on the outer `then` so the optional-discard prompt still appears even when the capture event was cancelled or partial — but the inner `then`'s `condition` then ensures the final effect is gated correctly.
+
+#### Guarding `preThenContext.target` access
+
+Any `then` block that reads `preThenContext.target` must defend against it being `undefined`. This is **not** limited to `target.optional: true` — it also happens in routine cases where the parent ability's target step finds **no eligible card**. Without a guard, the game crashes with `TypeError: Cannot read properties of undefined (reading '<prop>')` and the user sees an error toast mid-ability.
+
+**When `preThenContext.target` is undefined:**
+
+1. **Optional targets.** `target: { optional: true, ... }` and the player declined.
+2. **No eligible target.** The parent `target` declared `cardCondition`/`controller`/`location` restrictions and no card in scope matched (e.g. Replacement Targ played with all neighbors being Soldiers, Inspiring Oration played with no friendly creatures, Placeholder played with no creatures in play).
+3. **Mid-resolution invalidation.** The target was chosen but became invalid (left play, moved zones) before the `then` resolved.
+
+**When does the `then` still fire if there was no target?** Only when `alwaysTriggers: true` is set on the `then`:
+
+| Parent target step                     | `then.alwaysTriggers` | Does `then` fire?            |
+| -------------------------------------- | --------------------- | ---------------------------- |
+| Found a valid target, action resolved  | any                   | yes                          |
+| Found a valid target, action cancelled | `true`                | yes                          |
+| Found a valid target, action cancelled | `false`/absent        | no                           |
+| Found no eligible target               | `true`                | **yes (this is the danger)** |
+| Found no eligible target               | `false`/absent        | no                           |
+
+So the rule is: if your `then` uses `preThenContext.target` **and** sets `alwaysTriggers: true`, you must guard. If your `then` uses `preThenContext.target` **without** `alwaysTriggers`, you're usually safe — but still add a guard if the parent target uses `optional: true`, or if there's any path where the parent's `gameAction` produces events while leaving `target` unset.
+
+**The canonical guard pattern:**
+
+Add (or extend) a `condition` on the `then` that returns `false` when the target is missing. The whole `then` ability is then cleanly skipped:
+
+```javascript
+// Play: Put a neighboring non-Soldier creature into its owner's hand.
+// If you do, the most powerful friendly creature captures 2A.
+this.play({
+    target: {
+        cardType: 'creature',
+        controller: 'self',
+        cardCondition: (card, context) =>
+            !card.hasTrait('soldier') && context.source.neighbors.includes(card),
+        gameAction: ability.actions.returnToHand()
+    },
+    then: (preThenContext) => ({
+        alwaysTriggers: true,
+        // Guard: if no neighbor was eligible, preThenContext.target is undefined
+        condition: () => preThenContext.target && preThenContext.target.location === 'hand',
+        target: {
+            mode: 'mostStat',
+            cardType: 'creature',
+            controller: 'self',
+            numCards: 1,
+            cardStat: (card) => card.power,
+            gameAction: ability.actions.capture({ amount: 2 })
+        }
+    })
+});
+```
+
+If the `then` has no other condition, just add one:
+
+```javascript
+then: (preThenContext) => ({
+    condition: () => !!preThenContext.target,
+    gameAction: ability.actions.gainAmber({
+        amount: 1,
+        target: preThenContext.target && preThenContext.target.controller
+    })
+});
+```
+
+**Inline guarding for property accesses.** Even with a `condition` guard, any expression evaluated **outside** the condition (e.g. inside `messageArgs`, `effectArgs`, or a `gameAction` factory) is also evaluated — sometimes during `then` setup, before the condition fires. Defensively guard each access there too:
+
+```javascript
+// BAD — crashes if no eligible target
+then: (preThenContext) => ({
+    condition: () => !!preThenContext.target,
+    gameAction: ability.actions.draw({
+        amount: 2 * preThenContext.target.neighbors.length // evaluated immediately
+    })
+});
+
+// GOOD
+then: (preThenContext) => ({
+    condition: () => !!preThenContext.target,
+    gameAction: ability.actions.draw({
+        amount: preThenContext.target ? 2 * preThenContext.target.neighbors.length : 0
+    })
+});
+```
+
+The same applies to `preThenContext.preThenEvent` — when the parent produced no events (no eligible target with `alwaysTriggers: true`), `preThenEvent` is `undefined`. Guard `context.preThenEvent && context.preThenEvent.<prop>` whenever you read it.
+
+**Quick checklist when writing a `then` that reads `preThenContext.target`:**
+
+1. Does the parent ability have a `target` or `targets` requirement? → guard needed.
+2. Does the `then` set `alwaysTriggers: true`? → guard is **required**.
+3. Is the parent target `optional: true`? → guard is **required**.
+4. Does any `messageArgs` / `effectArgs` / `gameAction` factory dereference `preThenContext.target.X` outside the `condition`? → inline-guard those accesses too.

--- a/server/game/cards/01-Core/SwapWidget.js
+++ b/server/game/cards/01-Core/SwapWidget.js
@@ -11,12 +11,15 @@ class SwapWidget extends Card {
                 gameAction: ability.actions.returnToHand()
             },
             then: (preThenContext) => ({
+                condition: () => !!preThenContext.target,
                 target: {
                     cardType: 'creature',
                     controller: 'self',
                     location: 'hand',
                     cardCondition: (card) =>
-                        card.hasHouse('mars') && card.name !== preThenContext.target.name,
+                        card.hasHouse('mars') &&
+                        preThenContext.target &&
+                        card.name !== preThenContext.target.name,
                     gameAction: ability.actions.putIntoPlay()
                 },
                 message: '{0} puts {2} into play using {1}, and readies it',

--- a/server/game/cards/05-DT/Scooped.js
+++ b/server/game/cards/05-DT/Scooped.js
@@ -11,7 +11,9 @@ class Scooped extends Card {
             then: (preThenContext) => ({
                 alwaysTriggers: true,
                 condition: (context) =>
+                    !!preThenContext.target &&
                     !(
+                        context.preThenEvent &&
                         context.preThenEvent.destroyEvent &&
                         context.preThenEvent.destroyEvent.resolved
                     ),

--- a/server/game/cards/06-WoE/Camaraderie.js
+++ b/server/game/cards/06-WoE/Camaraderie.js
@@ -12,11 +12,13 @@ class Camaraderie extends Card {
                 gameAction: ability.actions.exhaust()
             },
             then: (preThenContext) => ({
+                condition: () => !!preThenContext.target,
                 gameAction: ability.actions.draw({
-                    amount:
-                        2 *
-                        preThenContext.target.neighbors.filter((c) => !c.hasHouse('staralliance'))
-                            .length
+                    amount: preThenContext.target
+                        ? 2 *
+                          preThenContext.target.neighbors.filter((c) => !c.hasHouse('staralliance'))
+                              .length
+                        : 0
                 })
             })
         });

--- a/server/game/cards/06-WoE/ForcedRetirement.js
+++ b/server/game/cards/06-WoE/ForcedRetirement.js
@@ -9,9 +9,10 @@ class ForcedRetirement extends Card {
                 gameAction: ability.actions.destroy()
             },
             then: (preThenContext) => ({
+                condition: () => !!preThenContext.target,
                 gameAction: ability.actions.gainAmber({
                     amount: 1,
-                    target: preThenContext.target.controller
+                    target: preThenContext.target && preThenContext.target.controller
                 })
             })
         });

--- a/server/game/cards/06-WoE/GeneticBlast.js
+++ b/server/game/cards/06-WoE/GeneticBlast.js
@@ -12,11 +12,15 @@ class GeneticBlast extends Card {
             effectArgs: (context) => [context.target],
             then: (preThenContext) => ({
                 alwaysTriggers: true,
+                condition: () => !!preThenContext.target,
                 gameAction: ability.actions.dealDamage((context) => ({
-                    target: context.game.cardsInPlay.filter(
-                        (card) =>
-                            card.name === preThenContext.target.name && card.type === 'creature'
-                    ),
+                    target: preThenContext.target
+                        ? context.game.cardsInPlay.filter(
+                              (card) =>
+                                  card.name === preThenContext.target.name &&
+                                  card.type === 'creature'
+                          )
+                        : [],
                     amount: 2
                 }))
             })

--- a/server/game/cards/06-WoE/InspiringOration.js
+++ b/server/game/cards/06-WoE/InspiringOration.js
@@ -12,6 +12,7 @@ class InspiringOration extends Card {
             },
             then: (preThenContext) => ({
                 alwaysTriggers: true,
+                condition: () => !!preThenContext.target,
                 message: '{0} uses {1} to make {3}{4}',
                 messageArgs: () =>
                     preThenContext.target.amber === 1

--- a/server/game/cards/06-WoE/ShakedownSullivan.js
+++ b/server/game/cards/06-WoE/ShakedownSullivan.js
@@ -19,6 +19,9 @@ class ShakedownSullivan extends Card {
             effectArgs: (context) => [context.target, context.target?.controller.deck[0]],
             then: (preThenContext) => ({
                 alwaysTriggers: true,
+                condition: (context) =>
+                    !!preThenContext.target &&
+                    !!(context.preThenEvent && context.preThenEvent.card),
                 gameAction: ability.actions.conditional((context) => ({
                     condition: context.preThenEvent.card
                         .getHouses()

--- a/server/game/cards/07-GR/QyxxlyxxGraveMaster.js
+++ b/server/game/cards/07-GR/QyxxlyxxGraveMaster.js
@@ -15,11 +15,16 @@ class QyxxlyxxGraveMaster extends Card {
                 gameAction: ability.actions.purge()
             },
             then: (preThenContext) => ({
+                condition: () => !!preThenContext.target,
                 gameAction: ability.actions.dealDamage((context) => ({
                     amount: 2,
-                    target: context.game.creaturesInPlay.filter((card) =>
-                        card.getTraits().some((trait) => preThenContext.target.hasTrait(trait))
-                    )
+                    target: preThenContext.target
+                        ? context.game.creaturesInPlay.filter((card) =>
+                              card
+                                  .getTraits()
+                                  .some((trait) => preThenContext.target.hasTrait(trait))
+                          )
+                        : []
                 }))
             })
         });

--- a/server/game/cards/07-GR/Shadys.js
+++ b/server/game/cards/07-GR/Shadys.js
@@ -12,7 +12,8 @@ class Shadys extends Card {
                 gameAction: ability.actions.playCard()
             },
             then: (preThenContext) => ({
-                condition: () => preThenContext.target.name === 'Purse-a-phone',
+                condition: () =>
+                    !!preThenContext.target && preThenContext.target.name === 'Purse-a-phone',
                 gameAction: ability.actions.destroy((context) => ({
                     target: context.source
                 }))

--- a/server/game/cards/08-AS/CoggMiller.js
+++ b/server/game/cards/08-AS/CoggMiller.js
@@ -11,8 +11,9 @@ class CoggMiller extends Card {
                 gameAction: ability.actions.destroy()
             },
             then: (preThenContext) => ({
+                condition: () => !!preThenContext.target,
                 gameAction: ability.actions.archiveAtRandom({
-                    target: preThenContext.target.owner,
+                    target: preThenContext.target && preThenContext.target.owner,
                     amount: 1
                 })
             })

--- a/server/game/cards/08-AS/Placeholder.js
+++ b/server/game/cards/08-AS/Placeholder.js
@@ -18,7 +18,8 @@ class Placeholder extends Card {
             },
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                condition: () => preThenContext.target.location === 'play area',
+                condition: () =>
+                    preThenContext.target && preThenContext.target.location === 'play area',
                 message: '{0} uses {1} to move {3} to a flank and deal 2 damage to it',
                 messageArgs: (context) => context.target,
                 target: {

--- a/server/game/cards/14-DM/ColdRopes.js
+++ b/server/game/cards/14-DM/ColdRopes.js
@@ -21,17 +21,23 @@ class ColdRopes extends Card {
                 preThenContext.player.isOverwhelmed()
                     ? {
                           alwaysTriggers: true,
+                          condition: () => !!preThenContext.target,
                           message: "{0} uses {1} to put {3} on the bottom of {4}'s deck",
-                          messageArgs: () => [preThenContext.target, preThenContext.target.owner]
+                          messageArgs: () =>
+                              preThenContext.target
+                                  ? [preThenContext.target, preThenContext.target.owner]
+                                  : []
                       }
                     : {
                           alwaysTriggers: true,
+                          condition: () => !!preThenContext.target,
                           gameAction: ability.actions.exhaust({
                               target: preThenContext.target
                           }),
                           message: '{0} uses {1} to move {3} to the {4} flank and exhaust it',
                           messageArgs: () => {
                               const t = preThenContext.target;
+                              if (!t) return [];
                               const inPlay = t.controller.cardsInPlay;
                               const side =
                                   inPlay.length <= 1 || inPlay.indexOf(t) === 0 ? 'left' : 'right';

--- a/server/game/cards/14-DM/ReplacementTarg.js
+++ b/server/game/cards/14-DM/ReplacementTarg.js
@@ -14,7 +14,7 @@ class ReplacementTarg extends Card {
             },
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                condition: () => preThenContext.target.location === 'hand',
+                condition: () => preThenContext.target && preThenContext.target.location === 'hand',
                 target: {
                     mode: 'mostStat',
                     cardType: 'creature',


### PR DESCRIPTION
Fixes crashes (Sentry #7480292138) where `then` blocks with `alwaysTriggers: true` would fire even when no eligible target existed, causing `TypeError: Cannot read properties of undefined`.

**Root cause:** When a card's `target` step finds no eligible card, `preThenContext.target` is `undefined`. Any `then` block that reads from it without a guard crashes at runtime.

**Fix:** Added `condition: () => !!preThenContext.target` guards (and null-safe access where needed) to 13 card implementations, plus documentation in `docs/card-abilities.md` describing the canonical pattern.

**Cards fixed:**
- Core: SwapWidget
- DT: Scooped
- WoE: Camaraderie, ForcedRetirement, GeneticBlast, InspiringOration, ShakedownSullivan
- GR: QyxxlyxxGraveMaster, Shadys
- AS: CoggMiller, Placeholder
- DM: ColdRopes, ReplacementTarg

---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized null/undefined guards in card scripts plus documentation, intended to prevent `TypeError` crashes without altering core engine behavior.
> 
> **Overview**
> Fixes multiple card implementations where `then` blocks (often with `alwaysTriggers: true`) could run with no valid parent target, causing `preThenContext.target` dereferences to crash.
> 
> Adds consistent `condition` guards and null-safe property access across the affected cards (and `preThenEvent` where relevant), and documents the required guard pattern in `docs/card-abilities.md` to prevent future regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e489daeff445089165aef5ad5d4c4cb41fd44690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
