### PR TITLE
fix: simultaneous capture now resolves correctly

### DIFF
--- a/server/game/cards/01-Core/HypnoticCommand.js
+++ b/server/game/cards/01-Core/HypnoticCommand.js
@@ -4,17 +4,15 @@ class HypnoticCommand extends Card {
     // Play: For each friendly Mars creature, choose an enemy creature to capture 1A from their own side.
     setupCardAbilities(ability) {
         this.play({
-            effect: 'force a enemy creature to capture 1 amber for each mars creature they control',
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: context.player.creaturesInPlay.filter((card) => card.hasHouse('mars')).length,
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle:
-                            'Choose a creature to capture 1 amber from its controller',
-                        cardType: 'creature',
-                        controller: 'opponent'
-                    }
-                })
+            effect: 'force an enemy creature to capture 1 amber for each mars creature they control',
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: Math.min(
+                    context.player.creaturesInPlay.filter((card) => card.hasHouse('mars')).length,
+                    context.player.opponent ? context.player.opponent.amber : 0
+                ),
+                controller: 'opponent',
+                player: context.player.opponent,
+                menuTitle: 'Choose a creature to capture 1 amber from its controller'
             }))
         });
     }

--- a/server/game/cards/02-AoA/Fetchdrones.js
+++ b/server/game/cards/02-AoA/Fetchdrones.js
@@ -20,24 +20,17 @@ class Fetchdrones extends Card {
                         : [];
                 return {
                     condition: () => cards.filter((card) => card.hasHouse('logos')).length > 0,
-                    gameAction: ability.actions.sequentialForEach({
-                        num: cards.filter((card) => card.hasHouse('logos')).length,
-                        action: ability.actions.capture((context) => ({
-                            amount: 2,
-                            promptForSelect: {
-                                activePromptTitle: 'Choose a creature',
-                                cardType: 'creature',
-                                controller: 'self',
-                                message: '{0} uses {1} to capture {2} amber onto {3}',
-                                messageArgs: (card) => [
-                                    context.player,
-                                    context.source,
-                                    Math.min(2, context.player.opponent?.amber || 0),
-                                    card
-                                ]
-                            }
-                        }))
-                    })
+                    gameAction: ability.actions.allocateCapture((context) => ({
+                        amberStep: 2,
+                        numSteps: Math.min(
+                            cards.filter((card) => card.hasHouse('logos')).length,
+                            Math.ceil(
+                                (context.player.opponent ? context.player.opponent.amber : 0) / 2
+                            )
+                        ),
+                        controller: 'self',
+                        menuTitle: 'Choose a creature to capture 2 amber'
+                    }))
                 };
             }
         });

--- a/server/game/cards/02-AoA/ShardOfHope.js
+++ b/server/game/cards/02-AoA/ShardOfHope.js
@@ -6,22 +6,6 @@ class ShardOfHope extends Card {
     setupCardAbilities(ability) {
         this.action({
             condition: (context) => !!context.player.opponent,
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: Math.min(
-                    context.player.opponent.amber,
-                    1 +
-                        context.player.cardsInPlay.filter(
-                            (card) => card !== context.source && card.hasTrait('shard')
-                        ).length
-                ),
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a creature to capture',
-                        cardType: 'creature',
-                        controller: 'self'
-                    }
-                })
-            })),
             effect: 'capture {1} amber from {2}',
             effectArgs: (context) => [
                 Math.min(
@@ -32,7 +16,18 @@ class ShardOfHope extends Card {
                         ).length
                 ),
                 context.player.opponent
-            ]
+            ],
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: Math.min(
+                    context.player.opponent.amber,
+                    1 +
+                        context.player.cardsInPlay.filter(
+                            (card) => card !== context.source && card.hasTrait('shard')
+                        ).length
+                ),
+                controller: 'self',
+                menuTitle: 'Choose a creature to capture 1 amber'
+            }))
         });
     }
 }

