### PR TITLE
fix: add prettier fmt check to CI and fix lint script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
             - run: npm ci --include=optional
             - name: Typecheck client
               run: npm run typecheck:client
-            - run: npm run fmt
             - run: npm run lint
             - name: Build client
               env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
             - run: npm ci --include=optional
             - name: Typecheck client
               run: npm run typecheck:client
+            - run: npm run fmt
             - run: npm run lint
             - name: Build client
               env:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+.prettierignore
+infrastructure/lobby/templates
+infrastructure/node/templates
+keyteki-json-data

--- a/docs/card-messages.md
+++ b/docs/card-messages.md
@@ -952,6 +952,7 @@ The same rule applies to prompt titles (see [`activePromptTitle`](#using-target)
 ## Best Practices
 
 -   **Pass card objects, not `.name`** - In `messageArgs`/`effectArgs`, always pass `context.source` (the card object), never `context.source.name` (a plain string). Card objects render as hoverable links in the game log; strings render as plain text. If you need the card name in a string concatenation, split the message template into separate placeholders instead:
+
     ```javascript
     // Bad - card name is plain text, not hoverable
     messageArgs: (cards) => [context.player, context.source.name, cards]
@@ -970,6 +971,7 @@ The same rule applies to prompt titles (see [`activePromptTitle`](#using-target)
         context.player.isHaunted() ? ' and archive ' : '',
         context.player.isHaunted() ? context.source : '']
     ```
+
 -   **Show actual values, not descriptions** - Instead of "lose half their amber", show "lose 3 amber".
 -   **Guard against undefined opponents** - Use `context.player.opponent ? ... : 0` for solo play compatibility.
 -   **List affected cards** - When destroying/affecting multiple cards, list them: "({3}), gaining a total of {4} amber".

--- a/package.json
+++ b/package.json
@@ -17,15 +17,18 @@
         "game": "node server/gamenode",
         "test": "vitest run",
         "test:watch": "vitest",
-        "lint": "eslint --ext=js --ext=jsx client/ server/ test/",
+        "fmt": "prettier --check .",
+        "lint": "eslint .",
         "build": "vite build --config vite.config.mjs",
         "typecheck:client": "tsc -p client/tsconfig.json --noEmit",
         "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:js:fix": "npm run lint:js -- --fix"
     },
     "lint-staged": {
+        "*": [
+            "prettier --write"
+        ],
         "*.{js,jsx,ts,tsx}": [
-            "prettier --write",
             "eslint --fix"
         ]
     },

--- a/package.json
+++ b/package.json
@@ -18,19 +18,18 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "fmt": "prettier --check --ignore-unknown .",
-        "lint": "eslint --ext=js --ext=jsx client/ server/ test/",
+        "lint": "eslint --ext=js,jsx,ts,tsx client/ server/ test/",
         "build": "vite build --config vite.config.mjs",
         "typecheck:client": "tsc -p client/tsconfig.json --noEmit",
         "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:js:fix": "npm run lint:js -- --fix"
     },
     "lint-staged": {
-        "*": [
-            "prettier --ignore-unknown --write"
-        ],
         "*.{js,jsx,ts,tsx}": [
+            "prettier --write",
             "eslint --fix"
-        ]
+        ],
+        "!(*.{js,jsx,ts,tsx})": "prettier --ignore-unknown --write"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -17,19 +17,14 @@
         "game": "node server/gamenode",
         "test": "vitest run",
         "test:watch": "vitest",
-        "fmt": "prettier --check --ignore-unknown .",
-        "lint": "eslint --ext=js,jsx,ts,tsx client/ server/ test/",
+        "lint": "prettier --check --ignore-unknown '!**/*.{js,jsx,ts,tsx}' . && eslint --ext=js,jsx,ts,tsx .",
+        "lint:fix": "prettier --write --ignore-unknown '!**/*.{js,jsx,ts,tsx}' . && eslint --fix --ext=js,jsx,ts,tsx .",
         "build": "vite build --config vite.config.mjs",
-        "typecheck:client": "tsc -p client/tsconfig.json --noEmit",
-        "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
-        "lint:js:fix": "npm run lint:js -- --fix"
+        "typecheck:client": "tsc -p client/tsconfig.json --noEmit"
     },
     "lint-staged": {
-        "*.{js,jsx,ts,tsx}": [
-            "prettier --write",
-            "eslint --fix"
-        ],
-        "!(*.{js,jsx,ts,tsx})": "prettier --ignore-unknown --write"
+        "!(*.{js,jsx,ts,tsx})": "prettier --ignore-unknown --write",
+        "*.{js,jsx,ts,tsx}": "eslint --fix"
     },
     "husky": {
         "hooks": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "game": "node server/gamenode",
         "test": "vitest run",
         "test:watch": "vitest",
-        "fmt": "prettier --check .",
+        "fmt": "prettier --check --ignore-unknown .",
         "lint": "eslint --ext=js --ext=jsx client/ server/ test/",
         "build": "vite build --config vite.config.mjs",
         "typecheck:client": "tsc -p client/tsconfig.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "lint-staged": {
         "*": [
-            "prettier --write"
+            "prettier --ignore-unknown --write"
         ],
         "*.{js,jsx,ts,tsx}": [
             "eslint --fix"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "fmt": "prettier --check .",
-        "lint": "eslint .",
+        "lint": "eslint --ext=js --ext=jsx client/ server/ test/",
         "build": "vite build --config vite.config.mjs",
         "typecheck:client": "tsc -p client/tsconfig.json --noEmit",
         "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Summary

- Add `npm run fmt` (`prettier --check --ignore-unknown .`) step to CI after typecheck, before lint
- Add `.prettierignore` to exclude generated/submodule dirs (`infrastructure/*/templates`, `keyteki-json-data`)
- Update `lint-staged`: run prettier on all files, eslint only on js/ts files
- Fix minor markdown blank lines in `docs/card-messages.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and documentation only; no runtime game or auth behavior changes.
> 
> **Overview**
> **Prettier is wired into local linting** while keeping JS/TS formatting on ESLint (with Prettier via eslint-plugin-prettier). `npm run lint` now runs Prettier `--check` on the repo **excluding** `*.{js,jsx,ts,tsx}`, then ESLint across the whole tree with `js,jsx,ts,tsx` extensions. **`lint:fix`** applies the same split with `--write` / `--fix`. Duplicate **`lint:js`** / **`lint:js:fix`** scripts were removed.
> 
> A new **`.prettierignore`** skips generated Helm paths (`infrastructure/lobby/templates`, `infrastructure/node/templates`) and **`keyteki-json-data`**.
> 
> **`lint-staged`** on pre-commit: Prettier only for non-JS/TS files; ESLint `--fix` only for JS/TS (no longer running Prettier on every staged TS/JS file).
> 
> **`docs/card-messages.md`**: cosmetic blank lines in the Best Practices section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3f339c0b8bf5dbb1a6ed6414c527f606f6c993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->