### PR TITLE
fix: consolidate username role CSS into shared role-* classes

### DIFF
--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -6,6 +6,7 @@ import AmberImage from '../../assets/img/amber.png';
 import CardBackImage from '../../assets/img/idbacks/cardback.jpg';
 import TideImage from '../../assets/img/tide/tide.png';
 import { Constants } from '../../constants';
+import { getRoleClass } from '../../util';
 import AlertPanel from '../Site/AlertPanel';
 import Avatar from '../Site/Avatar';
 import CardImage from './CardImage';
@@ -18,18 +19,6 @@ for (const colour of ['red', 'blue', 'yellow']) {
         unforged: new URL(`../../assets/img/unforgedkey${colour}.png`, import.meta.url).href
     };
 }
-
-const getRoleClass = (role) => {
-    const key = (role || '').toLowerCase();
-    const classes = {
-        admin: 'role-admin',
-        contributor: 'role-contributor',
-        supporter: 'role-supporter',
-        winner: 'role-winner',
-        previouswinner: 'role-previouswinner'
-    };
-    return classes[key] || 'font-semibold text-foreground';
-};
 
 const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
     const compactChatAlertClass =

--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -28,7 +28,7 @@ const getRoleClass = (role) => {
         winner: 'role-winner',
         previouswinner: 'role-previouswinner'
     };
-    return classes[key] || 'text-foreground';
+    return classes[key] || 'font-semibold text-foreground';
 };
 
 const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {

--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -19,21 +19,16 @@ for (const colour of ['red', 'blue', 'yellow']) {
     };
 }
 
