### PR TITLE
test: remove stale readies message from copy-text-box and infinite-loop specs

### DIFF
--- a/test/server/messages/copy-text-box.spec.js
+++ b/test/server/messages/copy-text-box.spec.js
@@ -18,7 +18,6 @@ describe('Copy Text Box Messages', function () {
             this.player2.clickPrompt('geistoid');
             expect(this.player2).isReadyToTakeAction();
             expect(this).toHaveAllChatMessagesBe([
-                'player1 readies their cards',
                 'player1 draws 6 cards to refill their hand to 6 cards',
                 'player1: 0 amber (0 keys) player2: 0 amber (0 keys)',
                 'player2 uses Doppelganger to have Doppelganger gain the text box of Umbra for the remainder of the turn',

--- a/test/server/messages/infinite-loop.spec.js
+++ b/test/server/messages/infinite-loop.spec.js
@@ -36,7 +36,6 @@ describe('Infinite Loop Messages', function () {
             expect(this.doppelgangerA.location).toBe('discard');
             expect(this.doppelgangerB.location).toBe('play area');
             expect(this).toHaveAllChatMessagesBe([
-                'player1 readies their cards',
                 'player1 draws 6 cards to refill their hand to 6 cards',
                 'player1: 0 amber (0 keys) player2: 0 amber (0 keys)',
                 'player2 uses Doppelganger to have Doppelganger gain the text box of Doppelganger for the remainder of the turn',


### PR DESCRIPTION
Follow-up to #5082 which batched `onCardsReadied` so cards that are already ready no longer emit a readies message at end of turn. Updates the two message spec tests that were asserting on this stale message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation updates with no production code changes.
> 
> **Overview**
> Updates **chat message expectations** in `copy-text-box.spec.js` and `infinite-loop.spec.js` so they no longer include **`player1 readies their cards`** at the start of the turn sequence.
> 
> This aligns the specs with the behavior from **#5082**, where end-of-turn readies logging was batched so cards that were already ready do not emit a readies message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 059feb73a9eec099b8925d97de21334672dbff32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->