### PR TITLE
fix: add null guards for context.target across card implementations

### DIFF
--- a/server/game/cards/01-Core/Commpod.js
+++ b/server/game/cards/01-Core/Commpod.js
@@ -11,7 +11,7 @@ class Commpod extends Card {
                 location: 'hand',
                 cardCondition: (card) => card.hasHouse('mars'),
                 gameAction: ability.actions.sequentialForEach((context) => ({
-                    num: context.target.length,
+                    num: (context.target || []).length,
                     action: ability.actions.ready({
                         promptForSelect: {
                             optional: true,

--- a/server/game/cards/02-AoA/1-2Punch.js
+++ b/server/game/cards/02-AoA/1-2Punch.js
@@ -10,10 +10,10 @@ class OneTwoPunch extends Card {
                 controller: 'opponent',
                 gameAction: [
                     ability.actions.destroy((context) => ({
-                        target: context.target.stunned ? context.target : []
+                        target: context.target?.stunned ? context.target : []
                     })),
                     ability.actions.stun((context) => ({
-                        target: context.target.stunned ? [] : context.target
+                        target: !context.target || context.target.stunned ? [] : context.target
                     }))
                 ]
             }

--- a/server/game/cards/02-AoA/DestructiveAnalysis.js
+++ b/server/game/cards/02-AoA/DestructiveAnalysis.js
@@ -20,8 +20,9 @@ class DestructiveAnalysis extends Card {
                         ability.actions.dealDamage((context) => ({
                             target: preThenContext.target,
                             amount:
-                                context.target.filter((card) => card.owner === card.controller)
-                                    .length * 2
+                                (context.target || []).filter(
+                                    (card) => card.owner === card.controller
+                                ).length * 2
                         }))
                     ]
                 }

--- a/server/game/cards/02-AoA/EntropicSwirl.js
+++ b/server/game/cards/02-AoA/EntropicSwirl.js
@@ -8,10 +8,10 @@ class EntropicSwirl extends Card {
                 cardType: 'creature',
                 gameAction: [
                     ability.actions.dealDamage((context) => ({
-                        amount: context.target.getTraits().length * 2
+                        amount: (context.target?.getTraits() || []).length * 2
                     })),
                     ability.actions.gainAmber((context) => ({
-                        amount: context.target.getTraits().length,
+                        amount: (context.target?.getTraits() || []).length,
                         target: context.player
                     }))
                 ]

--- a/server/game/cards/02-AoA/TheFlex.js
+++ b/server/game/cards/02-AoA/TheFlex.js
@@ -14,7 +14,7 @@ class TheFlex extends Card {
                     ability.actions.exhaust(),
                     ability.actions.gainAmber((context) => ({
                         target: context.player,
-                        amount: Math.floor(context.target.power / 2)
+                        amount: Math.floor((context.target?.power || 0) / 2)
                     }))
                 ]
             }

--- a/server/game/cards/03-WC/HunterOrHunted.js
+++ b/server/game/cards/03-WC/HunterOrHunted.js
@@ -18,14 +18,14 @@ class HunterOrHunted extends Card {
                     gameAction: [
                         ability.actions.ward((context) => ({
                             target:
-                                context.selects.action.choice === 'Ward a creature'
-                                    ? context.targets.creature
+                                context.selects?.action?.choice === 'Ward a creature'
+                                    ? context.targets?.creature
                                     : []
                         })),
                         ability.actions.removeWardToken((context) => ({
                             target:
-                                context.selects.action.choice === 'Move a ward'
-                                    ? context.targets.creature
+                                context.selects?.action?.choice === 'Move a ward'
+                                    ? context.targets?.creature
                                     : []
                         }))
                     ]

--- a/server/game/cards/04-MM/GrowthSurge.js
+++ b/server/game/cards/04-MM/GrowthSurge.js
@@ -11,11 +11,14 @@ class GrowthSurge extends Card {
                     gameAction: [
                         ability.actions.addPowerCounter({ amount: 3 }),
                         ability.actions.addPowerCounter((context) => ({
-                            target: context.targets.flank.neighbors,
-                            amount: context.targets.flank.neighbors.length !== 1 ? 0 : 2
+                            target: context.targets.flank?.neighbors,
+                            amount: context.targets.flank?.neighbors?.length !== 1 ? 0 : 2
                         })),
                         ability.actions.addPowerCounter((context) => {
-                            if (context.targets.flank.neighbors.length !== 1) {
+                            if (
+                                !context.targets.flank?.neighbors ||
+                                context.targets.flank.neighbors.length !== 1
+                            ) {
                                 return { amount: 0 };
                             }
 

--- a/server/game/cards/04-MM/MarkOfDis.js
+++ b/server/game/cards/04-MM/MarkOfDis.js
@@ -9,9 +9,9 @@ class MarkOfDis extends Card {
                 gameAction: ability.actions.sequential([
                     ability.actions.dealDamage({ amount: 2 }),
                     ability.actions.conditional((context) => ({
-                        condition: () => context.target.location === 'play area',
+                        condition: () => context.target?.location === 'play area',
                         trueGameAction:
-                            context.player === context.target.controller
+                            context.target && context.player === context.target.controller
                                 ? ability.actions.untilPlayerNextTurnEnd({
                                       targetController: 'current',
                                       effect: ability.effects.restrictHouseChoice(
@@ -21,7 +21,7 @@ class MarkOfDis extends Card {
                                 : ability.actions.duringOpponentNextTurn({
                                       targetController: 'opponent',
                                       effect: ability.effects.restrictHouseChoice(
-                                          context.target.getHouses()
+                                          context.target?.getHouses() || []
                                       )
                                   })
                     }))

--- a/server/game/cards/04-MM/Shadowsaurus.js
+++ b/server/game/cards/04-MM/Shadowsaurus.js
@@ -17,15 +17,15 @@ class Shadowsaurus extends Card {
                 gameAction: [
                     ability.actions.returnAmber((context) => ({
                         all: true,
-                        recipient: context.target.controller
+                        recipient: context.target?.controller
                     })),
                     ability.actions.cardLastingEffect((context) => ({
                         duration: 'lastingEffect',
-                        target: context.target.amber ? context.target : [],
+                        target: context.target?.amber ? context.target : [],
                         effect: ability.effects.takeControl(context.player)
                     })),
                     ability.actions.cardLastingEffect((context) => ({
-                        target: context.target.amber ? context.target : [],
+                        target: context.target?.amber ? context.target : [],
                         duration: 'lastingEffect',
                         condition: (context) => context.target.controller === context.player,
                         effect: ability.effects.changeHouse('shadows')

--- a/server/game/cards/05-DT/CallOfTheVoid.js
+++ b/server/game/cards/05-DT/CallOfTheVoid.js
@@ -7,13 +7,13 @@ class CallOfTheVoid extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: ability.actions.conditional({
-                    condition: (context) => !context.target.exhausted,
+                    condition: (context) => !context.target?.exhausted,
                     trueGameAction: ability.actions.exhaust(),
                     falseGameAction: [
                         ability.actions.destroy(),
                         ability.actions.loseAmber((context) => ({
                             amount: 1,
-                            target: context.target.controller
+                            target: context.target?.controller
                         }))
                     ]
                 })

--- a/server/game/cards/05-DT/LightsmithClarielEvilTwin.js
+++ b/server/game/cards/05-DT/LightsmithClarielEvilTwin.js
@@ -11,10 +11,12 @@ class LightsmithClarielEvilTwin extends Card {
                     duration: 'lastingEffect',
                     effect: [
                         ability.effects.modifyPower(
-                            context.target.armorPrinted - context.target.powerPrinted
+                            (context.target?.armorPrinted || 0) -
+                                (context.target?.powerPrinted || 0)
                         ),
                         ability.effects.modifyArmor(
-                            context.target.powerPrinted - context.target.armorPrinted
+                            (context.target?.powerPrinted || 0) -
+                                (context.target?.armorPrinted || 0)
                         )
                     ]
                 }))

--- a/server/game/cards/05-DT/SeneschalSargassa.js
+++ b/server/game/cards/05-DT/SeneschalSargassa.js
@@ -11,7 +11,7 @@ class SeneschalSargassa extends Card {
                 cardType: 'creature',
                 cardCondition: (card) => card.controller.isTideHigh(),
                 gameAction: ability.actions.capture((context) => ({
-                    player: context.target.controller.opponent,
+                    player: context.target?.controller?.opponent,
                     amount: 2
                 }))
             }

--- a/server/game/cards/06-WoE/ExchangeProgram.js
+++ b/server/game/cards/06-WoE/ExchangeProgram.js
@@ -22,25 +22,25 @@ class ExchangeProgram extends Card {
                     cardCondition: (card) => card.isOnFlank(),
                     gameAction: [
                         ability.actions.cardLastingEffect((context) => ({
-                            target: context.targets.second,
+                            target: context.targets?.second || [],
                             duration: 'lastingEffect',
                             effect: ability.effects.takeControl(context.player)
                         })),
                         ability.actions.cardLastingEffect((context) => ({
-                            target: context.targets.second,
+                            target: context.targets?.second || [],
                             effect: ability.effects.takeControlOn(
-                                context.player.cardsInPlay.indexOf(context.targets.first)
+                                context.player.cardsInPlay.indexOf(context.targets?.first)
                             )
                         })),
                         ability.actions.cardLastingEffect((context) => ({
-                            target: context.targets.first,
+                            target: context.targets?.first || [],
                             duration: 'lastingEffect',
                             effect: ability.effects.takeControl(context.player.opponent)
                         })),
                         ability.actions.cardLastingEffect((context) => ({
-                            target: context.targets.first,
+                            target: context.targets?.first || [],
                             effect: ability.effects.takeControlOn(
-                                context.player.opponent.cardsInPlay.indexOf(context.targets.second)
+                                context.player.opponent.cardsInPlay.indexOf(context.targets?.second)
                             )
                         }))
                     ]

--- a/server/game/cards/07-GR/EnergyVampirism.js
+++ b/server/game/cards/07-GR/EnergyVampirism.js
@@ -11,10 +11,10 @@ class EnergyVampirism extends Card {
                 gameAction: ability.actions.sequential([
                     ability.actions.capture((context) => ({
                         amount: 1,
-                        player: context.target.controller
+                        player: context.target && context.target.controller
                     })),
                     ability.actions.allocateDamage((context) => ({
-                        numSteps: context.target.amber || 0
+                        numSteps: (context.target && context.target.amber) || 0
                     }))
                 ])
             },

--- a/server/game/cards/07-GR/SecurityDetail.js
+++ b/server/game/cards/07-GR/SecurityDetail.js
@@ -8,7 +8,7 @@ class SecurityDetail extends Card {
                 controller: 'self',
                 cardType: 'creature',
                 gameAction: ability.actions.capture((context) => ({
-                    target: context.target.neighbors.concat(context.target)
+                    target: context.target ? context.target.neighbors.concat(context.target) : []
                 }))
             },
             effect: 'capture 1 amber onto {1}',

--- a/server/game/cards/08-AS/Crunch.js
+++ b/server/game/cards/08-AS/Crunch.js
@@ -12,7 +12,7 @@ class Crunch extends Card {
                 cardCondition: (card, context) => context.source.neighbors.includes(card),
                 gameAction: ability.actions.addPowerCounter((context) => ({
                     target: context.source,
-                    amount: context.target.power
+                    amount: context.target?.power || 0
                 }))
             }
         });

--- a/server/game/cards/08-AS/ImprovisedAviation.js
+++ b/server/game/cards/08-AS/ImprovisedAviation.js
@@ -32,7 +32,7 @@ class ImprovisedAviation extends Card {
                                         cardType: 'artifact',
                                         controller: 'any',
                                         gameAction: ability.actions.returnToDeck((context) => ({
-                                            shufflePlayer: context.target.owner,
+                                            shufflePlayer: context.target?.owner,
                                             shuffle: true
                                         }))
                                     }

--- a/server/game/cards/08-AS/SharkBait.js
+++ b/server/game/cards/08-AS/SharkBait.js
@@ -11,7 +11,7 @@ class SharkBait extends Card {
                 gameAction: ability.actions.sequential([
                     ability.actions.dealDamage({ amount: 2 }),
                     ability.actions.conditional((context) => ({
-                        condition: () => context.target.location === 'play area',
+                        condition: () => context.target?.location === 'play area',
                         trueGameAction: ability.actions.capture({
                             target: context.target,
                             amount: 2

--- a/server/game/cards/09-ToC/CognitiveAssumptions.js
+++ b/server/game/cards/09-ToC/CognitiveAssumptions.js
@@ -13,8 +13,8 @@ class CognitiveAssumptions extends Card {
                 location: 'hand',
                 cardCondition: (card) => card.hasHouse('logos'),
                 gameAction: ability.actions.makeTokenCreature((context) => ({
-                    target: context.player.deck.slice(0, context.target.length),
-                    amount: context.target.length
+                    target: context.player.deck.slice(0, (context.target || []).length),
+                    amount: (context.target || []).length
                 }))
             },
             effect: 'reveal {1} and make {2} token creature{3}',

--- a/server/game/cards/11-VM25/Antanagoge.js
+++ b/server/game/cards/11-VM25/Antanagoge.js
@@ -23,7 +23,7 @@ class Antanagoge extends Card {
                 cardCondition: (card, context) =>
                     card.type === 'creature' && card.parent === context.source,
                 gameAction: ability.actions.dealDamage((context) => ({
-                    amount: context.target.power,
+                    amount: context.target?.power || 0,
                     target: context.game.creaturesInPlay
                 }))
             }

--- a/server/game/cards/13-CC/RenderGuilt.js
+++ b/server/game/cards/13-CC/RenderGuilt.js
@@ -10,7 +10,7 @@ class RenderGuilt extends Card {
                 gameAction: ability.actions.sequential([
                     ability.actions.capture(),
                     ability.actions.allocateDamage((context) => ({
-                        numSteps: context.target.amber || 0
+                        numSteps: context.target?.amber || 0
                     }))
                 ])
             },

--- a/server/game/cards/13-CC/Ruination.js
+++ b/server/game/cards/13-CC/Ruination.js
@@ -8,13 +8,15 @@ class Ruination extends Card {
                 cardType: ['creature', 'artifact', 'upgrade'],
                 location: 'play area',
                 gameAction: ability.actions.destroy((context) => ({
-                    target: context.game.cardsInPlay
-                        .filter((card) => card.name === context.target.name)
-                        .concat(
-                            context.game.cardsInPlay
-                                .flatMap((card) => card.upgrades || [])
-                                .filter((upgrade) => upgrade.name === context.target.name)
-                        )
+                    target: context.target
+                        ? context.game.cardsInPlay
+                              .filter((card) => card.name === context.target.name)
+                              .concat(
+                                  context.game.cardsInPlay
+                                      .flatMap((card) => card.upgrades || [])
+                                      .filter((upgrade) => upgrade.name === context.target.name)
+                              )
+                        : []
                 }))
             },
             effect: 'destroy {1} and each card with the same name',

--- a/server/game/cards/13-CC/UberkingTablets.js
+++ b/server/game/cards/13-CC/UberkingTablets.js
@@ -16,12 +16,12 @@ class ÜberkingTablets extends Card {
                     dependsOn: 'action',
                     cardType: 'creature',
                     gameAction: ability.actions.conditional((context) => ({
-                        condition: context.selects.action.choice === 'Ready creature',
+                        condition: context.selects?.action?.choice === 'Ready creature',
                         trueGameAction: ability.actions.ready({
-                            target: context.targets.creature
+                            target: context.targets?.creature
                         }),
                         falseGameAction: ability.actions.exhaust({
-                            target: context.targets.creature
+                            target: context.targets?.creature
                         })
                     }))
                 }

--- a/server/game/cards/14-DM/UjkyytrPrime.js
+++ b/server/game/cards/14-DM/UjkyytrPrime.js
@@ -13,7 +13,9 @@ class UjkyytrPrime extends Card {
                 gameAction: ability.actions.conditional((context) => ({
                     condition: context.player.isOverwhelmed(),
                     trueGameAction: ability.actions.stun({
-                        target: [context.target].concat(context.target.neighbors)
+                        target: context.target
+                            ? [context.target].concat(context.target.neighbors)
+                            : []
                     }),
                     falseGameAction: ability.actions.stun({ target: context.target })
                 }))


### PR DESCRIPTION
Sentry originally detected this for Energy Vampirism, add the null checks across the board.

Fixes crashes when `context.target` is undefined or null in optional `promptForSelect` targets. Adds null checks (`?.\ and `|| []`) across 24 card files spanning sets 01–14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are defensive defaults on optional/skipped targets across card scripts; no auth or persistence impact, with low regression risk when selections are present.
> 
> **Overview**
> Adds **defensive null/undefined handling** across many card ability resolvers so gameplay does not throw when a player skips an optional target or a multi-step selection is incomplete.
> 
> **Single-target play/action paths** now use optional chaining and safe defaults on `context.target` (e.g. `?.location`, `?.power`, `?.stunned`, `?.controller`, `?.getTraits()`) so damage, stun/destroy branches, capture, house restriction, and lasting effects resolve to **no-op or zero** instead of crashing.
> 
> **Multi-target and choice flows** guard `context.targets` / `context.selects` (e.g. flank swap, ward move, ready/exhaust choice) with `?.` and `|| []` when passing targets into actions.
> 
> **Array-style targets** (unlimited/upTo hand reveals, archive purge) treat missing selection as `[]` for `.length` and follow-up loops (e.g. Commpod ready count, Destructive Analysis bonus damage, Cognitive Assumptions tokens).
> 
> **Ruination** only builds the same-name destroy list when a target was actually chosen; otherwise it destroys nothing.
> 
> Behavior when a target *is* chosen should match prior logic; the change is mainly **crash prevention** on edge paths, not new card rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c0ec792a23df58ce1a43083f5376a3317c1b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->