--- a/server/game/cards/03-WC/Gargantodon.js
+++ b/server/game/cards/03-WC/Gargantodon.js
@@ -25,24 +25,12 @@ class Gargantodon extends Card {
             })),
             then: (preThenContext) => ({
                 alwaysTriggers: true,
-                gameAction: ability.actions.sequentialForEach((context) => ({
-                    num: preThenContext.event.amount,
-                    action: ability.actions.capture((captureContext) => ({
-                        amount: 1,
-                        player: preThenContext.event.player,
-                        promptForSelect: {
-                            activePromptTitle: 'Choose a creature to capture amber',
-                            cardType: 'creature',
-                            cardCondition: (card) =>
-                                card.controller === captureContext.game.activePlayer,
-                            message: '{0} uses {1} to capture 1 amber on {2}',
-                            messageArgs: (cards) => [
-                                captureContext.game.activePlayer,
-                                context.source,
-                                cards
-                            ]
-                        }
-                    }))
+                gameAction: ability.actions.allocateCapture(() => ({
+                    numAmber: preThenContext.event.amount,
+                    player: preThenContext.event.player,
+                    cardCondition: (card) => card.controller === preThenContext.game.activePlayer,
+                    controller: 'any',
+                    menuTitle: 'Choose a creature to capture amber'
                 }))
             })
         });

--- a/server/game/cards/03-WC/Xenotraining.js
+++ b/server/game/cards/03-WC/Xenotraining.js
@@ -6,18 +6,13 @@ class Xenotraining extends Card {
         this.play({
             condition: (context) => !!context.player.opponent && context.player.opponent.amber > 0,
             effect: 'capture 1 amber on a friendly creature for each house represented by friendly creatures',
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: Math.min(
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: Math.min(
                     context.player.opponent.amber,
                     context.game.getHousesInPlay(context.player.creaturesInPlay).length
                 ),
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a creature to capture 1 amber',
-                        cardType: 'creature',
-                        controller: 'self'
-                    }
-                })
+                controller: 'self',
+                menuTitle: 'Choose a creature to capture 1 amber'
             }))
         });
     }

--- a/server/game/cards/04-MM/BringLow.js
+++ b/server/game/cards/04-MM/BringLow.js
@@ -10,15 +10,12 @@ class BringLow extends Card {
                 context.player.opponent ? Math.max(context.player.opponent.amber - 5, 0) : 0,
                 context.player.opponent
             ],
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: context.player.opponent ? Math.max(context.player.opponent.amber - 5, 0) : 0,
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a creature to capture 1 amber',
-                        cardType: 'creature',
-                        controller: 'self'
-                    }
-                })
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: context.player.opponent
+                    ? Math.max(context.player.opponent.amber - 5, 0)
+                    : 0,
+                controller: 'self',
+                menuTitle: 'Choose a creature to capture 1 amber'
             }))
         });
     }

--- a/server/game/cards/07-GR/HallowedEveFestival.js
+++ b/server/game/cards/07-GR/HallowedEveFestival.js
@@ -15,17 +15,12 @@ class HallowedEveFestival extends Card {
                         (event) => !!event.card && event.card.hasHouse('geistoid')
                     ).length
                 ],
-                gameAction: ability.actions.sequentialForEach((context) => ({
-                    num: context.preThenEvents.filter(
+                gameAction: ability.actions.allocateCapture((context) => ({
+                    numAmber: context.preThenEvents.filter(
                         (event) => !!event.card && event.card.hasHouse('geistoid')
                     ).length,
-                    action: ability.actions.capture({
-                        promptForSelect: {
-                            activePromptTitle: 'Choose a creature to capture 1 amber',
-                            cardType: 'creature',
-                            controller: 'self'
-                        }
-                    })
+                    controller: 'self',
+                    menuTitle: 'Choose a creature to capture 1 amber'
                 }))
             }
         });

--- a/server/game/cards/07-GR/VeilOfEctoplasm.js
+++ b/server/game/cards/07-GR/VeilOfEctoplasm.js
@@ -7,18 +7,13 @@ class VeilOfEctoplasm extends Card {
         this.play({
             condition: (context) => !!context.player.opponent && context.player.opponent.amber > 0,
             effect: 'capture 1 amber on a friendly creature for each Geistoid creature in your discard pile',
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: Math.min(
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: Math.min(
                     context.player.opponent.amber,
                     context.player.discard.filter((c) => c.hasHouse('geistoid')).length
                 ),
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a creature to capture 1 amber',
-                        cardType: 'creature',
-                        controller: 'self'
-                    }
-                })
+                controller: 'self',
+                menuTitle: 'Choose a creature to capture 1 amber'
             }))
         });
     }

