### PR TITLE
Don't "resolve" house enhancements

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -658,6 +658,13 @@ class Card extends EffectSource {
             .filter((e) => Constants.Houses.includes(e.toLowerCase()));
     }
 
+    getResolvableBonusIcons() {
+        return this.bonusIcons.filter((icon) => {
+            const normalized = icon.replace(/\s/g, '').toLowerCase();
+            return !Constants.Houses.includes(normalized);
+        });
+    }
+
     getHouses() {
         let combinedHouses = [];
 

--- a/server/game/GameActions/ResolveBonusIconsAction.js
+++ b/server/game/GameActions/ResolveBonusIconsAction.js
@@ -195,7 +195,7 @@ class ResolveBonusIconsAction extends CardGameAction {
             EVENTS.onResolveBonusIcons,
             { card: card, context: context },
             (event) => {
-                for (let icon of event.card.bonusIcons) {
+                for (let icon of event.card.getResolvableBonusIcons()) {
                     const resolveCount = card.sumEffects('resolveBonusIconsAdditionalTime') + 1;
 
                     for (let rc = 0; rc < resolveCount; ++rc) {

--- a/test/server/cards/04-MM/AmphoraCaptura.spec.js
+++ b/test/server/cards/04-MM/AmphoraCaptura.spec.js
@@ -71,5 +71,13 @@ describe('Amphora Captura', function () {
             expect(this.player2.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();
         });
+
+        it('should not offer to resolve house enhancements when replacing bonus icons with capture', function () {
+            this.ancientBear.enhancements = ['capture', 'untamed'];
+            this.player1.play(this.ancientBear);
+            this.player1.clickCard(this.senatorShrix);
+            expect(this.player1).not.toHavePrompt('How do you wish to resolve this untamed icon?');
+            expect(this.player1).isReadyToTakeAction();
+        });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, targeted filter in bonus icon resolution with a regression test; no auth, data, or broad gameplay refactors.
> 
> **Overview**
> Bonus icon resolution no longer treats **house enhancements** (e.g. `untamed`, `star alliance`) as icons to resolve. A new `getResolvableBonusIcons()` on `Card` filters `bonusIcons` the same way house names are recognized elsewhere, and `ResolveBonusIconsAction` uses that list instead of the full `bonusIcons` array.
> 
> This fixes incorrect prompts such as “How do you wish to resolve this untamed icon?” when effects like Amphora Captura’s “resolve as capture” run on cards that also have house-enhanced pips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0e8625b5c41dbddb434321a94baa3649d234484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->