### PR TITLE
DM: fix Victor Flux's alert message

### DIFF
--- a/server/game/cards/14-DM/VictorFlux.js
+++ b/server/game/cards/14-DM/VictorFlux.js
@@ -13,8 +13,8 @@ class VictorFlux extends Card {
                 const purgedType = preThenContext.target && preThenContext.target.type;
                 return {
                     condition: () => !!purgedType,
-                    effect: 'stop {1} from playing cards of type {2}',
-                    effectArgs: (context) => [context.player.opponent, purgedType],
+                    message: '{0} uses {1} to stop {3} from playing cards of type {4}',
+                    messageArgs: (context) => [context.player.opponent, purgedType],
                     effectAlert: true,
                     gameAction: ability.actions.duringOpponentNextTurn({
                         targetController: 'opponent',

--- a/test/server/cards/14-DM/VictorFlux.spec.js
+++ b/test/server/cards/14-DM/VictorFlux.spec.js
@@ -15,9 +15,21 @@ describe('Victor Flux', function () {
         });
 
         it('prevents creatures and allows other types after purging a creature', function () {
+            const messageCountBefore = this.game.messages.length;
             this.player1.reap(this.victorFlux);
             this.player1.clickCard(this.urchin);
             expect(this.urchin.location).toBe('purged');
+            const alert = this.game.messages
+                .slice(messageCountBefore)
+                .find((entry) => entry.message && entry.message.alert);
+            expect(alert).toBeDefined();
+            expect(alert.message.alert.type).toBe('bell');
+            const alertText = JSON.stringify(alert.message);
+            expect(alertText).toContain('"name":"player1"');
+            expect(alertText).toContain('Victor Flux');
+            expect(alertText).toContain('"name":"player2"');
+            expect(alertText).toContain('from playing cards of type');
+            expect(alertText).toContain('creature');
             this.player1.endTurn();
             this.player2.clickPrompt('brobnar');
 
@@ -103,11 +115,16 @@ describe('Victor Flux', function () {
         });
 
         it('does nothing if no card is purged', function () {
+            const messageCountBefore = this.game.messages.length;
             this.player1.moveCard(this.urchin, 'hand');
             this.player1.moveCard(this.dimensionDoor, 'hand');
             this.player1.moveCard(this.cannon, 'hand');
             this.player1.moveCard(this.phoenixHeart, 'hand');
             this.player1.reap(this.victorFlux);
+            const alert = this.game.messages
+                .slice(messageCountBefore)
+                .find((entry) => entry.message && entry.message.alert);
+            expect(alert).toBeUndefined();
             this.player1.endTurn();
             this.player2.clickPrompt('brobnar');
             this.player2.play(this.troll);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-card messaging and test-only changes; gameplay restriction logic is unchanged.
> 
> **Overview**
> **Victor Flux**’s post-reap restriction now uses a **`message` / `messageArgs`** alert (the usual `{0} uses {1} to …` pattern) instead of **`effect` / `effectArgs`**, so the in-game bell alert names the active player, **Victor Flux**, the opponent, and the **purged card type**.
> 
> Tests assert that alert appears with type `bell` and the expected text when a discard purge succeeds, and that **no** alert is emitted when the reap resolves without purging anything.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673a6a0a89869b710216da08d53ac4e5e9d23a62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->