### PR TITLE
feat: add set filters to game lobby and deck list

### DIFF
--- a/client/Components/Decks/DeckList.jsx
+++ b/client/Components/Decks/DeckList.jsx
@@ -89,9 +89,10 @@ const DeckList = ({
             const allExpansionValues = Array.isArray(expansions)
                 ? expansions.map((expansion) => expansion.value)
                 : [];
+            const isSubsetOfAll = expansions.length < Constants.Expansions.length;
             const hasPartialExpansionFilter =
                 selectedExpansionValues.length > 0 &&
-                selectedExpansionValues.length < allExpansionValues.length;
+                (selectedExpansionValues.length < allExpansionValues.length || isSubsetOfAll);
             const hasNoExpansionSelection =
                 Array.isArray(expansionValues) && expansionValues.length === 0;
 

--- a/client/Components/Decks/DeckSetFilter.jsx
+++ b/client/Components/Decks/DeckSetFilter.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Checkbox, Input, Popover } from '@heroui/react';
 import Icon from '../Icon';
 import { faChevronDown, faChevronUp, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { Constants } from '../../constants';
 
 const DeckSetFilter = ({ expansions = [], selectedExpansions = [], onChange, label, t }) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -17,9 +18,9 @@ const DeckSetFilter = ({ expansions = [], selectedExpansions = [], onChange, lab
         }
 
         return expansions.filter((expansion) =>
-            String(expansion.label || expansion.name || expansion.value)
-                .toLowerCase()
-                .includes(query)
+            [expansion.fullName, expansion.label, expansion.name, expansion.value]
+                .filter(Boolean)
+                .some((field) => field.toLowerCase().includes(query))
         );
     }, [expansions, search]);
 
@@ -117,7 +118,10 @@ const DeckSetFilter = ({ expansions = [], selectedExpansions = [], onChange, lab
                         <div className='max-h-56 space-y-1 overflow-y-auto pr-1'>
                             {filteredExpansions.map((expansion) => {
                                 const expansionLabel =
-                                    expansion.label || expansion.name || expansion.value;
+                                    expansion.fullName ||
+                                    expansion.label ||
+                                    expansion.name ||
+                                    expansion.value;
                                 const checked = isSetSelected(expansion.value);
 
                                 return (
@@ -132,7 +136,12 @@ const DeckSetFilter = ({ expansions = [], selectedExpansions = [], onChange, lab
                                         variant='tertiary'
                                         onChange={(isSelected) => toggleSet(expansion, isSelected)}
                                     >
-                                        <span className='text-foreground dark:text-zinc-100'>
+                                        <span className='inline-flex items-center gap-1.5 text-foreground dark:text-zinc-100'>
+                                            <img
+                                                src={Constants.DeckIconPaths[expansion.value]}
+                                                alt=''
+                                                className='h-4 w-4 object-contain'
+                                            />
                                             {expansionLabel}
                                         </span>
                                     </Checkbox>

--- a/client/Components/Games/GameFormats.jsx
+++ b/client/Components/Games/GameFormats.jsx
@@ -95,19 +95,6 @@ const GameFormats = ({
                                 variant='ghost'
                                 onPress={() => {
                                     setAllExpansions(false);
-                                    for (const name of ['cota', 'aoa', 'wc', 'mm', 'dt']) {
-                                        formProps.setFieldValue(name, true);
-                                    }
-                                }}
-                            >
-                                <Trans>FFG Sets</Trans>
-                            </Button>
-                            <Button
-                                className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
-                                size='sm'
-                                variant='ghost'
-                                onPress={() => {
-                                    setAllExpansions(false);
                                     for (const name of [
                                         'momu',
                                         'woe',
@@ -128,6 +115,19 @@ const GameFormats = ({
                                 }}
                             >
                                 <Trans>GG Sets</Trans>
+                            </Button>
+                            <Button
+                                className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
+                                size='sm'
+                                variant='ghost'
+                                onPress={() => {
+                                    setAllExpansions(false);
+                                    for (const name of ['cota', 'aoa', 'wc', 'mm', 'dt']) {
+                                        formProps.setFieldValue(name, true);
+                                    }
+                                }}
+                            >
+                                <Trans>FFG Sets</Trans>
                             </Button>
                             <Button
                                 className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'

--- a/client/Components/Games/GameFormats.jsx
+++ b/client/Components/Games/GameFormats.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Button, Label, Switch } from '@heroui/react';
+import { Constants } from '../../constants';
 
 const GameFormats = ({
     formProps,
@@ -11,34 +12,15 @@ const GameFormats = ({
     const { t } = useTranslation();
 
     const formats = [
-        { name: 'normal', label: t('Normal') },
-        { name: 'unchained', label: t('Unchained') },
+        { name: 'archon', label: t('Archon') },
+        { name: 'alliance', label: t('Alliance') },
         { name: 'sealed', label: t('Sealed') },
-        { name: 'reversal', label: t('Reversal') },
         { name: 'adaptive-bo1', label: t('Adaptive - Best of 1') },
-        { name: 'alliance', label: t('Alliance') }
+        { name: 'reversal', label: t('Reversal') },
+        { name: 'unchained', label: t('Unchained') }
     ];
 
-    const expansions = [
-        { name: 'cota', label: t('Call of the Archons') },
-        { name: 'aoa', label: t('Age of Ascension') },
-        { name: 'wc', label: t('Worlds Collide') },
-        { name: 'mm', label: t('Mass Mutation') },
-        { name: 'dt', label: t('Dark Tidings') },
-        { name: 'woe', label: t('Winds of Exchange') },
-        { name: 'gr', label: t('Grim Reminders') },
-        { name: 'as', label: t('Aember Skies') },
-        { name: 'toc', label: t('Tokens of Change') },
-        { name: 'momu', label: t('More Mutation') },
-        { name: 'disc', label: t('Discovery') },
-        { name: 'vm2023', label: t('Vault Masters 2023') },
-        { name: 'vm2024', label: t('Vault Masters 2024') },
-        { name: 'vm2025', label: t('Vault Masters 2025') },
-        { name: 'vm2026', label: t('Vault Masters 2026') },
-        { name: 'pv', label: t('Prophetic Visions') },
-        { name: 'cc', label: t('Crucible Clash') },
-        { name: 'dm', label: t('Draconian Measures') }
-    ];
+    const expansions = Constants.Expansions.filter((e) => e.name !== 'uc2022');
     const expansionNames = expansions.map((expansion) => expansion.name);
 
     const setAllExpansions = (nextValue) => {
@@ -52,7 +34,7 @@ const GameFormats = ({
             {showGameMode && (
                 <div>
                     <div className='mb-1 text-sm font-semibold text-foreground'>
-                        <Trans>Game mode</Trans>
+                        <Trans>Game format</Trans>
                     </div>
                     <div className='grid gap-x-3.5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3'>
                         {formats.map((format) => (
@@ -81,7 +63,7 @@ const GameFormats = ({
                 </div>
             )}
 
-            {showAllowedSets && formProps.values.gameFormat === 'sealed' && (
+            {showAllowedSets && formProps.values.gameFormat !== 'unchained' && (
                 <div>
                     <div
                         className={`mb-0.5 ${
@@ -92,10 +74,12 @@ const GameFormats = ({
                     >
                         <Trans>Allowed sets</Trans>
                     </div>
+                    {formProps.errors.allowedSets ? (
+                        <div className='mt-0.5 mb-1 text-xs text-red-300'>
+                            {formProps.errors.allowedSets}
+                        </div>
+                    ) : null}
                     <div className='mb-1.5 flex items-center justify-between gap-3'>
-                        <p className='text-xs leading-tight text-foreground/80'>
-                            <Trans>Select which sets can be used for sealed decks.</Trans>
-                        </p>
                         <div className='flex items-center gap-2'>
                             <Button
                                 className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
@@ -109,19 +93,68 @@ const GameFormats = ({
                                 className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
                                 size='sm'
                                 variant='ghost'
+                                onPress={() => {
+                                    setAllExpansions(false);
+                                    for (const name of ['cota', 'aoa', 'wc', 'mm', 'dt']) {
+                                        formProps.setFieldValue(name, true);
+                                    }
+                                }}
+                            >
+                                <Trans>FFG Sets</Trans>
+                            </Button>
+                            <Button
+                                className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
+                                size='sm'
+                                variant='ghost'
+                                onPress={() => {
+                                    setAllExpansions(false);
+                                    for (const name of [
+                                        'momu',
+                                        'woe',
+                                        'gr',
+                                        'as',
+                                        'toc',
+                                        'pv',
+                                        'cc',
+                                        'dm',
+                                        'disc',
+                                        'vm2023',
+                                        'vm2024',
+                                        'vm2025',
+                                        'vm2026'
+                                    ]) {
+                                        formProps.setFieldValue(name, true);
+                                    }
+                                }}
+                            >
+                                <Trans>GG Sets</Trans>
+                            </Button>
+                            <Button
+                                className='h-auto min-h-0 rounded-md px-2 py-1 text-xs font-medium text-muted hover:bg-[var(--table-row-hover)] hover:text-[color:var(--brand)]'
+                                size='sm'
+                                variant='ghost'
                                 onPress={() => setAllExpansions(false)}
                             >
                                 <Trans>Clear all</Trans>
                             </Button>
                         </div>
                     </div>
-                    <div className='grid gap-x-2 gap-y-1.5 sm:grid-cols-2 lg:grid-cols-4'>
+                    <div className='columns-1 gap-x-2 space-y-1.5 sm:columns-2 lg:columns-4'>
                         {expansions.map((expansion) => (
                             <div
                                 key={expansion.name}
-                                className='flex items-center justify-between gap-2 rounded-md bg-surface-secondary/70 px-3 py-0.5'
+                                className='break-inside-avoid flex items-center justify-between gap-2 rounded-md bg-surface-secondary/70 px-3 py-0.5'
                             >
-                                <Label className='text-sm text-foreground'>{expansion.label}</Label>
+                                <span className='flex items-center gap-1.5'>
+                                    <img
+                                        src={Constants.DeckIconPaths[expansion.value]}
+                                        alt=''
+                                        className='h-5 w-5 object-contain'
+                                    />
+                                    <Label className='text-sm text-foreground'>
+                                        {t(expansion.fullName)}
+                                    </Label>
+                                </span>
                                 <Switch
                                     id={expansion.name}
                                     name={expansion.name}

--- a/client/Components/Games/GameList.jsx
+++ b/client/Components/Games/GameList.jsx
@@ -9,6 +9,7 @@ import { faLock, faTrash } from '@fortawesome/free-solid-svg-icons';
 
 import Avatar from '../Site/Avatar';
 import AlertPanel from '../Site/AlertPanel';
+import { Constants } from '../../constants';
 import { lobbyActions } from '../../redux/slices/lobbySlice';
 import TimeLimitIcon from '../../assets/img/Timelimit.png';
 import ShowHandIcon from '../../assets/img/ShowHandIcon.png';
@@ -27,18 +28,18 @@ const typeBadgeClass = {
 };
 
 const gameFormatIcons = [
-    ['sealed', { src: SealedIcon, title: 'Sealed game format', noInvert: false }],
     ['alliance', { src: AllianceIcon, title: 'Alliance game format', noInvert: true }],
-    ['reversal', { src: ReversalIcon, title: 'Reversal game format', noInvert: false }],
+    ['sealed', { src: SealedIcon, title: 'Sealed game format', noInvert: false }],
     [
         'adaptive-bo1',
         { src: AdaptiveIcon, title: 'Adaptive (Best of 1) game format', noInvert: false }
     ],
+    ['reversal', { src: ReversalIcon, title: 'Reversal game format', noInvert: false }],
     ['unchained', { src: UnchainedIcon, title: 'Unchained game format', noInvert: false }]
 ];
 
 const gameFormatStyles = {
-    normal: {
+    archon: {
         pillClass: 'bg-surface/55 text-foreground/85 border-border/70',
         iconClass: 'invert-[0.72]'
     },
@@ -240,6 +241,26 @@ const GameList = ({ gameFilter = {}, games = [], onJoinOrWatchClick }) => {
                                                     ) : null}
                                                     {t(game.gameFormat)}
                                                 </span>
+                                                {game.expansions &&
+                                                Object.values(game.expansions).some((v) => !v) ? (
+                                                    <span className='inline-flex items-center gap-0.5 rounded-sm border border-border/50 bg-surface-secondary/55 px-1 py-0.5'>
+                                                        {Constants.Expansions.filter(
+                                                            (e) =>
+                                                                e.name !== 'uc2022' &&
+                                                                game.expansions[e.name]
+                                                        ).map((e) => (
+                                                            <img
+                                                                key={e.value}
+                                                                src={
+                                                                    Constants.DeckIconPaths[e.value]
+                                                                }
+                                                                className='h-4 w-4 object-contain'
+                                                                alt={e.label}
+                                                                title={e.fullName}
+                                                            />
+                                                        ))}
+                                                    </span>
+                                                ) : null}
                                                 {game.gamePrivate && isAdmin ? (
                                                     <span className='rounded-sm border border-border/70 bg-overlay/80 px-1.5 py-0.5 text-xs uppercase tracking-wide text-muted'>
                                                         Private

--- a/client/Components/Games/GameList.jsx
+++ b/client/Components/Games/GameList.jsx
@@ -202,7 +202,7 @@ const GameList = ({ gameFilter = {}, games = [], onJoinOrWatchClick }) => {
                             const players = Object.values(game.players || {});
                             const iconClass = 'h-5 w-5 object-contain invert-[0.9]';
                             const formatStyle =
-                                gameFormatStyles[game.gameFormat] || gameFormatStyles.normal;
+                                gameFormatStyles[game.gameFormat] || gameFormatStyles.archon;
                             const formatMeta = gameFormatIconMap[game.gameFormat];
                             const rowTone =
                                 game.node && isAdmin

--- a/client/Components/Games/GameLobby.jsx
+++ b/client/Components/Games/GameLobby.jsx
@@ -42,7 +42,7 @@ const createMockLobbyGames = () => {
         allowSpectators: true,
         createdAt: new Date(Date.now() - 1000 * 60 * 9).toISOString(),
         full: false,
-        gameFormat: 'normal',
+        gameFormat: 'archon',
         gamePrivate: false,
         gameType: 'casual',
         id: `mock-${Math.random().toString(36).slice(2, 10)}`,
@@ -72,9 +72,9 @@ const createMockLobbyGames = () => {
     return [
         withDemoNode(
             makeGame({
-                gameFormat: 'normal',
+                gameFormat: 'archon',
                 gameType: 'beginner',
-                name: 'Beginner Open Normal',
+                name: 'Beginner Open Archon',
                 players: { admin: mockPlayers.admin }
             })
         ),
@@ -125,7 +125,7 @@ const createMockLobbyGames = () => {
         ),
         withDemoNode(
             makeGame({
-                gameFormat: 'normal',
+                gameFormat: 'archon',
                 gameType: 'casual',
                 name: 'Everything On',
                 needsPassword: true,
@@ -146,11 +146,11 @@ const GameLobby = ({ gameId }) => {
             { name: 'beginner', label: t('Beginner') },
             { name: 'casual', label: t('Casual') },
             { name: 'competitive', label: t('Competitive') },
-            { name: 'normal', label: t('Normal') },
-            { name: 'sealed', label: t('Sealed') },
-            { name: 'reversal', label: t('Reversal') },
-            { name: 'adaptive-bo1', label: t('Adaptive (Bo1)') },
+            { name: 'archon', label: t('Archon') },
             { name: 'alliance', label: t('Alliance') },
+            { name: 'sealed', label: t('Sealed') },
+            { name: 'adaptive-bo1', label: t('Adaptive (Bo1)') },
+            { name: 'reversal', label: t('Reversal') },
             { name: 'unchained', label: t('Unchained') }
         ],
         [t]

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import * as yup from 'yup';
 
+import { Constants } from '../../constants';
 import { lobbyActions } from '../../redux/slices/lobbySlice';
 import { lobbySendMessage } from '../../redux/socketActions';
 import Panel from '../Site/Panel';
@@ -67,12 +68,14 @@ const NewGame = ({
         password: '',
         requirePassword: false,
         allowSpectators: true,
-        gameFormat: 'normal',
+        gameFormat: 'archon',
         gameType: defaultGameType || 'casual',
         useGameTimeLimit: !!defaultTimeLimit,
         gameTimeLimit: defaultTimeLimit || 45,
         gamePrivate: defaultPrivate,
-        pv: true
+        ...Object.fromEntries(
+            Constants.Expansions.filter((e) => e.name !== 'uc2022').map((e) => [e.name, true])
+        )
     };
 
     if (!lobbySocket) {
@@ -161,7 +164,7 @@ const NewGame = ({
                             }
 
                             if (
-                                formProps.values.gameFormat === 'sealed' &&
+                                formProps.values.gameFormat !== 'unchained' &&
                                 !formProps.values.aoa &&
                                 !formProps.values.cota &&
                                 !formProps.values.wc &&
@@ -182,7 +185,7 @@ const NewGame = ({
                                 !formProps.values.dm
                             ) {
                                 formProps.setFieldError(
-                                    'gameFormat',
+                                    'allowedSets',
                                     t('You must select at least one expansion')
                                 );
 
@@ -195,7 +198,7 @@ const NewGame = ({
                         {quickJoin && (
                             <div className='rounded-md border border-border/45 bg-surface-secondary/32 px-3 py-1.5 text-xs text-muted'>
                                 <Trans>
-                                    Choose a game mode and type. We&apos;ll match you to an open
+                                    Choose a game format and type. We&apos;ll match you to an open
                                     game or create one with default options.
                                 </Trans>
                             </div>

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -102,26 +102,12 @@ const NewGame = ({
                         ...values,
                         password: values.requirePassword ? values.password : ''
                     };
-                    const expansions = {
-                        aoa: values.aoa,
-                        as: values.as,
-                        cc: values.cc,
-                        cota: values.cota,
-                        dm: values.dm,
-                        disc: values.disc,
-                        dt: values.dt,
-                        gr: values.gr,
-                        mm: values.mm,
-                        momu: values.momu,
-                        pv: values.pv,
-                        toc: values.toc,
-                        vm2023: values.vm2023,
-                        vm2024: values.vm2024,
-                        vm2025: values.vm2025,
-                        vm2026: values.vm2026,
-                        wc: values.wc,
-                        woe: values.woe
-                    };
+                    const expansions = Object.fromEntries(
+                        Constants.Expansions.filter((e) => e.name !== 'uc2022').map((e) => [
+                            e.name,
+                            !!values[e.name]
+                        ])
+                    );
 
                     if (tournament) {
                         for (const match of matches) {
@@ -165,24 +151,9 @@ const NewGame = ({
 
                             if (
                                 formProps.values.gameFormat !== 'unchained' &&
-                                !formProps.values.aoa &&
-                                !formProps.values.cota &&
-                                !formProps.values.wc &&
-                                !formProps.values.mm &&
-                                !formProps.values.dt &&
-                                !formProps.values.woe &&
-                                !formProps.values.gr &&
-                                !formProps.values.as &&
-                                !formProps.values.toc &&
-                                !formProps.values.momu &&
-                                !formProps.values.disc &&
-                                !formProps.values.vm2023 &&
-                                !formProps.values.vm2024 &&
-                                !formProps.values.vm2025 &&
-                                !formProps.values.vm2026 &&
-                                !formProps.values.pv &&
-                                !formProps.values.cc &&
-                                !formProps.values.dm
+                                !Constants.Expansions.filter((e) => e.name !== 'uc2022').some(
+                                    (e) => formProps.values[e.name]
+                                )
                             ) {
                                 formProps.setFieldError(
                                     'allowedSets',

--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -126,6 +126,9 @@ const PendingGame = () => {
         expansions = Constants.Expansions.filter((e) => e.value === '601');
     } else {
         expansions = Constants.Expansions.filter((e) => e.value !== '601');
+        if (currentGame.expansions) {
+            expansions = expansions.filter((e) => currentGame.expansions[e.name]);
+        }
     }
 
     deckFilter.expansion = expansions;
@@ -328,6 +331,22 @@ const PendingGame = () => {
                         <span className='rounded-md border border-border/60 bg-surface-secondary/42 px-2 py-0.5 text-xs text-foreground/75'>
                             {formatLabel(currentGame.gameType)}
                         </span>
+                        {currentGame.expansions &&
+                            Object.values(currentGame.expansions).some((v) => !v) && (
+                                <span className='inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-surface-secondary/42 px-1.5 py-0.5'>
+                                    {Constants.Expansions.filter(
+                                        (e) => e.name !== 'uc2022' && currentGame.expansions[e.name]
+                                    ).map((e) => (
+                                        <img
+                                            key={e.value}
+                                            src={Constants.DeckIconPaths[e.value]}
+                                            className='h-4 w-4 object-contain'
+                                            alt={e.label}
+                                            title={e.fullName}
+                                        />
+                                    ))}
+                                </span>
+                            )}
                         <span className='rounded-md border border-border/60 bg-surface-secondary/42 px-2 py-0.5 text-xs text-foreground/75'>
                             {t('{{players}} / 2 players', { players: playerCountInGame })}
                         </span>

--- a/client/constants.js
+++ b/client/constants.js
@@ -47,134 +47,172 @@ export const Constants = {
     Locales: ['de', 'en', 'es', 'fr', 'it', 'ko', 'pt', 'pl', 'th', 'zhhans', 'zhhant'],
     Expansions: [
         {
+            name: 'cota',
             value: '341',
             label: 'CotA',
+            fullName: 'Call of the Archons',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'aoa',
             value: '435',
             label: 'AoA',
+            fullName: 'Age of Ascension',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'wc',
             value: '452',
             label: 'WC',
+            fullName: 'Worlds Collide',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'mm',
             value: '479',
             label: 'MM',
+            fullName: 'Mass Mutation',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'momu',
+            value: '874',
+            label: 'MoMu',
+            fullName: 'More Mutation',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'dt',
             value: '496',
             label: 'DT',
+            fullName: 'Dark Tidings',
             tideRequired: true,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'woe',
             value: '600',
             label: 'WoE',
+            fullName: 'Winds of Exchange',
             tideRequired: false,
             tokenRequired: true,
             prophecySupported: false
         },
         {
-            value: '601',
-            label: 'UC2022',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
-            value: '609',
-            label: 'VM2023',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
+            name: 'gr',
             value: '700',
             label: 'GR',
+            fullName: 'Grim Reminders',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
-            value: '737',
-            label: 'VM2024',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
+            name: 'as',
             value: '800',
             label: 'AS',
+            fullName: 'Aember Skies',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'toc',
             value: '855',
             label: 'ToC',
+            fullName: 'Tokens of Change',
             tideRequired: false,
             tokenRequired: true,
             prophecySupported: false
         },
         {
-            value: '874',
-            label: 'MoMu',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
-            value: '907',
-            label: 'DISC',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
-            value: '939',
-            label: 'VM2025',
-            tideRequired: false,
-            tokenRequired: false,
-            prophecySupported: false
-        },
-        {
+            name: 'pv',
             value: '886',
             label: 'PV',
+            fullName: 'Prophetic Visions',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: true
         },
         {
+            name: 'cc',
             value: '918',
             label: 'CC',
+            fullName: 'Crucible Clash',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'dm',
             value: '928',
             label: 'DM',
+            fullName: 'Draconian Measures',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false
         },
         {
+            name: 'disc',
+            value: '907',
+            label: 'DISC',
+            fullName: 'Discovery',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'uc2022',
+            value: '601',
+            label: 'UC2022',
+            fullName: 'Unchained 2022',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'vm2023',
+            value: '609',
+            label: 'VM2023',
+            fullName: 'Vault Masters 2023',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'vm2024',
+            value: '737',
+            label: 'VM2024',
+            fullName: 'Vault Masters 2024',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'vm2025',
+            value: '939',
+            label: 'VM2025',
+            fullName: 'Vault Masters 2025',
+            tideRequired: false,
+            tokenRequired: false,
+            prophecySupported: false
+        },
+        {
+            name: 'vm2026',
             value: '964',
             label: 'VM2026',
+            fullName: 'Vault Masters 2026',
             tideRequired: false,
             tokenRequired: false,
             prophecySupported: false

--- a/client/locales/it.json
+++ b/client/locales/it.json
@@ -555,7 +555,7 @@
     "Won't appear in Current Games.": "Non apparirà nelle partite attuali.",
     "Unlisted (link only)": "Non in elenco (solo link)",
     "Visibility": "Visibilità",
-    "Game mode": "Modalità di gioco",
+    "Game format": "Modalità di gioco",
     "Time": "Tempo",
     "Access": "Accesso",
     "Opponent": "Avversario",

--- a/client/typedefs.js
+++ b/client/typedefs.js
@@ -1,17 +1,17 @@
 /**
- * @typedef {'canEditNews' | 
-    'canManageUsers' | 
-    'canManagePermissions' | 
-    'canManageGames' | 
+ * @typedef {'canEditNews' |
+    'canManageUsers' |
+    'canManagePermissions' |
+    'canManageGames' |
     'canManageNodes' |
-    'canModerateChat' | 
-    'canVerifyDecks' | 
-    'canManageBanlist' | 
-    'canManageMotd' | 
-    'canManageTournaments' | 
-    'isAdmin' | 
-    'isContributor' | 
-    'isSupporter' | 
+    'canModerateChat' |
+    'canVerifyDecks' |
+    'canManageBanlist' |
+    'canManageMotd' |
+    'canManageTournaments' |
+    'isAdmin' |
+    'isContributor' |
+    'isSupporter' |
     'isWinner'} Permission
  */
 
@@ -27,11 +27,11 @@
  */
 
 /**
- * @typedef {'normal' | 'sealed'| 'reversal' | 'adaptive-bo1'} GameFormat
+ * @typedef {'archon' | 'alliance' | 'sealed' | 'adaptive-bo1' | 'reversal' | 'unchained'} GameFormat
  */
 
 /**
- * @typedef {'casual' | 'beginner'| 'competitive' | 'adaptive-bo1'} GameType
+ * @typedef {'casual' | 'beginner'| 'competitive'} GameType
  */
 
 /**

--- a/server/constants.js
+++ b/server/constants.js
@@ -35,27 +35,158 @@ Constants.HousesNames = [
     'Untamed'
 ];
 Constants.Expansions = [
-    { id: 341, label: 'CotA', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 435, label: 'AoA', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 452, label: 'WC', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 479, label: 'MM', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 496, label: 'DT', tideRequired: true, tokenRequired: false, prophecySupported: false },
-    { id: 600, label: 'WoE', tideRequired: false, tokenRequired: true, prophecySupported: false },
-    { id: 700, label: 'GR', tideRequired: false, tokenRequired: false, prophecySupported: true },
-    { id: 800, label: 'AS', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 855, label: 'ToC', tideRequired: false, tokenRequired: true, prophecySupported: false },
-    { id: 874, label: 'MoMu', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 907, label: 'DISC', tideRequired: false, tokenRequired: false, prophecySupported: false },
+    {
+        id: 341,
+        name: 'cota',
+        label: 'CotA',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 435,
+        name: 'aoa',
+        label: 'AoA',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 452,
+        name: 'wc',
+        label: 'WC',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 479,
+        name: 'mm',
+        label: 'MM',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 496,
+        name: 'dt',
+        label: 'DT',
+        tideRequired: true,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 600,
+        name: 'woe',
+        label: 'WoE',
+        tideRequired: false,
+        tokenRequired: true,
+        prophecySupported: false
+    },
+    {
+        id: 601,
+        name: 'uc2022',
+        label: 'UC2022',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 609,
+        name: 'vm2023',
+        label: 'VM2023',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 700,
+        name: 'gr',
+        label: 'GR',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: true
+    },
+    {
+        id: 737,
+        name: 'vm2024',
+        label: 'VM2024',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 800,
+        name: 'as',
+        label: 'AS',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 855,
+        name: 'toc',
+        label: 'ToC',
+        tideRequired: false,
+        tokenRequired: true,
+        prophecySupported: false
+    },
+    {
+        id: 874,
+        name: 'momu',
+        label: 'MoMu',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 886,
+        name: 'pv',
+        label: 'PV',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: true
+    },
+    {
+        id: 907,
+        name: 'disc',
+        label: 'DISC',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 918,
+        name: 'cc',
+        label: 'CC',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
+    {
+        id: 928,
+        name: 'dm',
+        label: 'DM',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    },
     {
         id: 939,
+        name: 'vm2025',
         label: 'VM2025',
         tideRequired: false,
         tokenRequired: false,
         prophecySupported: false
     },
-    { id: 886, label: 'PV', tideRequired: false, tokenRequired: false, prophecySupported: true },
-    { id: 918, label: 'CC', tideRequired: false, tokenRequired: false, prophecySupported: false },
-    { id: 928, label: 'DM', tideRequired: false, tokenRequired: false, prophecySupported: false }
+    {
+        id: 964,
+        name: 'vm2026',
+        label: 'VM2026',
+        tideRequired: false,
+        tokenRequired: false,
+        prophecySupported: false
+    }
 ];
 Constants.Tide = Object.freeze({
     HIGH: 'high',

--- a/server/constants.js
+++ b/server/constants.js
@@ -105,7 +105,7 @@ Constants.Expansions = [
         label: 'GR',
         tideRequired: false,
         tokenRequired: false,
-        prophecySupported: true
+        prophecySupported: false
     },
     {
         id: 737,

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -749,7 +749,10 @@ class Lobby {
                     verified: true
                 };
 
-                game.selectDeck(socket.user.username, deck);
+                if (!game.selectDeck(socket.user.username, deck)) {
+                    socket.emit('gameerror', 'That deck is not from an allowed expansion');
+                    return;
+                }
 
                 this.sendGameState(game);
             })
@@ -831,7 +834,10 @@ class Lobby {
                     deck.name = 'Alliance Deck';
                 }
 
-                game.selectDeck(socket.user.username, deck);
+                if (!game.selectDeck(socket.user.username, deck)) {
+                    socket.emit('gameerror', 'That deck is not from an allowed expansion');
+                    return;
+                }
 
                 this.sendGameState(game);
             })

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -749,8 +749,9 @@ class Lobby {
                     verified: true
                 };
 
-                if (!game.selectDeck(socket.user.username, deck)) {
-                    socket.emit('gameerror', 'That deck is not from an allowed expansion');
+                const selectError = game.selectDeck(socket.user.username, deck);
+                if (selectError) {
+                    socket.emit('gameerror', selectError);
                     return;
                 }
 
@@ -834,8 +835,9 @@ class Lobby {
                     deck.name = 'Alliance Deck';
                 }
 
-                if (!game.selectDeck(socket.user.username, deck)) {
-                    socket.emit('gameerror', 'That deck is not from an allowed expansion');
+                const selectError = game.selectDeck(socket.user.username, deck);
+                if (selectError) {
+                    socket.emit('gameerror', selectError);
                     return;
                 }
 

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -244,7 +244,7 @@ class PendingGame {
     selectDeck(playerName, deck) {
         var player = this.getPlayerByName(playerName);
         if (!player) {
-            return;
+            return false;
         }
 
         if (this.expansions && this.gameFormat !== 'unchained') {
@@ -257,7 +257,7 @@ class PendingGame {
                 logger.info(
                     `Player ${playerName} attempted to select deck from expansion ${deck.expansion} which is not allowed`
                 );
-                return;
+                return false;
             }
         }
 
@@ -267,6 +267,7 @@ class PendingGame {
 
         player.deck = deck;
         player.deck.selected = true;
+        return true;
     }
 
     // interrogators

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -16,7 +16,7 @@ class PendingGame {
         this.createdAt = new Date();
         this.expansions = details.expansions;
         this.gameChat = new GameChat(this);
-        this.gameFormat = details.gameFormat;
+        this.gameFormat = details.gameFormat === 'normal' ? 'archon' : details.gameFormat;
         this.gamePrivate = !!details.gamePrivate;
         this.gameTimeLimit = details.gameTimeLimit;
         this.gameType = details.gameType;

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -244,7 +244,7 @@ class PendingGame {
     selectDeck(playerName, deck) {
         var player = this.getPlayerByName(playerName);
         if (!player) {
-            return false;
+            return;
         }
 
         if (this.expansions && this.gameFormat !== 'unchained') {
@@ -257,7 +257,7 @@ class PendingGame {
                 logger.info(
                     `Player ${playerName} attempted to select deck from expansion ${deck.expansion} which is not allowed`
                 );
-                return false;
+                return 'That deck is not from an allowed expansion';
             }
         }
 
@@ -267,7 +267,6 @@ class PendingGame {
 
         player.deck = deck;
         player.deck.selected = true;
-        return true;
     }
 
     // interrogators

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -2,8 +2,11 @@ const { randomUUID } = require('node:crypto');
 const _ = require('underscore');
 const crypto = require('crypto');
 
+const Constants = require('./constants');
 const GameChat = require('./game/gamechat.js');
 const logger = require('./log');
+
+const expansionNameToId = Object.fromEntries(Constants.Expansions.map((e) => [e.name, e.id]));
 
 class PendingGame {
     constructor(owner, details) {
@@ -244,6 +247,20 @@ class PendingGame {
             return;
         }
 
+        if (this.expansions && this.gameFormat !== 'unchained') {
+            const allowedIds = Object.entries(this.expansions)
+                .filter(([, allowed]) => allowed)
+                .map(([name]) => expansionNameToId[name])
+                .filter(Boolean);
+
+            if (allowedIds.length > 0 && !allowedIds.includes(deck.expansion)) {
+                logger.info(
+                    `Player ${playerName} attempted to select deck from expansion ${deck.expansion} which is not allowed`
+                );
+                return;
+            }
+        }
+
         if (player.deck) {
             player.deck.selected = false;
         }
@@ -344,6 +361,7 @@ class PendingGame {
             allowSpectators: this.allowSpectators,
             challonge: this.challonge,
             createdAt: this.createdAt,
+            expansions: this.expansions,
             gameFormat: this.gameFormat,
             gamePrivate: this.gamePrivate,
             gameType: this.gameType,


### PR DESCRIPTION
Added a set filter for all game modes as a lead up to adding menagerie and other alternative formats.

- Add `name`/`fullName` fields to Expansions constants (client & server)
- Add More Mutation (MoMu) expansion entry
- Add set filter UI to DeckSetFilter, GameFormats, GameList, GameLobby, NewGame, PendingGame
- Update typedefs for new filter types

New game (notice set selection for Archon):
<img width="1175" height="441" alt="image" src="https://github.com/user-attachments/assets/3aacc503-f58b-49ff-8ab9-6e9a63a56c92" />

Current games (notice pill):
<img width="416" height="150" alt="image" src="https://github.com/user-attachments/assets/b9718a8f-4a49-4c25-a45e-26037ff03346" />

Deck selection: (notice pill in bg, search set is limited, and decks are filtered)
<img width="1040" height="660" alt="image" src="https://github.com/user-attachments/assets/c59ac95d-eae5-4acf-b24b-6bac437f4e4a" />

Fixes #374 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default game format naming (`archon`), new server-side deck expansion checks, and broader allowed-set rules on create/join—existing games or clients sending `normal` rely on server mapping but mismatches could still confuse users.
> 
> **Overview**
> This PR adds **allowed-set restrictions** across the lobby and deck flows, centered on shared **`Constants.Expansions`** metadata (`name`, `fullName`, MoMu) on client and server.
> 
> **Game creation & lobby:** Default format **`normal` → `archon`** (server still maps incoming `normal`). **Allowed sets** appear for every format except **Unchained**, driven from constants (with **GG Sets** / **FFG Sets** shortcuts and set icons). New games default all expansions on and send an **`expansions`** map; validation requires at least one allowed set (field **`allowedSets`**).
> 
> **Display & filtering:** **Game list** and **pending game** show a pill of allowed set icons when not all sets are enabled. **Deck list** expansion filtering treats a restricted expansion list as a real filter. **Deck set filter** searches `fullName` and shows deck icons.
> 
> **Enforcement:** **`PendingGame.selectDeck`** rejects decks outside allowed expansions; the lobby surfaces that error on select. Pending-game deck pickers and API state include **`expansions`** for clients to filter decks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef7826ca18b2b6e6f37c1a96b8490a47e3f975c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->