### PR TITLE
fix: targeted block list updates for quick join games (#2766)

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -1197,21 +1197,74 @@ class Lobby {
     }
 
     onBlocklistChanged(user) {
-        let updatedUser = this.users[user.username];
+        const updatedUser = this.users[user.username];
 
         if (!updatedUser) {
             return;
         }
 
+        const socket = this.socketsByName[user.username];
+        if (!socket) {
+            updatedUser.blockList = user.blockList;
+            return;
+        }
+
+        const oldBlockList = updatedUser.blockList || [];
+        const newBlockList = user.blockList || [];
+
+        const added = newBlockList.filter((entry) => !oldBlockList.includes(entry));
+        const removed = oldBlockList.filter((entry) => !newBlockList.includes(entry));
+
+        // Snapshot game visibility before the update
+        let gameVisibilityBefore = {};
+        for (let game of Object.values(this.games)) {
+            gameVisibilityBefore[game.id] = game.isVisibleFor(updatedUser);
+        }
+
         updatedUser.blockList = user.blockList;
 
-        // Re-send the lobby state so the user's game/user list (which is
-        // filtered by their block list) reflects the change without
-        // requiring a page refresh.
-        const socket = this.socketsByName[user.username];
-        if (socket) {
-            this.sendUserListFilteredWithBlockList(socket, this.getUserList());
-            this.broadcastGameList(socket);
+        // Send targeted removals for newly blocked users
+        for (let blockedName of added) {
+            let blockedUser = this.users[blockedName];
+            if (blockedUser) {
+                socket.send('userleft', blockedUser.getShortSummary());
+            }
+        }
+
+        // Send targeted additions for newly unblocked users
+        for (let unblockedName of removed) {
+            let unblockedUser = this.users[unblockedName];
+            if (unblockedUser) {
+                socket.send('newuser', unblockedUser.getShortSummary());
+            }
+        }
+
+        // Send targeted game removals/additions based on visibility changes
+        let gamesToRemove = [];
+        let gamesToAdd = [];
+        for (let game of Object.values(this.games)) {
+            let wasVisible = gameVisibilityBefore[game.id];
+            let isVisible = game.isVisibleFor(updatedUser);
+
+            if (wasVisible && !isVisible) {
+                gamesToRemove.push(game);
+            } else if (!wasVisible && isVisible) {
+                gamesToAdd.push(game);
+            }
+        }
+
+        if (gamesToRemove.length > 0) {
+            socket.send(
+                'removegame',
+                gamesToRemove.map((game) => game.getSummary())
+            );
+        }
+
+        if (gamesToAdd.length > 0) {
+            socket.send(
+                'newgame',
+                gamesToAdd.map((game) => game.getSummary())
+            );
         }
     }
 

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -1225,7 +1225,9 @@ class Lobby {
 
         // Send targeted removals for newly blocked users
         for (let blockedName of added) {
-            let blockedUser = this.users[blockedName];
+            let blockedUser = Object.values(this.users).find(
+                (u) => u.username.toLowerCase() === blockedName
+            );
             if (blockedUser) {
                 socket.send('userleft', blockedUser.getShortSummary());
             }
@@ -1233,7 +1235,9 @@ class Lobby {
 
         // Send targeted additions for newly unblocked users
         for (let unblockedName of removed) {
-            let unblockedUser = this.users[unblockedName];
+            let unblockedUser = Object.values(this.users).find(
+                (u) => u.username.toLowerCase() === unblockedName
+            );
             if (unblockedUser) {
                 socket.send('newuser', unblockedUser.getShortSummary());
             }


### PR DESCRIPTION
As requested [here](https://github.com/keyteki/keyteki/pull/5092#pullrequestreview-4382639510)

Instead of re-sending the full user/game list on block list change, send targeted add/remove events for only the affected users and games.

This avoids flooding clients with the entire lobby state on every block list change, and ensures quick-join games (which are filtered by block list) are properly hidden/shown when a user is blocked/unblocked.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lobby real-time sync behavior changes; incorrect diffs could leave clients with stale users or games, though scope is limited to connected users on block list change.
> 
> **Overview**
> **`onBlocklistChanged`** no longer pushes a full filtered **`users`** list and **`games`** snapshot to the affected client. It now diffs the block list and emits **`userleft`** / **`newuser`** only for users who were blocked or unblocked.
> 
> For lobby games, it snapshots **`isVisibleFor`** before updating the list, then sends batched **`removegame`** and **`newgame`** summaries only when visibility flips—so quick-join eligible games disappear or reappear without a full lobby refresh.
> 
> If the user is offline (no socket), it only updates **`blockList`** in memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96028cdf1569578ea7d64615148d2980a4a93a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->