### PR TITLE
fix(DitchTheLoot): prevent remove amber when fewer than 2 creatures in play

### DIFF
--- a/server/game/cards/14-DM/DitchTheLoot.js
+++ b/server/game/cards/14-DM/DitchTheLoot.js
@@ -5,12 +5,7 @@ class DitchTheLoot extends Card {
     // Play: Move all amber from one creature to another creature.
     setupCardAbilities(ability) {
         this.play({
-            condition: (context) =>
-                context.player.creaturesInPlay.length +
-                    (context.player.opponent
-                        ? context.player.opponent.creaturesInPlay.length
-                        : 0) >=
-                2,
+            condition: (context) => context.game.creaturesInPlay.length >= 2,
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.removeAmber({ all: true })

--- a/server/game/cards/14-DM/DitchTheLoot.js
+++ b/server/game/cards/14-DM/DitchTheLoot.js
@@ -5,6 +5,12 @@ class DitchTheLoot extends Card {
     // Play: Move all amber from one creature to another creature.
     setupCardAbilities(ability) {
         this.play({
+            condition: (context) =>
+                context.player.creaturesInPlay.length +
+                    (context.player.opponent
+                        ? context.player.opponent.creaturesInPlay.length
+                        : 0) >=
+                2,
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.removeAmber({ all: true })

--- a/test/server/cards/14-DM/DitchTheLoot.spec.js
+++ b/test/server/cards/14-DM/DitchTheLoot.spec.js
@@ -44,4 +44,24 @@ describe('Ditch the Loot', function () {
             expect(this.player1).toBeAbleToSelect(this.troll);
         });
     });
+
+    describe('Ditch the Loot with only one creature in play that has amber', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'shadows',
+                    hand: ['ditch-the-loot'],
+                    inPlay: ['urchin']
+                },
+                player2: {}
+            });
+            this.urchin.amber = 3;
+        });
+
+        it('leaves the amber on the creature when there is no other creature to receive it', function () {
+            this.player1.play(this.ditchTheLoot);
+            expect(this.urchin.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
 });

--- a/test/server/cards/14-DM/DitchTheLoot.spec.js
+++ b/test/server/cards/14-DM/DitchTheLoot.spec.js
@@ -8,40 +8,74 @@ describe('Ditch the Loot', function () {
                     inPlay: ['urchin', 'hobnobber']
                 },
                 player2: {
-                    inPlay: ['troll']
+                    inPlay: ['troll', 'bumpsy']
                 }
             });
             this.urchin.amber = 3;
+            this.bumpsy.amber = 2;
         });
 
