### PR TITLE
fix: show targeting subjects in ability prompts

### DIFF
--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -252,6 +252,8 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
                 let event = context.event;
                 if (context.target) {
                     targets = targets.concat(context.target);
+                } else if (context.subject) {
+                    targets = targets.concat(context.subject);
                 } else if (event.card && event.card !== context.source) {
                     targets = targets.concat(event.card);
                 } else if (event.card) {

--- a/server/game/gamesteps/handlermenuprompt.js
+++ b/server/game/gamesteps/handlermenuprompt.js
@@ -98,8 +98,12 @@ class HandlerMenuPrompt extends UiPrompt {
 
             targets = this.context.targets ? Object.values(this.context.targets) : [];
             targets = targets.reduce((array, target) => array.concat(target), []);
-            if (targets.length === 0 && this.context.event && this.context.event.card) {
-                this.targets = [this.context.event.card];
+            if (targets.length === 0) {
+                if (this.context.subject) {
+                    targets = [this.context.subject];
+                } else if (this.context.event && this.context.event.card) {
+                    targets = [this.context.event.card];
+                }
             }
         }
 

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -115,8 +115,12 @@ class SelectCardPrompt extends UiPrompt {
     getDefaultControls() {
         let targets = this.context.targets ? Object.values(this.context.targets) : [];
         targets = targets.reduce((array, target) => array.concat(target), []);
-        if (targets.length === 0 && this.context.event && this.context.event.card) {
-            this.targets = [this.context.event.card];
+        if (targets.length === 0) {
+            if (this.context.subject) {
+                targets = [this.context.subject];
+            } else if (this.context.event && this.context.event.card) {
+                targets = [this.context.event.card];
+            }
         }
 
         return [


### PR DESCRIPTION
## Summary

This issue was found by AI while investigating something else, broke it out into a PR.

Fix AbilityTargeting UI not showing target cards for abilities that use `multiTriggerEvent` (e.g. Cosmicrux).

## Problem

When abilities trigger via `multiTriggerEvent`, the affected card is stored in `context.subject`. However, the prompt controls only checked `context.target` and `event.card`. Since batch events like `onCardsReadied` use `event.cards` (plural), `event.card` is undefined and no targets were displayed.

Additionally, `selectcardprompt` and `handlermenuprompt` had a long-standing bug where the fallback assigned to `this.targets` (instance property) instead of the local `targets` variable used in the return value.

## Changes

- `forcedtriggeredabilitywindow.getPromptControls()` — add `context.subject` fallback
- `selectcardprompt.getDefaultControls()` — fix variable assignment + add `context.subject` fallback
- `handlermenuprompt.getDefaultControls()` — fix variable assignment + add `context.subject` fallback

## Testing

All 38,047 tests pass. Manually verified Cosmicrux triggered ability now shows target cards in the prompt UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized prompt-control changes with no auth or data-path impact; main risk is incorrect target display in edge-case prompts.
> 
> **Overview**
> **Ability targeting prompts** now surface the affected card when abilities fire from **`multiTriggerEvent`** flows (e.g. Cosmicrux on readied creatures), by falling back to **`context.subject`** when **`context.target`** and **`event.card`** are missing.
> 
> The same **`context.subject`** fallback is applied in **`forcedtriggeredabilitywindow.getPromptControls()`**, **`selectcardprompt.getDefaultControls()`**, and **`handlermenuprompt.getAdditionalPromptControls()`**. **`selectcardprompt`** and **`handlermenuprompt`** also fix a bug where empty-target fallback wrote to **`this.targets`** instead of the local **`targets`** list returned to the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9afdbcec699ed3d0a5e61f3eef40bd6c2ba89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->