### PR TITLE
test: Tya Arhi Esquire + Prospector + Mass Buyout with empty deck

### DIFF
--- a/test/server/cards/06-WoE/TyaArhiEsquire.spec.js
+++ b/test/server/cards/06-WoE/TyaArhiEsquire.spec.js
@@ -45,4 +45,66 @@ describe('Tya Arhi Esquire', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe('with Prospectors, an empty deck, and Mass Buyout', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'ekwidon',
+                    token: 'prospector',
+                    inPlay: [
+                        'tya-arhĭ-esquire',
+                        'antiquities-dealer',
+                        'prospector:flaxia',
+                        'prospector:bumpsy'
+                    ],
+                    hand: ['mass-buyout'],
+                    discard: ['pen-pal', 'change-agent']
+                },
+                player2: {}
+            });
+
+            const prospectors = this.player1.player.creaturesInPlay.filter(
+                (c) => c.name === 'Prospector'
+            );
+            this.prospector1 = prospectors[0];
+            this.prospector2 = prospectors[1];
+            this.player1.deck = [];
+        });
+
+        it('lets the player order make-token and prospector draw triggers even with an empty deck', function () {
+            this.player1.play(this.massBuyout);
+            const handSize = this.player1.player.hand.length;
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+            expect(this.player1).toBeAbleToSelect(this.tyaArhĭEsquire);
+            expect(this.player1).toBeAbleToSelect(this.antiquitiesDealer);
+            expect(this.player1).toBeAbleToSelect(this.prospector1);
+            expect(this.player1).toBeAbleToSelect(this.prospector2);
+
+            // Tya Arhi fails to make a token
+            this.player1.clickCard(this.tyaArhĭEsquire);
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+
+            // Prospector draws and flips the discard
+            this.player1.clickCard(this.prospector1);
+            expect(this.player1.deck.length).toBeGreaterThan(0);
+            expect(this.player1).toHavePrompt('Triggered Abilities');
+
+            // Antiquities Dealer makes a token
+            this.player1.clickCard(this.antiquitiesDealer);
+            this.player1.clickPrompt('Right');
+
+            // Prospector draws a card
+
+            // After all destroyed triggers resolve, the cards move to discard.
+            expect(this.tyaArhĭEsquire.location).toBe('discard');
+            expect(this.antiquitiesDealer.location).toBe('discard');
+            expect(this.prospector1.location).toBe('discard');
+            expect(this.prospector2.location).toBe('discard');
+            expect(this.player1.player.creaturesInPlay.length).toBe(1);
+            expect(this.player1.amber).toBe(2);
+            expect(this.player1.player.hand.length).toBe(handSize + 1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
Add test case covering the scenario where Tya Arhi Esquire, Prospectors, and Mass Buyout interact with an empty deck (issue #3368).

Verifies that the player can order triggered abilities and use Prospector draw to replenish the deck before resolving Tya Arhi's make-a-token effects.

Closes #3368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a focused regression test for triggered-ability ordering when the deck is empty; no production logic changes.
> 
> **Overview**
> Adds a new regression test to `TyaArhiEsquire.spec.js` covering `Mass Buyout` with `Tya Arhi Esquire` plus multiple `Prospector` tokens when the active player’s deck is empty.
> 
> The test asserts the player can still choose the order of destroyed triggers, use a Prospector trigger to rebuild the deck from discard, and then resolve token-creation/draw outcomes with the expected board, amber, and hand size results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466ac622f25435e11714948f0d0809ad79a48c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->