--- a/server/game/cards/10-MoMu/SirsColossus.js
+++ b/server/game/cards/10-MoMu/SirsColossus.js
@@ -15,15 +15,10 @@ class SirsColossus extends GiganticCard {
         this.play({
             effect: "capture all of {1}'s amber onto friendly creatures",
             effectArgs: (context) => [context.player.opponent],
-            gameAction: ability.actions.sequentialForEach((context) => ({
-                num: context.player.opponent ? context.player.opponent.amber : 0,
-                action: ability.actions.capture({
-                    promptForSelect: {
-                        activePromptTitle: 'Choose a creature to capture 1 amber',
-                        cardType: 'creature',
-                        controller: 'self'
-                    }
-                })
+            gameAction: ability.actions.allocateCapture((context) => ({
+                numAmber: context.player.opponent ? context.player.opponent.amber : 0,
+                controller: 'self',
+                menuTitle: 'Choose a creature to capture 1 amber'
             }))
         });
 

--- a/server/game/cards/12-PV/CrypticCollapse.js
+++ b/server/game/cards/12-PV/CrypticCollapse.js
@@ -9,15 +9,11 @@ class CrypticCollapse extends Card {
                 target: context.player
             })),
             then: {
-                gameAction: ability.actions.sequentialForEach((context) => ({
-                    num: context.preThenCards.length,
-                    action: ability.actions.capture({
-                        promptForSelect: {
-                            activePromptTitle: 'Choose a creature to capture 1 amber',
-                            cardType: 'creature',
-                            controller: 'opponent'
-                        }
-                    })
+                gameAction: ability.actions.allocateCapture((context) => ({
+                    numAmber: context.preThenCards.length,
+                    controller: 'opponent',
+                    player: context.player.opponent,
+                    menuTitle: 'Choose a creature to capture 1 amber'
                 }))
             }
         });

--- a/server/game/cards/14-DM/ProductiveTrash.js
+++ b/server/game/cards/14-DM/ProductiveTrash.js
@@ -17,39 +17,13 @@ class ProductiveTrash extends Card {
                     return { alwaysTriggers: true };
                 }
 
-                const captures = new Map();
-                const captureAction = ability.actions.capture({
-                    promptForSelect: {
-                        cardType: 'creature',
-                        controller: 'self',
-                        onSelect: (_, card) => {
-                            captureAction.setTarget(card);
-                            captures.set(card, (captures.get(card) || 0) + 1);
-                            return true;
-                        }
-                    }
-                });
-
                 return {
                     alwaysTriggers: true,
-                    gameAction: ability.actions.sequentialForEach(() => ({
-                        num: preThenContext.target.bonusIcons.length,
-                        action: captureAction
-                    })),
-                    then: () => ({
-                        alwaysTriggers: true,
-                        handler: (thenContext) => {
-                            for (const [card, amount] of captures) {
-                                thenContext.game.addMessage(
-                                    '{0} uses {1} to capture {2} amber on {3}',
-                                    thenContext.player,
-                                    thenContext.source,
-                                    amount,
-                                    card
-                                );
-                            }
-                        }
-                    })
+                    gameAction: ability.actions.allocateCapture(() => ({
+                        numAmber: preThenContext.target.bonusIcons.length,
+                        controller: 'self',
+                        menuTitle: 'Choose a creature to capture 1 amber'
+                    }))
                 };
             }
         });

--- a/test/server/cards/03-WC/Gargantodon.spec.js
+++ b/test/server/cards/03-WC/Gargantodon.spec.js
@@ -248,4 +248,47 @@ describe('Gargantodon', function () {
             });
         });
     });
