### PR TITLE
test: add edge case tests for ClonalWitch and VoltashCoilbreath

### DIFF
--- a/test/server/cards/12-PV/ClonalWitch.spec.js
+++ b/test/server/cards/12-PV/ClonalWitch.spec.js
@@ -7,7 +7,7 @@ describe('Clonal Witch', function () {
                     inPlay: ['clonal-witch', 'ember-imp', 'krump']
                 },
                 player2: {
-                    inPlay: ['troll', 'titan-guardian', 'titan-mechanic']
+                    inPlay: ['troll', 'titan-guardian', 'titan-mechanic', 'snufflegator']
                 }
             });
         });
@@ -24,8 +24,32 @@ describe('Clonal Witch', function () {
             expect(this.emberImp.location).toBe('play area');
             expect(this.titanGuardian.location).toBe('play area');
             expect(this.titanMechanic.location).toBe('play area');
+            expect(this.snufflegator.location).toBe('play area');
 
             // Player should gain 2 amber (one for each Brobnar creature destroyed), plus 1 for the reap.
+            expect(this.player1.amber).toBe(3);
+
+            // Clonal Witch should be on top of the deck
+            expect(this.clonalWitch.location).toBe('deck');
+            expect(this.player1.deck[0]).toBe(this.clonalWitch);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can target itself from discard', function () {
+            this.player1.reap(this.clonalWitch);
+            this.player1.clickPrompt('untamed');
+
+            // Untamed creatures should not be destroyed
+            expect(this.snufflegator.location).toBe('discard');
+
+            // Non-Untamed creatures should survive
+            expect(this.krump.location).toBe('play area');
+            expect(this.troll.location).toBe('play area');
+            expect(this.emberImp.location).toBe('play area');
+            expect(this.titanGuardian.location).toBe('play area');
+            expect(this.titanMechanic.location).toBe('play area');
+
+            // Player should gain 3 amber
             expect(this.player1.amber).toBe(3);
 
             // Clonal Witch should be on top of the deck

--- a/test/server/cards/14-DM/VoltashCoilbreath.spec.js
+++ b/test/server/cards/14-DM/VoltashCoilbreath.spec.js
@@ -4,10 +4,13 @@ describe('Voltash Coilbreath', function () {
             this.setupTest({
                 player1: {
                     house: 'ouboros',
+                    amber: 3,
+
                     inPlay: ['voltash-coilbreath']
                 },
                 player2: {
-                    inPlay: ['cannon', 'troll']
+                    amber: 3,
+                    inPlay: ['cannon', 'screechbomb', 'troll']
                 }
             });
         });
@@ -21,6 +24,17 @@ describe('Voltash Coilbreath', function () {
             this.player1.clickCard(this.troll);
             expect(this.cannon.location).toBe('deck');
             expect(this.player2.deck[this.player2.deck.length - 1]).toBe(this.cannon);
+            expect(this.player2.deck.length).toBe(deckSize + 1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('can target artifacts that destroy themselves', function () {
+            const deckSize = this.player2.deck.length;
+            this.player1.reap(this.voltashCoilbreath);
+            expect(this.player1).toHavePrompt('Choose a artifact');
+            this.player1.clickCard(this.screechbomb);
+            expect(this.screechbomb.location).toBe('deck');
+            expect(this.player2.deck[this.player2.deck.length - 1]).toBe(this.screechbomb);
             expect(this.player2.deck.length).toBe(deckSize + 1);
             expect(this.player1).isReadyToTakeAction();
         });


### PR DESCRIPTION
- **ClonalWitch**: add test for choosing a house with no in-play creatures (Untamed), verifying correct destruction behavior
- **VoltashCoilbreath**: add test for targeting artifacts that destroy themselves (Screechbomb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to card spec files; no runtime or rules engine code is modified.
> 
> **Overview**
> Adds **server card tests only**—no game logic changes.
> 
> **Clonal Witch** (`12-PV/ClonalWitch.spec.js`): extends the shared setup with `snufflegator` and tightens the Brobnar reap case so a non-Brobnar creature stays in play. Adds a case where the player picks **Untamed** on reap, asserting which creatures are destroyed vs kept, amber total, and that Clonal Witch returns to the top of the deck.
> 
> **Voltash Coilbreath** (`14-DM/VoltashCoilbreath.spec.js`): gives both players starting amber and adds **Screechbomb** to the opponent’s board. Adds a reap test that chooses Screechbomb and checks it still lands on the **bottom of the opponent’s deck** after a self-destructing artifact resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975432f446b606cbcbf14580a5bf0b6a59b94a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->