-        it('moves all amber from one creature to another', function () {
+        it('moves all amber from friendly to friendly', function () {
             this.player1.play(this.ditchTheLoot);
             expect(this.player1).toBeAbleToSelect(this.urchin);
             expect(this.player1).toBeAbleToSelect(this.hobnobber);
             expect(this.player1).toBeAbleToSelect(this.troll);
+            expect(this.player1).toBeAbleToSelect(this.bumpsy);
             this.player1.clickCard(this.urchin);
+            expect(this.player1).not.toBeAbleToSelect(this.urchin);
+            expect(this.player1).toBeAbleToSelect(this.hobnobber);
+            expect(this.player1).toBeAbleToSelect(this.troll);
+            expect(this.player1).toBeAbleToSelect(this.bumpsy);
             this.player1.clickCard(this.hobnobber);
             expect(this.urchin.amber).toBe(0);
             expect(this.hobnobber.amber).toBe(3);
             expect(this.troll.amber).toBe(0);
+            expect(this.bumpsy.amber).toBe(2);
             expect(this.player1).isReadyToTakeAction();
         });
 
-        it('can move amber to an enemy creature', function () {
+        it('moves all amber from friendly to enemy', function () {
             this.player1.play(this.ditchTheLoot);
             this.player1.clickCard(this.urchin);
             this.player1.clickCard(this.troll);
             expect(this.urchin.amber).toBe(0);
             expect(this.hobnobber.amber).toBe(0);
             expect(this.troll.amber).toBe(3);
+            expect(this.bumpsy.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('moves all amber from enemy to friendly', function () {
+            this.player1.play(this.ditchTheLoot);
+            this.player1.clickCard(this.bumpsy);
+            this.player1.clickCard(this.urchin);
+            expect(this.urchin.amber).toBe(5);
+            expect(this.hobnobber.amber).toBe(0);
+            expect(this.troll.amber).toBe(0);
+            expect(this.bumpsy.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('moves all amber from enemy to enemy', function () {
+            this.player1.play(this.ditchTheLoot);
+            this.player1.clickCard(this.bumpsy);
+            this.player1.clickCard(this.troll);
+            expect(this.urchin.amber).toBe(3);
+            expect(this.hobnobber.amber).toBe(0);
+            expect(this.troll.amber).toBe(2);
+            expect(this.bumpsy.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
 
         it('can target creatures with no amber on them', function () {
             this.player1.play(this.ditchTheLoot);
-            expect(this.player1).toBeAbleToSelect(this.urchin);
-            expect(this.player1).toBeAbleToSelect(this.hobnobber);
-            expect(this.player1).toBeAbleToSelect(this.troll);
+            this.player1.clickCard(this.hobnobber);
+            this.player1.clickCard(this.troll);
+            expect(this.urchin.amber).toBe(3);
+            expect(this.hobnobber.amber).toBe(0);
+            expect(this.troll.amber).toBe(0);
+            expect(this.bumpsy.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 
@@ -53,14 +87,26 @@ describe('Ditch the Loot', function () {
                     hand: ['ditch-the-loot'],
                     inPlay: ['urchin']
                 },
-                player2: {}
+                player2: {
+                    inPlay: ['troll']
+                }
             });
-            this.urchin.amber = 3;
         });
 
-        it('leaves the amber on the creature when there is no other creature to receive it', function () {
+        it('leaves the amber on the friendly creature when there is no other creature to receive it', function () {
+            this.player2.moveCard(this.troll, 'discard');
+            this.urchin.amber = 3;
             this.player1.play(this.ditchTheLoot);
             expect(this.urchin.amber).toBe(3);
+            expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('leaves the amber on the enemy creature when there is no other creature to receive it', function () {
+            this.player1.moveCard(this.urchin, 'discard');
+            this.troll.amber = 3;
+            this.player1.play(this.ditchTheLoot);
+            expect(this.troll.amber).toBe(3);
             expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });

--- a/test/server/cards/14-DM/DitchTheLoot.spec.js
+++ b/test/server/cards/14-DM/DitchTheLoot.spec.js
@@ -61,6 +61,7 @@ describe('Ditch the Loot', function () {
         it('leaves the amber on the creature when there is no other creature to receive it', function () {
             this.player1.play(this.ditchTheLoot);
             expect(this.urchin.amber).toBe(3);
+            expect(this.player1.amber).toBe(1);
             expect(this.player1).isReadyToTakeAction();
         });
     });


### PR DESCRIPTION
Fixes #5104

Add a `condition` to Ditch the Loot that requires at least 2 creatures in play (combined across both players) before initiates the amber move. This prevents an unresolvable state where there is only one creature with amber and no valid second target to move it to.

### Changes
- `server/game/cards/14-DM/DitchTheLoot.js`: added play condition
- `test/server/cards/14-DM/DitchTheLoot.spec.js`: added test case for single-creature scenario


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted card rule fix with matching server tests; no auth, persistence, or shared infrastructure changes.
> 
> **Overview**
> **Ditch the Loot** now only runs its play ability when there are at least two creatures in play (`context.game.creaturesInPlay.length >= 2`). With a single creature on the board, the card still resolves (amber cost is paid) but amber is no longer stripped with no valid second target—fixing an unresolvable game state (issue #5104).
> 
> Tests were broadened for normal two-step moves (friendly/enemy combinations, zero-amber sources) and new cases assert amber stays on the lone creature when only one remains in play.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ad3bb87b0630ea6f4ededa494c02b6345457fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->