### PR TITLE
fix: ability targeting prompt overflow with many targets

### DIFF
--- a/client/Components/GameBoard/AbilityTargeting.jsx
+++ b/client/Components/GameBoard/AbilityTargeting.jsx
@@ -50,7 +50,7 @@ const AbilityTargeting = (props) => {
             {renderSimpleCard(props.source)}
             {count > 0 && <Icon icon={faArrowRight} />}
             {count > 0 && (
-                <div className='flex min-w-0 flex-1 flex-row items-center justify-end'>
+                <div className='flex min-w-0 flex-1 flex-row items-center'>
                     {props.targets.map((target, index) => (
                         <React.Fragment key={target.uuid || index}>
                             {renderSimpleCard(target, index > 0 ? overlapMargin : undefined)}

--- a/client/Components/GameBoard/AbilityTargeting.jsx
+++ b/client/Components/GameBoard/AbilityTargeting.jsx
@@ -1,8 +1,8 @@
-import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
-import CardImage from './CardImage';
-import Icon from '../Icon';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+import React, { useCallback } from 'react';
+import Icon from '../Icon';
+import CardImage from './CardImage';
 
 const AbilityTargeting = (props) => {
     const onMouseOver = useCallback(
@@ -23,9 +23,10 @@ const AbilityTargeting = (props) => {
         [props]
     );
 
-    const renderSimpleCard = (card) => (
+    const renderSimpleCard = (card, style) => (
         <div
-            className='mb-2 h-24 w-16 shrink-0 overflow-hidden rounded-[6.25%] [&>canvas]:!h-full [&>canvas]:!w-full'
+            className='h-24 w-16 shrink-0 overflow-hidden rounded-[6.25%] [&>canvas]:!h-full [&>canvas]:!w-full'
+            style={style}
             onMouseOut={() => onMouseOut(card)}
             onMouseOver={() =>
                 onMouseOver({
@@ -38,13 +39,25 @@ const AbilityTargeting = (props) => {
         </div>
     );
 
-    const targetCards = props.targets.map((target) => renderSimpleCard(target));
+    const count = props.targets.length;
+    // Overlap margin: spread cards across available width, overlapping when
+    // they don't fit. 100% = parent width, 4rem = card width (w-16).
+    const overlapMargin =
+        count > 1 ? { marginLeft: `calc((100% - ${count} * 4rem) / ${count - 1})` } : undefined;
 
     return (
-        <div className='flex flex-row items-center justify-center gap-2'>
+        <div className='mb-2 flex w-full flex-row items-center gap-2'>
             {renderSimpleCard(props.source)}
-            {targetCards.length > 0 && <Icon icon={faArrowRight} />}
-            {targetCards}
+            {count > 0 && <Icon icon={faArrowRight} />}
+            {count > 0 && (
+                <div className='flex min-w-0 flex-1 flex-row items-center justify-end'>
+                    {props.targets.map((target, index) => (
+                        <React.Fragment key={target.uuid || index}>
+                            {renderSimpleCard(target, index > 0 ? overlapMargin : undefined)}
+                        </React.Fragment>
+                    ))}
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Summary

When many target cards are shown in the AbilityTargeting prompt, they overflow the container. This replaces the CSS-class approach with inline flex layout that gracefully overlaps cards when they don't fit.

## Changes

- Outer container: add `w-full`, move `mb-2` from card divs
- Target row: `flex min-w-0 flex-1` container with `justify-end`
- Inline `calc((100% - n * 4rem) / (n - 1))` margin for overlap
- Add `key` props via React.Fragment for target cards
- Remove `.ability-target-row` CSS class (no longer needed)

## Testing

Manually verified with Cosmicrux triggering on multiple readied creatures — cards overlap cleanly when they exceed container width.

<img width="526" height="826" alt="image" src="https://github.com/user-attachments/assets/e1b7716c-4543-471c-b0a4-0a9e91c201fd" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component layout and styling change for the ability targeting prompt; no auth, data, or game logic changes.
> 
> **Overview**
> Fixes **AbilityTargeting** so many target cards no longer overflow the prompt width.
> 
> The layout switches from a centered row with fixed gaps to a full-width flex row: source card and arrow stay on the left, targets sit in a `flex-1 min-w-0` strip. When there are multiple targets, each card after the first gets a computed `marginLeft` so cards spread across the row and **overlap** when they would not fit (`calc` based on count and `4rem` card width). Per-card `mb-2` moves to the outer container; target list items get stable `key`s via `uuid` or index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb039e54f13fb9867fb955ac3efc649ac1c2d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->