### PR TITLE
[WIP] fix: reverse opponent battleline card ordering to match visual expectation

### DIFF
--- a/client/Components/GameBoard/PlayerBoard.jsx
+++ b/client/Components/GameBoard/PlayerBoard.jsx
@@ -54,29 +54,33 @@ const PlayerBoard = (props) => {
                 source='play area'
                 manualMode={props.manualMode}
             >
-                {rows.map((row, index) => (
-                    <div className={`card-row ${row.name}`} key={`card-row-${index}`}>
-                        {row.cards.map((card) => (
-                            <Card
-                                key={card.uuid}
-                                cardBack={props.cardBack}
-                                canDrag={props.manualMode}
-                                card={card}
-                                disableMouseOver={card.facedown && !card.code}
-                                halfSize={props.user.settings.optionSettings.useHalfSizedCards}
-                                isSpectating={props.isSpectating}
-                                onClick={props.onCardClick}
-                                onMenuItemClick={props.onMenuItemClick}
-                                onMouseOut={props.onMouseOut}
-                                onMouseOver={props.onMouseOver}
-                                size={props.user.settings.cardSize}
-                                hasActiveHouse={props.hasActiveHouse}
-                                isMe={props.isMe}
-                                source='play area'
-                            />
-                        ))}
-                    </div>
-                ))}
+                {rows.map((row, index) => {
+                    const cards =
+                        props.rowDirection === 'reverse' ? [...row.cards].reverse() : row.cards;
+                    return (
+                        <div className={`card-row ${row.name}`} key={`card-row-${index}`}>
+                            {cards.map((card) => (
+                                <Card
+                                    key={card.uuid}
+                                    cardBack={props.cardBack}
+                                    canDrag={props.manualMode}
+                                    card={card}
+                                    disableMouseOver={card.facedown && !card.code}
+                                    halfSize={props.user.settings.optionSettings.useHalfSizedCards}
+                                    isSpectating={props.isSpectating}
+                                    onClick={props.onCardClick}
+                                    onMenuItemClick={props.onMenuItemClick}
+                                    onMouseOut={props.onMouseOut}
+                                    onMouseOver={props.onMouseOver}
+                                    size={props.user.settings.cardSize}
+                                    hasActiveHouse={props.hasActiveHouse}
+                                    isMe={props.isMe}
+                                    source='play area'
+                                />
+                            ))}
+                        </div>
+                    );
+                })}
             </Droppable>
             {props.isMe && (
                 <PlayerRow


### PR DESCRIPTION
Reverses the card order in the opponent's battleline rows when `rowDirection === 'reverse'`, so the visual ordering matches the expected left-to-right layout from the opponent's perspective.

<img width="1866" height="1426" alt="image" src="https://github.com/user-attachments/assets/f8f32e84-63a6-4b65-9bf2-8ca4e9b53425" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-only change in `PlayerBoard` with no game logic or data flow impact.
> 
> **Overview**
> When rendering the opponent play area (`rowDirection === 'reverse'`), each battleline row now maps cards through a **reversed copy** of `row.cards` before rendering, so left-to-right order matches what players expect from the opponent’s side.
> 
> Your own board (`default`) is unchanged and still uses the original card order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1d8d121459a7a2da78bd99352b3c98df45f382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->