### PR TITLE
fix: remove double spaces in forge message assertions

### DIFF
--- a/test/server/messages/archive.spec.js
+++ b/test/server/messages/archive.spec.js
@@ -122,13 +122,13 @@ describe('Archive Messages', function () {
             expect(this).toHaveAllChatMessagesBe([
                 'player1 draws 6 cards to refill their hand to 6 cards',
                 'player1: 0 amber (0 keys) player2: 0 amber (0 keys)',
-                'player2 does not forge a key.  They have 0 amber.  The current cost is 6 amber',
+                'player2 does not forge a key. They have 0 amber. The current cost is 6 amber',
                 'player2 chooses logos as their active house this turn',
                 'player2 draws 5 cards to refill their hand to 6 cards',
                 'player1: 0 amber (0 keys) player2: 0 amber (0 keys)',
                 'player1 uses Novu Dynamo to discard Dextre and gain 1 amber',
                 'player1 uses Novu Dynamo to discard Dextre',
-                'player1 does not forge a key.  They have 1 amber.  The current cost is 6 amber'
+                'player1 does not forge a key. They have 1 amber. The current cost is 6 amber'
             ]);
         });
     });


### PR DESCRIPTION
Fixes double spaces in 'does not forge a key' message test assertions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation tweaks with no production or gameplay logic changes.
> 
> **Overview**
> Updates expected chat log strings in `archive.spec.js` for the **does not forge a key** messages: double spaces after sentence-ending periods are removed so assertions match the current single-space formatting (`They have X amber. The current cost is 6 amber`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbec5e5b66b6e4bff1a42f79e820798fd93e3f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->