### PR TITLE
fix: make switch toggles fully clickable across label area

### DIFF
--- a/client/Components/GameBoard/GameConfiguration.jsx
+++ b/client/Components/GameBoard/GameConfiguration.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label, Switch } from '@heroui/react';
+import { Switch } from '@heroui/react';
 
 import Panel from '../Site/Panel';
 
@@ -33,23 +33,18 @@ const GameConfiguration = ({ optionSettings, onOptionSettingToggle }) => {
         <Panel title={t('Game Settings')} compactHeader>
             <div className='grid gap-2'>
                 {options.map((option) => (
-                    <div
+                    <Switch
                         key={option.id}
-                        className='flex items-center justify-between gap-2 rounded bg-surface-secondary/70 px-2 py-1.5'
+                        id={option.id}
+                        isSelected={!!optionSettings[option.key]}
+                        onChange={(isSelected) => toggleOption(option.key, isSelected)}
+                        className='flex w-full cursor-pointer items-center justify-between gap-2 rounded bg-surface-secondary/70 px-2 py-1.5'
                     >
-                        <Label htmlFor={option.id} className='text-sm'>
-                            {option.label}
-                        </Label>
-                        <Switch
-                            id={option.id}
-                            isSelected={!!optionSettings[option.key]}
-                            onChange={(isSelected) => toggleOption(option.key, isSelected)}
-                        >
-                            <Switch.Control>
-                                <Switch.Thumb />
-                            </Switch.Control>
-                        </Switch>
-                    </div>
+                        <span className='text-sm'>{option.label}</span>
+                        <Switch.Control>
+                            <Switch.Thumb />
+                        </Switch.Control>
+                    </Switch>
                 ))}
             </div>
         </Panel>

--- a/client/Components/Games/GameFormats.jsx
+++ b/client/Components/Games/GameFormats.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button, Label, Switch } from '@heroui/react';
+import { Button, Switch } from '@heroui/react';
 
 const GameFormats = ({
     formProps,
@@ -117,24 +117,21 @@ const GameFormats = ({
                     </div>
                     <div className='grid gap-x-2 gap-y-1.5 sm:grid-cols-2 lg:grid-cols-4'>
                         {expansions.map((expansion) => (
-                            <div
+                            <Switch
                                 key={expansion.name}
-                                className='flex items-center justify-between gap-2 rounded-md bg-surface-secondary/70 px-3 py-0.5'
+                                id={expansion.name}
+                                name={expansion.name}
+                                isSelected={!!formProps.values[expansion.name]}
+                                onChange={(isSelected) =>
+                                    formProps.setFieldValue(expansion.name, isSelected)
+                                }
+                                className='flex w-full cursor-pointer items-center justify-between gap-2 rounded-md bg-surface-secondary/70 px-3 py-0.5'
                             >
-                                <Label className='text-sm text-foreground'>{expansion.label}</Label>
-                                <Switch
-                                    id={expansion.name}
-                                    name={expansion.name}
-                                    isSelected={!!formProps.values[expansion.name]}
-                                    onChange={(isSelected) =>
-                                        formProps.setFieldValue(expansion.name, isSelected)
-                                    }
-                                >
-                                    <Switch.Control>
-                                        <Switch.Thumb />
-                                    </Switch.Control>
-                                </Switch>
-                            </div>
+                                <span className='text-sm text-foreground'>{expansion.label}</span>
+                                <Switch.Control>
+                                    <Switch.Thumb />
+                                </Switch.Control>
+                            </Switch>
                         ))}
                     </div>
                 </div>

--- a/client/Components/Games/GameLobby.jsx
+++ b/client/Components/Games/GameLobby.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Button, Label, Switch, toast } from '@heroui/react';
+import { Button, Switch, toast } from '@heroui/react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import NewGame from './NewGame';
@@ -295,43 +295,35 @@ const GameLobby = ({ gameId }) => {
                     >
                         <div className='grid gap-x-3 gap-y-2 sm:grid-cols-2 lg:grid-cols-3'>
                             {filters.map((filter) => (
-                                <div
+                                <Switch
                                     key={filter.name}
-                                    className='flex items-center justify-between gap-2 rounded border border-border/45 bg-surface-secondary/45 px-2 py-1.5'
+                                    id={filter.name}
+                                    isSelected={!!currentFilter[filter.name]}
+                                    onChange={(isSelected) =>
+                                        onFilterChecked(filter.name, isSelected)
+                                    }
+                                    className='flex w-full cursor-pointer items-center justify-between gap-2 rounded border border-border/45 bg-surface-secondary/45 px-2 py-1.5'
                                 >
-                                    <Label className='text-sm text-foreground'>
-                                        {filter.label}
-                                    </Label>
-                                    <Switch
-                                        id={filter.name}
-                                        isSelected={!!currentFilter[filter.name]}
-                                        onChange={(isSelected) =>
-                                            onFilterChecked(filter.name, isSelected)
-                                        }
-                                    >
-                                        <Switch.Control>
-                                            <Switch.Thumb />
-                                        </Switch.Control>
-                                    </Switch>
-                                </div>
+                                    <span className='text-sm text-foreground'>{filter.label}</span>
+                                    <Switch.Control>
+                                        <Switch.Thumb />
+                                    </Switch.Control>
+                                </Switch>
                             ))}
                         </div>
-                        <div className='mt-2 flex items-center justify-between gap-2 rounded border border-border/45 bg-surface-secondary/45 px-2 py-1.5'>
-                            <Label className='text-sm text-foreground'>
+                        <Switch
+                            id='onlyShowNew'
+                            isSelected={!!currentFilter.onlyShowNew}
+                            onChange={(isSelected) => onFilterChecked('onlyShowNew', isSelected)}
+                            className='mt-2 flex w-full cursor-pointer items-center justify-between gap-2 rounded border border-border/45 bg-surface-secondary/45 px-2 py-1.5'
+                        >
+                            <span className='text-sm text-foreground'>
                                 {t('Only show new games')}
-                            </Label>
-                            <Switch
-                                id='onlyShowNew'
-                                isSelected={!!currentFilter.onlyShowNew}
-                                onChange={(isSelected) =>
-                                    onFilterChecked('onlyShowNew', isSelected)
-                                }
-                            >
-                                <Switch.Control>
-                                    <Switch.Thumb />
-                                </Switch.Control>
-                            </Switch>
-                        </div>
+                            </span>
+                            <Switch.Control>
+                                <Switch.Thumb />
+                            </Switch.Control>
+                        </Switch>
                     </Panel>
                 </div>
 

--- a/client/Components/Games/GameOptions.jsx
+++ b/client/Components/Games/GameOptions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Button, Input, Label, Switch, toast } from '@heroui/react';
+import { Button, Input, Switch, toast } from '@heroui/react';
 
 const GameOptions = ({ formProps, gameLink }) => {
     const { t } = useTranslation();
@@ -9,19 +9,19 @@ const GameOptions = ({ formProps, gameLink }) => {
         'flex-1 rounded-md border border-[color:color-mix(in_oklab,var(--border)_72%,transparent)] bg-[color:var(--section)] px-3 py-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]';
 
     const renderToggle = (name, label) => (
-        <div className='flex min-h-10 items-center justify-between gap-3 px-1' key={name}>
-            <Label className='text-sm text-foreground'>{label}</Label>
-            <Switch
-                id={name}
-                name={name}
-                isSelected={!!formProps.values[name]}
-                onChange={(isSelected) => formProps.setFieldValue(name, isSelected)}
-            >
-                <Switch.Control>
-                    <Switch.Thumb />
-                </Switch.Control>
-            </Switch>
-        </div>
+        <Switch
+            id={name}
+            name={name}
+            isSelected={!!formProps.values[name]}
+            onChange={(isSelected) => formProps.setFieldValue(name, isSelected)}
+            className='flex min-h-10 w-full cursor-pointer items-center justify-between gap-3 px-1'
+            key={name}
+        >
+            <span className='text-sm text-foreground'>{label}</span>
+            <Switch.Control>
+                <Switch.Thumb />
+            </Switch.Control>
+        </Switch>
     );
 
     const handleCopyLink = async () => {
@@ -47,26 +47,27 @@ const GameOptions = ({ formProps, gameLink }) => {
                     <Trans>Visibility</Trans>
                 </div>
                 <div className={sectionBlockClass}>
-                    <div className='flex items-center justify-between gap-3'>
-                        <Label className='text-sm text-foreground'>
-                            {t('Unlisted (link only)')}
-                        </Label>
-                        <Switch
-                            id='gamePrivate'
-                            name='gamePrivate'
-                            isSelected={!!formProps.values.gamePrivate}
-                            onChange={(isSelected) =>
-                                formProps.setFieldValue('gamePrivate', isSelected)
-                            }
-                        >
-                            <Switch.Control>
-                                <Switch.Thumb />
-                            </Switch.Control>
-                        </Switch>
-                    </div>
-                    <p className='text-xs text-foreground/78'>
-                        {t("Won't appear in Current Games.")}
-                    </p>
+                    <Switch
+                        id='gamePrivate'
+                        name='gamePrivate'
+                        isSelected={!!formProps.values.gamePrivate}
+                        onChange={(isSelected) =>
+                            formProps.setFieldValue('gamePrivate', isSelected)
+                        }
+                        className='flex w-full cursor-pointer items-center justify-between gap-3'
+                    >
+                        <div className='flex flex-col'>
+                            <span className='text-sm text-foreground'>
+                                {t('Unlisted (link only)')}
+                            </span>
+                            <span className='text-xs text-foreground/78'>
+                                {t("Won't appear in Current Games.")}
+                            </span>
+                        </div>
+                        <Switch.Control>
+                            <Switch.Thumb />
+                        </Switch.Control>
+                    </Switch>
                     {formProps.values.gamePrivate && gameLink && (
                         <div>
                             <Button
@@ -135,9 +136,9 @@ const GameOptions = ({ formProps, gameLink }) => {
                 </div>
                 <div className={sectionBlockClass}>
                     <div className='divide-y divide-[color:color-mix(in_oklab,var(--border)_58%,transparent)]'>
-                        {renderToggle('requirePassword', t('Require password'))}
+                        {renderToggle('hideDeckLists', t('Hide deck lists'))}
                         <div className='pt-1'>
-                            {renderToggle('hideDeckLists', t('Hide deck lists'))}
+                            {renderToggle('requirePassword', t('Require password'))}
                         </div>
                     </div>
                     {formProps.values.requirePassword && (

--- a/client/Components/Profile/KeyforgeGameSettings.jsx
+++ b/client/Components/Profile/KeyforgeGameSettings.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label, Switch } from '@heroui/react';
+import { Switch } from '@heroui/react';
 import Panel from '../Site/Panel';
 
 /**
@@ -28,21 +28,18 @@ const KeyforgeGameSettings = ({ formProps }) => {
     ];
 
     const renderOption = ([id, text]) => (
-        <div
+        <Switch
             key={id}
-            className='flex items-center justify-between gap-2 rounded bg-surface-secondary/70 px-2 py-1.5'
+            id={id}
+            isSelected={formProps.values.gameOptions[id]}
+            onChange={(isSelected) => formProps.setFieldValue(`gameOptions.${id}`, isSelected)}
+            className='flex w-full cursor-pointer items-center justify-between gap-2 rounded bg-surface-secondary/70 px-2 py-1.5'
         >
-            <Label className='text-sm'>{text}</Label>
-            <Switch
-                id={id}
-                isSelected={formProps.values.gameOptions[id]}
-                onChange={(isSelected) => formProps.setFieldValue(`gameOptions.${id}`, isSelected)}
-            >
-                <Switch.Control>
-                    <Switch.Thumb />
-                </Switch.Control>
-            </Switch>
-        </div>
+            <span className='text-sm'>{text}</span>
+            <Switch.Control>
+                <Switch.Thumb />
+            </Switch.Control>
+        </Switch>
     );
 
     return (


### PR DESCRIPTION
Clicking only the small toggle switch control was working, but clicking the label text was not toggling the switch.

Fix by wrapping the label content as a child inside the `Switch` component rather than using a separate `Label` component alongside it. This makes the full row clickable.

Also fixes the toggle order in `GameOptions` (Hide deck lists before Require password).

Files changed:
- `GameConfiguration.jsx`
- `GameFormats.jsx`
- `GameLobby.jsx`
- `GameOptions.jsx`
- `KeyforgeGameSettings.jsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only interaction and layout changes to toggles; no auth, API, or data logic changes beyond reordering two option rows in GameOptions.
> 
> **Overview**
> Makes **HeroUI `Switch` rows fully clickable** in game settings, lobby filters, new-game options, formats, and profile preferences by dropping separate `Label` wrappers and putting label text (and helper copy where needed) **inside** the `Switch`, with full-width flex styling on the control.
> 
> In **`GameOptions`**, the Access section now lists **Hide deck lists** before **Require password** (order-only change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73557f953d7dda211cefec4a08cdd9d9823f922e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->