### PR TITLE
test(14-DM): add test for Ditch the Loot simultaneous amber move

### DIFF
--- a/test/server/cards/14-DM/DitchTheLoot.spec.js
+++ b/test/server/cards/14-DM/DitchTheLoot.spec.js
@@ -111,4 +111,36 @@ describe('Ditch the Loot', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe("Ditch the Loot's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'staralliance',
+                    hand: ['essence-entangler'],
+                    inPlay: ['cxo-taber']
+                },
+                player2: {
+                    hand: ['ditch-the-loot'],
+                    inPlay: ['urchin']
+                }
+            });
+            this.cxoTaber.amber = 2;
+            this.urchin.amber = 3;
+        });
+
+        it('moves all amber simultaneously', function () {
+            this.player1.playUpgrade(this.essenceEntangler, this.cxoTaber);
+            this.player1.endTurn();
+            this.player2.clickPrompt('shadows');
+            this.player2.play(this.ditchTheLoot);
+            this.player2.clickCard(this.urchin);
+            this.player2.clickCard(this.cxoTaber);
+            expect(this.urchin.amber).toBe(0);
+            expect(this.cxoTaber.location).toBe('discard');
+            expect(this.player1.amber).toBe(1);
+            expect(this.player2.amber).toBe(6);
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
Adds a test case verifying that Ditch the Loot moves amber simultaneously, so Essence Entangler does not destroy itself when Ditch the Loot moves amber away from a creature with lethal damage.

Fixes #5106

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or game logic modifications.
> 
> **Overview**
> Adds a **server integration test** for `Ditch the Loot` that covers amber being moved **all at once**, not step-by-step.
> 
> The scenario pairs **Essence Entangler** on **Cxo Taber** (lethal damage) with **Ditch the Loot** moving amber from **Urchin** onto Taber. Expectations check that amber leaves Urchin, Taber is discarded, and both players’ amber pools match a simultaneous transfer—guarding against a bug where sequential moves could trigger Entangler self-destruction incorrectly (issue #5106).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 012ce49fd45011998fd5b3accc532b02692b16a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->