-const getRoleTextClass = (role) => {
-    switch ((role || '').toLowerCase()) {
-        case 'admin':
-            return 'text-red-500';
-        case 'contributor':
-            return 'text-cyan-600 dark:text-cyan-400';
-        case 'supporter':
-            return 'text-emerald-600 dark:text-emerald-400';
-        case 'winner':
-            return 'text-amber-600 dark:text-amber-400';
-        case 'previouswinner':
-            return 'text-fuchsia-600 dark:text-fuchsia-400';
-        default:
-            return 'text-foreground';
-    }
+const getRoleClass = (role) => {
+    const key = (role || '').toLowerCase();
+    const classes = {
+        admin: 'role-admin',
+        contributor: 'role-contributor',
+        supporter: 'role-supporter',
+        winner: 'role-winner',
+        previouswinner: 'role-previouswinner'
+    };
+    return classes[key] || 'text-foreground';
 };
 
 const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
@@ -246,7 +241,7 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
                     </span>
                 );
             } else if (fragment.name && fragment.argType === 'player') {
-                const userClass = `username font-semibold ${getRoleTextClass(fragment.role)}`;
+                const userClass = `username ${getRoleClass(fragment.role)}`;
 
                 messages.push(
                     <div key={index++} className='message-chat flex items-center gap-1.5'>
@@ -257,7 +252,7 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
                     </div>
                 );
             } else if (fragment.argType === 'nonAvatarPlayer') {
-                const userClass = `username font-semibold ${getRoleTextClass(fragment.role)}`;
+                const userClass = `username ${getRoleClass(fragment.role)}`;
 
                 messages.push(
                     <span key={index++} className={userClass}>

--- a/client/Components/Lobby/LobbyChat.jsx
+++ b/client/Components/Lobby/LobbyChat.jsx
@@ -28,7 +28,7 @@ const getRoleClass = (role) => {
         winner: 'role-winner',
         previouswinner: 'role-previouswinner'
     };
-    return classes[key] || 'text-foreground';
+    return classes[key] || 'font-semibold text-foreground';
 };
 
 const LobbyChat = ({

--- a/client/Components/Lobby/LobbyChat.jsx
+++ b/client/Components/Lobby/LobbyChat.jsx
@@ -19,21 +19,16 @@ const containsUserMention = (messageText, username) => {
     return mentionRegex.test(messageText);
 };
 
-const getRoleTextClass = (role) => {
-    switch ((role || '').toLowerCase()) {
-        case 'admin':
-            return 'text-red-500 dark:text-red-400';
-        case 'contributor':
-            return 'text-cyan-600 dark:text-cyan-400';
-        case 'supporter':
-            return 'text-emerald-600 dark:text-emerald-400';
-        case 'winner':
-            return 'text-amber-600 dark:text-amber-400';
-        case 'previouswinner':
-            return 'text-fuchsia-600 dark:text-fuchsia-400';
-        default:
-            return 'text-foreground';
-    }
+const getRoleClass = (role) => {
+    const key = (role || '').toLowerCase();
+    const classes = {
+        admin: 'role-admin',
+        contributor: 'role-contributor',
+        supporter: 'role-supporter',
+        winner: 'role-winner',
+        previouswinner: 'role-previouswinner'
+    };
+    return classes[key] || 'text-foreground';
 };
 
 const LobbyChat = ({
@@ -272,7 +267,7 @@ const LobbyChat = ({
                 );
             });
 
-            const userClass = `username font-semibold ${getRoleTextClass(firstMessage.user.role)}`;
+            const userClass = `username ${getRoleClass(firstMessage.user.role)}`;
 
             return (
                 <div

--- a/client/Components/Lobby/LobbyChat.jsx
+++ b/client/Components/Lobby/LobbyChat.jsx
@@ -4,6 +4,7 @@ import Icon from '../Icon';
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import Avatar from '../Site/Avatar';
+import { getRoleClass } from '../../util';
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -17,18 +18,6 @@ const containsUserMention = (messageText, username) => {
         'i'
     );
     return mentionRegex.test(messageText);
-};
-
-const getRoleClass = (role) => {
-    const key = (role || '').toLowerCase();
-    const classes = {
-        admin: 'role-admin',
-        contributor: 'role-contributor',
-        supporter: 'role-supporter',
-        winner: 'role-winner',
-        previouswinner: 'role-previouswinner'
-    };
-    return classes[key] || 'font-semibold text-foreground';
 };
 
 const LobbyChat = ({

--- a/client/pages/About.jsx
+++ b/client/pages/About.jsx
@@ -89,21 +89,23 @@ const About = () => {
                     </p>
                     <ul className='list-disc pl-6'>
                         <li>
-                            <span className='role-admin'>admin</span> - site administrator
+                            <span className='username role-admin'>admin</span> - site administrator
                         </li>
                         <li>
-                            <span className='role-contributor'>contributor</span> - people who have
-                            made significant development contributions to the site
+                            <span className='username role-contributor'>contributor</span> - people
+                            who have made significant development contributions to the site
                         </li>
                         <li>
-                            <span className='role-supporter'>supporter</span> - patreon supporters
+                            <span className='username role-supporter'>supporter</span> - patreon
+                            supporters
                         </li>
                         <li>
-                            <span className='role-winner'>winner</span> - current tournament winner
-                        </li>
-                        <li>
-                            <span className='role-previouswinner'>previous winner</span> - former
+                            <span className='username role-winner'>winner</span> - current
                             tournament winner
+                        </li>
+                        <li>
+                            <span className='username role-previouswinner'>previous winner</span> -
+                            former tournament winner
                         </li>
                     </ul>
                 </Trans>

--- a/client/pages/About.jsx
+++ b/client/pages/About.jsx
@@ -87,25 +87,23 @@ const About = () => {
                         Some usernames have different colors and the intent is to acknowledge the
                         supporters of the platform:
                     </p>
-                    <ul>
+                    <ul className='list-disc pl-6'>
                         <li>
-                            <span className='username admin-role'>admin</span> - site administrator
+                            <span className='role-admin'>admin</span> - site administrator
                         </li>
                         <li>
-                            <span className='username contributor-role'>contributor</span> - people
-                            who have made significant development contributions to the site
+                            <span className='role-contributor'>contributor</span> - people who have
+                            made significant development contributions to the site
                         </li>
                         <li>
-                            <span className='username supporter-role'>supporter</span> - patreon
-                            supporters
+                            <span className='role-supporter'>supporter</span> - patreon supporters
                         </li>
                         <li>
-                            <span className='username winner-role'>winner</span> - current
+                            <span className='role-winner'>winner</span> - current tournament winner
+                        </li>
+                        <li>
+                            <span className='role-previouswinner'>previous winner</span> - former
                             tournament winner
-                        </li>
-                        <li>
-                            <span className='username previouswinner-role'>previous winner</span> -
-                            former tournament winner
                         </li>
                     </ul>
                 </Trans>

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -2131,4 +2131,20 @@ pre {
     .blocklist td {
         vertical-align: middle !important;
     }
+
+    .role-admin {
+        @apply font-semibold text-red-500 dark:text-red-400;
+    }
+    .role-contributor {
+        @apply font-semibold text-cyan-600 dark:text-cyan-400;
+    }
+    .role-supporter {
+        @apply font-semibold text-emerald-600 dark:text-emerald-400;
+    }
+    .role-winner {
+        @apply font-semibold text-amber-600 dark:text-amber-400;
+    }
+    .role-previouswinner {
+        @apply font-semibold text-fuchsia-600 dark:text-fuchsia-400;
+    }
 }

--- a/client/util.jsx
+++ b/client/util.jsx
@@ -71,3 +71,15 @@ export const toBase64 = (file) =>
         reader.onload = () => resolve(reader.result.toString().split(',')[1]);
         reader.onerror = (error) => reject(error);
     });
+
+export function getRoleClass(role) {
+    const key = (role || '').toLowerCase();
+    const classes = {
+        admin: 'role-admin',
+        contributor: 'role-contributor',
+        supporter: 'role-supporter',
+        winner: 'role-winner',
+        previouswinner: 'role-previouswinner'
+    };
+    return classes[key] || 'font-semibold text-foreground';
+}


### PR DESCRIPTION
Closes #4954

## Summary
- Extract role color/weight styles into shared `.role-admin`, `.role-contributor`, `.role-supporter`, `.role-winner`, `.role-previouswinner` CSS classes in `tailwind.css`
- Replace duplicated inline Tailwind utility classes in `Messages.jsx` and `LobbyChat.jsx` with the shared `role-*` classes
- Fix `About.jsx` to use the same `role-*` classes for consistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor with no auth or data changes; minor risk of visual drift if old and new class mappings differed.
> 
> **Overview**
> Centralizes username role styling so lobby chat, in-game messages, and the About page all use the same **role-*** classes instead of duplicated inline Tailwind.
> 
> Adds **`getRoleClass`** in `util.jsx` and component-layer **`.role-admin`**, **`.role-contributor`**, etc. in `tailwind.css`, then removes local **`getRoleTextClass`** helpers from **`Messages.jsx`** and **`LobbyChat.jsx`**. **`About.jsx`** switches from legacy `*-role` class names to the shared **`role-*`** set and adds list styling on the color legend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e61037e9baac6fc08db0cef3e9b0f4f001de2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->