### PR TITLE
fix: re-handoff lobby users to game after gamenode reconnect

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -1299,27 +1299,30 @@ class Lobby {
             }
         }
 
-        // Re-handoff any logged-in users whose started game lives on the
-        // just-(re)connected node. Without this, players stranded in the
-        // lobby after a gamenode restart never get bounced back into
-        // their game — they have to refresh or re-login to trigger the
-        // doPostAuth handoff. The handoff payload is a fresh
-        // JWT and is safe to re-issue if the client is already on /play.
+        // Re-handoff only when this game is still the user's active lobby game,
+        // mirroring doPostAuth/findGameForUser behavior.
         for (let game of Object.values(this.games)) {
             if (!game.node || game.node.identity !== nodeName || !game.started) {
                 continue;
             }
-            for (let playerName of Object.keys(game.players || {})) {
-                const socket = this.socketsByName[playerName];
-                if (socket) {
-                    this.sendHandoff(socket, game.node, game.id);
+
+            const names = new Set([
+                ...Object.keys(game.players || {}),
+                ...Object.keys(game.spectators || {})
+            ]);
+
+            for (let name of names) {
+                const socket = this.socketsByName[name];
+                if (!socket) {
+                    continue;
                 }
-            }
-            for (let spectatorName of Object.keys(game.spectators || {})) {
-                const socket = this.socketsByName[spectatorName];
-                if (socket) {
-                    this.sendHandoff(socket, game.node, game.id);
+
+                const activeGame = this.findGameForUser(name);
+                if (!activeGame || activeGame.id !== game.id) {
+                    continue;
                 }
+
+                this.sendHandoff(socket, game.node, game.id);
             }
         }
 

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -1299,6 +1299,30 @@ class Lobby {
             }
         }
 
+        // Re-handoff any logged-in users whose started game lives on the
+        // just-(re)connected node. Without this, players stranded in the
+        // lobby after a gamenode restart never get bounced back into
+        // their game — they have to refresh or re-login to trigger the
+        // doPostAuth handoff. The handoff payload is a fresh
+        // JWT and is safe to re-issue if the client is already on /play.
+        for (let game of Object.values(this.games)) {
+            if (!game.node || game.node.identity !== nodeName || !game.started) {
+                continue;
+            }
+            for (let playerName of Object.keys(game.players || {})) {
+                const socket = this.socketsByName[playerName];
+                if (socket) {
+                    this.sendHandoff(socket, game.node, game.id);
+                }
+            }
+            for (let spectatorName of Object.keys(game.spectators || {})) {
+                const socket = this.socketsByName[spectatorName];
+                if (socket) {
+                    this.sendHandoff(socket, game.node, game.id);
+                }
+            }
+        }
+
         this.broadcastGameList();
     }
 }


### PR DESCRIPTION
When a gamenode reconnects to the lobby, re-send the handoff for any players/spectators whose game lives on that node. Without this, players stranded in the lobby after a gamenode restart never get bounced back into their game — they had to refresh or re-login to trigger `doPostAuth`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change reusing existing handoff logic; no new auth model, mainly improves recovery after node restarts.
> 
> **Overview**
> When a **gamenode** reconnects, `onNodeReconnected` already re-syncs lobby game state from the node but did not push clients back onto the game server. This adds a pass after that sync: for every **started** game on the reconnected node, it calls `sendHandoff` for any **players and spectators** still connected to the lobby.
> 
> That closes the gap where users stayed in the lobby after a gamenode restart until they refreshed or re-authenticated (the only other paths that triggered handoff). Handoff uses the same fresh short-lived JWT as normal start/watch flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e5522ee1bfb566089beec3e108cb7655f25b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->