### PR TITLE
fix: guard against null opponent in EvenSwap and takeControl

### DIFF
--- a/server/game/cards/14-DM/EvenSwap.js
+++ b/server/game/cards/14-DM/EvenSwap.js
@@ -5,7 +5,8 @@ class EvenSwap extends Card {
     setupCardAbilities(ability) {
         const giveTarget = () => ({
             mode: 'exactly',
-            numCards: (context) => (context.player.creaturesInPlay.length >= 1 ? 1 : 0),
+            numCards: (context) =>
+                context.player.opponent && context.player.creaturesInPlay.length >= 1 ? 1 : 0,
             cardType: 'creature',
             controller: 'self',
             gameAction: ability.actions.cardLastingEffect((context) => ({

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1318,11 +1318,13 @@ class Game extends EventEmitter {
             this.checkWinCondition();
             // if the state has changed, check for:
             let modifiedControl = false;
-            for (const player of this.getPlayers()) {
+            const allPlayers = this.getPlayers();
+            for (const player of allPlayers) {
                 _.each(player.cardsInPlay, (card) => {
-                    if (card.getModifiedController() !== player) {
+                    const newController = card.getModifiedController();
+                    if (newController !== player && allPlayers.includes(newController)) {
                         // any card being controlled by the wrong player
-                        this.takeControl(card.getModifiedController(), card, modifiedByPlayer);
+                        this.takeControl(newController, card, modifiedByPlayer);
                         modifiedControl = true;
                     }
                 });


### PR DESCRIPTION
- **EvenSwap**: only require a target creature when an opponent exists (guards against null `context.player.opponent`)
- **game.js**: skip `takeControl` when `newController` is not a valid player (prevents crash when controller resolves to a non-player value)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive checks in card targeting and game-state reconciliation; no auth or data changes.
> 
> **Overview**
> Hardens **control-swap** flows when there is no valid opponent (e.g. solo or edge game states).
> 
> **EvenSwap** now requires `context.player.opponent` before treating the “give a friendly creature” step as needing a target, so the card does not drive selection or `takeControl` effects against a null opponent.
> 
> In **`checkGameState`**, mismatched controllers are reconciled only when `getModifiedController()` resolves to another entry in `getPlayers()`; invalid or non-player controllers no longer trigger `takeControl`, avoiding crashes during state cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2395e2157a545022f6069cf2c41fe85eb31a7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->