+
+    describe("Gargantodon's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 13,
+                    house: 'staralliance',
+                    hand: ['essence-entangler'],
+                    inPlay: ['gargantodon']
+                },
+                player2: {
+                    inPlay: ['dodger', 'urchin'],
+                    hand: ['too-much-to-protect']
+                }
+            });
+        });
+
+        it('replaces mass steal simultaneously', function () {
+            this.player1.playUpgrade(this.essenceEntangler, this.dodger);
+            expect(this.player1.amber).toBe(14);
+            this.player1.endTurn();
+            this.player2.clickPrompt('Shadows');
+
+            // Steal 8 into capture without being forced to capture onto Urchin
+            this.player2.play(this.tooMuchToProtect);
+            expect(this.player2).toBeAbleToSelect(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            this.player2.clickCard(this.dodger);
+            expect(this.player2).isReadyToTakeAction();
+
+            expect(this.dodger.amber).toBe(0);
+            expect(this.urchin.amber).toBe(0);
+            expect(this.dodger.location).toBe('discard');
+            expect(this.player1.amber).toBe(14);
+            expect(this.player2.amber).toBe(1);
+        });
+    });
 });

--- a/test/server/cards/06-WoE/Kretchee.spec.js
+++ b/test/server/cards/06-WoE/Kretchee.spec.js
@@ -132,7 +132,7 @@ describe('Kretchee', function () {
             this.player1.clickCard(this.troll);
             this.player1.clickCard(this.troll);
             expect(this.kretchee.amber).toBe(0);
-            expect(this.troll.amber).toBe(4);
+            expect(this.troll.amber).toBe(3);
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(0);
             expect(this.player1).isReadyToTakeAction();

--- a/test/server/cards/07-GR/EssenceEntangler.spec.js
+++ b/test/server/cards/07-GR/EssenceEntangler.spec.js
@@ -37,4 +37,45 @@ describe('Essence Entangler', function () {
             expect(this.player1).isReadyToTakeAction();
         });
     });
+
+    describe("Essence Entangler's ability", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    amber: 8,
+                    house: 'staralliance',
+                    hand: ['essence-entangler'],
+                    inPlay: ['po-s-pixies']
+                },
+                player2: {
+                    inPlay: ['bull-wark'],
+                    hand: ['bring-low']
+                }
+            });
+        });
+
+        it('modifies power after mass capture', function () {
+            this.bullWark.amber = 2;
+            this.player1.playUpgrade(this.essenceEntangler, this.bullWark);
+            expect(this.bullWark.power).toBe(2);
+            expect(this.player1.amber).toBe(9);
+            this.player1.endTurn();
+            this.player2.clickPrompt('Sanctum');
+
+            // Capture 4 from pool
+            this.player2.play(this.bringLow);
+            expect(this.player2).toBeAbleToSelect(this.bullWark);
+            this.player2.clickCard(this.bullWark);
+            this.player2.clickCard(this.bullWark);
+            this.player2.clickCard(this.bullWark);
+            this.player2.clickCard(this.bullWark);
+
+            // Amber returns to player1: 9 + 6 = 15
+            expect(this.bullWark.amber).toBe(0);
+            expect(this.bullWark.location).toBe('discard');
+            expect(this.player1.amber).toBe(15);
+            expect(this.player2.amber).toBe(1);
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
Fixes #4975

Cards that perform simultaneous capture now resolve correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core amber/capture resolution and many card definitions; behavior changes are intentional but affect combat, steal, and reaction ordering across the rules engine.
> 
> **Overview**
> Many cards that **distribute multiple captures in one effect** now use **`allocateCapture`** instead of **`sequentialForEach` + repeated `capture` prompts**, so the full amount is chosen and applied in one coordinated step (including caps like opponent amber and **Fetchdrones**’ 2-amber steps).
> 
> **Fading Apparition** is rewritten as an **`onModifyAmber` interrupt** (reap-only, optional creature target) that zeroes the reap gain and grants 1A after moving amber from a friendly creature, replacing the old **`EventRegistrar`** / manual prompt flow.
> 
> Specs are expanded or adjusted for **mass steal → capture** (**Gargantodon**), **power after mass capture** (**Essence Entangler** + **Bring Low**), **per-capture triggers** (**Kretchee** / **Veil of Ectoplasm**), and broader **Fading Apparition** timing and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42859eae2bfa58c997049fe2925fcf8cc39fae97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->