### PR TITLE
fix: increase username max length from 15 to 20 characters

### DIFF
--- a/client/Components/Profile/Profile.jsx
+++ b/client/Components/Profile/Profile.jsx
@@ -156,7 +156,7 @@ const Profile = ({ onSubmit, isLoading }) => {
             .string()
             .required(t('You must specify a username'))
             .min(3, t('Your username must be at least 3 characters long'))
-            .max(15, t('Your username cannot be more than 15 charcters'))
+            .max(20, t('Your username cannot be more than 20 characters'))
             .matches(
                 /^[A-Za-z0-9_-]+$/,
                 t('Usernames must only use the characters a-z, 0-9, _ and -')

--- a/client/locales/de.json
+++ b/client/locales/de.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Um den Prozess zur Passwortwiederherstellung zu starten, geben Sie bitte Ihren Benutzernamen oder Ihre E-Mail-Adresse ein und klicken Sie auf die Schaltfläche „Senden“.",
     "You must specify a username": "Du musst einen Nutzernamen angeben",
-    "Username must be at least 3 characters and no more than 15 characters long": "Der Nutzername muss mindestens 3 und höchstens 15 Zeichen lang sein",
+    "Username must be at least 3 characters and no more than 20 characters long": "Der Nutzername muss mindestens 3 und höchstens 20 Zeichen lang sein",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Nutzernamen dürfen nur die Zeichen a-z, 0-9, _ und - verwenden",
     "You must specify a password": "Du musst ein Passwort angeben",
     "Password must be at least 6 characters": "Passwörter müssen mindestens 6 Zeichen lang sein",

--- a/client/locales/en.json
+++ b/client/locales/en.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Enter your username or email address",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "To start the password recovery process, please enter your username or email address and click the submit button.",
     "You must specify a username": "You must specify a username",
-    "Username must be at least 3 characters and no more than 15 characters long": "Username must be at least 3 characters and no more than 15 characters long",
+    "Username must be at least 3 characters and no more than 20 characters long": "Username must be at least 3 characters and no more than 20 characters long",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Usernames must only use the characters a-z, 0-9, _ and -",
     "You must specify a password": "You must specify a password",
     "Password must be at least 6 characters": "Password must be at least 6 characters",

--- a/client/locales/es.json
+++ b/client/locales/es.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Introduzca su nombre de usuario o dirección de correo electrónico",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Para iniciar el proceso de recuperación de contraseña, ingrese su nombre de usuario o dirección de correo electrónico y haga clic en el botón enviar.",
     "You must specify a username": "Debes especificar un nombre de usuario",
-    "Username must be at least 3 characters and no more than 15 characters long": "El nombre de usuario debe tener al menos 3 caracteres y no más de 15 caracteres de longitud",
+    "Username must be at least 3 characters and no more than 20 characters long": "El nombre de usuario debe tener al menos 3 caracteres y no más de 20 caracteres de longitud",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Los nombres de usuario deben usar solo los caracteres a-z, 0-9, _ y -",
     "You must specify a password": "Debes especificar una contraseña",
     "Password must be at least 6 characters": "La contraseña debe tener al menos 6 caracteres",

--- a/client/locales/fr.json
+++ b/client/locales/fr.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Entrez votre nom d'utilisateur ou votre adresse e-mail",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Pour démarrer le processus de récupération du mot de passe, veuillez entrer votre nom d'utilisateur ou votre adresse e-mail et cliquez sur le bouton Soumettre.",
     "You must specify a username": "Vous devez renseigner un nom d'utilisateur",
-    "Username must be at least 3 characters and no more than 15 characters long": "Le nom d'utilisateur doit posséder au moins 3 caractères mais pas plus de 15 caractères",
+    "Username must be at least 3 characters and no more than 20 characters long": "Le nom d'utilisateur doit posséder au moins 3 caractères mais pas plus de 20 caractères",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Le nom d'utilisateur doit uniquement inclure des caractères comme a-z, 0-9, _ and -",
     "You must specify a password": "Vous devez renseigner un mot de passe",
     "Password must be at least 6 characters": "Votre mot de passe doit compter au moins 6 caractères",

--- a/client/locales/it.json
+++ b/client/locales/it.json
@@ -293,7 +293,7 @@
     "Enter your username or email address": "Inserisci il tuo nome utente o indirizzo e-mail",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Per avviare il processo di recupero della password, inserisci il tuo nome utente o indirizzo e-mail e fai clic sul pulsante Invia.",
     "You must specify a username": "È necessario specificare un nome utente",
-    "Username must be at least 3 characters and no more than 15 characters long": "Il nome utente deve avere una lunghezza compresa tra 3 e 15 caratteri",
+    "Username must be at least 3 characters and no more than 20 characters long": "Il nome utente deve avere una lunghezza compresa tra 3 e 20 caratteri",
     "Usernames must only use the characters a-z, 0-9, _ and -": "I nomi utente possono contenere solo i caratteri a-z, 0-9, _ e -",
     "You must specify a password": "È necessario specificare una password",
     "Password must be at least 6 characters": "La password deve contenere almeno 6 caratteri",

--- a/client/locales/ko.json
+++ b/client/locales/ko.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "사용자 이름이나 이메일 주소를 입력하세요",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "비밀번호 복구 프로세스를 시작하려면 사용자 이름이나 이메일 주소를 입력하고 제출 버튼을 클릭하세요.",
     "You must specify a username": "유저 이름을 확인해주세요",
-    "Username must be at least 3 characters and no more than 15 characters long": "유저 이름은 3문자 이상 15문자 이하여야 합니다",
+    "Username must be at least 3 characters and no more than 20 characters long": "유저 이름은 3문자 이상 20문자 이하여야 합니다",
     "Usernames must only use the characters a-z, 0-9, _ and -": "유저이름은 알파벳 a-z, 숫자 0-9, 특수문자 _과 -로만 이루어져야 합니다",
     "You must specify a password": "비밀번호를 확인해주세요",
     "Password must be at least 6 characters": "비밀번호는 최소 6문자 이상이어야 합니다",

--- a/client/locales/pl.json
+++ b/client/locales/pl.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Wpisz swoją nazwę użytkownika lub adres e-mail",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Aby rozpocząć proces odzyskiwania hasła, wpisz swoją nazwę użytkownika lub adres e-mail i kliknij przycisk Prześlij.",
     "You must specify a username": "Musisz podać nazwę użytkownika",
-    "Username must be at least 3 characters and no more than 15 characters long": "Nazwa użytkownia musi mieć co najmniej 3 znaki i nie więcej niż 15 znaków",
+    "Username must be at least 3 characters and no more than 20 characters long": "Nazwa użytkownia musi mieć co najmniej 3 znaki i nie więcej niż 20 znaków",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Nazwa użytkownika może zawierać tylko znaki a-z, 0-9, _ and -",
     "You must specify a password": "Musisz podać hasło",
     "Password must be at least 6 characters": "Hasło musi mieć co najmniej 6 znaków",

--- a/client/locales/pt.json
+++ b/client/locales/pt.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Entre com seu usuário ou e-mail",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Para iniciar o processo de recuperação de senha, por favor entre com seu usuário ou e-mail e clique no botão Enviar.",
     "You must specify a username": "Você deve informar um nome de usuário",
-    "Username must be at least 3 characters and no more than 15 characters long": "Nome de usuário deve ter pelo menos 3 e no máximo 15 caracteres",
+    "Username must be at least 3 characters and no more than 20 characters long": "Nome de usuário deve ter pelo menos 3 e no máximo 20 caracteres",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Nome de usuário só pode conter os caracteres a-z, 0-9, _ e -",
     "You must specify a password": "Você deve informar uma senha",
     "Password must be at least 6 characters": "A senha deve ter pelo menos 6 caracteres",

--- a/client/locales/th.json
+++ b/client/locales/th.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "กรอกชื่อผู้ใช้หรือที่อยู่อีเมลของคุณ",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "หากต้องการเริ่มกระบวนการกู้คืนรหัสผ่าน โปรดป้อนชื่อผู้ใช้หรือที่อยู่อีเมลของคุณแล้วคลิกปุ่มส่ง",
     "You must specify a username": "คุณต้องระบุชื่อผู้ใช้",
-    "Username must be at least 3 characters and no more than 15 characters long": "ชื่อผู้ใช้จะต้องมีอย่างน้อย 3 ตัวอักษรและไม่เกิน 15 ตัวอักษร",
+    "Username must be at least 3 characters and no more than 20 characters long": "ชื่อผู้ใช้จะต้องมีอย่างน้อย 3 ตัวอักษรและไม่เกิน 20 ตัวอักษร",
     "Usernames must only use the characters a-z, 0-9, _ and -": "ชื่อผู้ใช้ต้องใช้อักขระ a-z, 0-9, _ และ - เท่านั้น",
     "You must specify a password": "คุณต้องระบุรหัสผ่าน",
     "Password must be at least 6 characters": "รหัสผ่านต้องมีอย่างน้อย 6 ตัวอักษร",

--- a/client/locales/vi.json
+++ b/client/locales/vi.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "Nhập tên tài khoản hoặc địa chỉ email của bạn",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "Để bắt đầu quá trình khôi phục mật khẩu, xin hãy nhập tên tài khoản hoặc địa chỉ email của bạn và chọn nút xác nhận.",
     "You must specify a username": "Tên người dùng bạn điền phải được xác thực",
-    "Username must be at least 3 characters and no more than 15 characters long": "Tên tài khoản phải có ít nhất 3 kí tự và không nhiều hơn 15 kí tự",
+    "Username must be at least 3 characters and no more than 20 characters long": "Tên tài khoản phải có ít nhất 3 kí tự và không nhiều hơn 20 kí tự",
     "Usernames must only use the characters a-z, 0-9, _ and -": "Tên tài khoản chỉ sử dụng các kí tự a-z, 0-9,_ và -",
     "You must specify a password": "Mật khẩu phải được xác thực",
     "Password must be at least 6 characters": "Mật khẩu phải chứa ít nhất 6 kí tự",

--- a/client/locales/zhhans.json
+++ b/client/locales/zhhans.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "输入您的用户名或电子邮件地址",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "要开始密码恢复过程，请输入您的用户名或电子邮件地址，然后单击提交按钮。",
     "You must specify a username": "必须输入用户名称",
-    "Username must be at least 3 characters and no more than 15 characters long": "用户名称长度需介于 3 到 15 个字",
+    "Username must be at least 3 characters and no more than 20 characters long": "用户名称长度需介于 3 到 20 个字",
     "Usernames must only use the characters a-z, 0-9, _ and -": "用户名称仅能包含 a-z, 0-9, _ 与 -",
     "You must specify a password": "必须输入密码",
     "Password must be at least 6 characters": "密码长度最短为 6 个字",

--- a/client/locales/zhhant.json
+++ b/client/locales/zhhant.json
@@ -227,7 +227,7 @@
     "Enter your username or email address": "輸入您的使用者名稱或電子郵件地址",
     "To start the password recovery process, please enter your username or email address and click the submit button.": "若要開始密碼恢復流程，請輸入您的使用者名稱或電子郵件地址，然後按一下提交按鈕。",
     "You must specify a username": "必須輸入使用者名稱",
-    "Username must be at least 3 characters and no more than 15 characters long": "使用者名稱長度需介於 3 到 15 個字",
+    "Username must be at least 3 characters and no more than 20 characters long": "使用者名稱長度需介於 3 到 20 個字",
     "Usernames must only use the characters a-z, 0-9, _ and -": "使用者名稱僅能包含 a-z, 0-9, _ 與 -",
     "You must specify a password": "必須輸入密碼",
     "Password must be at least 6 characters": "密碼長度最短為 6 個字",

--- a/client/pages/Register.jsx
+++ b/client/pages/Register.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from 'react';
-import { Formik } from 'formik';
-import * as yup from 'yup';
 import { Button, Input, Label, toast } from '@heroui/react';
+import { Formik } from 'formik';
+import React, { useEffect } from 'react';
+import * as yup from 'yup';
 
+import Link from '../Components/Navigation/Link.jsx';
 import AlertPanel from '../Components/Site/AlertPanel.jsx';
 import Panel from '../Components/Site/Panel.jsx';
-import Link from '../Components/Navigation/Link.jsx';
 import { useRegisterAccountMutation } from '../redux/api';
 
 import { Trans, useTranslation } from 'react-i18next';
@@ -38,10 +38,10 @@ const Register = () => {
         username: yup
             .string()
             .required(t('You must specify a username'))
-            .min(3, t('Username must be at least 3 characters and no more than 15 characters long'))
+            .min(3, t('Username must be at least 3 characters and no more than 20 characters long'))
             .max(
-                15,
-                t('Username must be at least 3 characters and no more than 15 characters long')
+                20,
+                t('Username must be at least 3 characters and no more than 20 characters long')
             )
             .matches(
                 /^[A-Za-z0-9_-]+$/,

--- a/server/api/account.js
+++ b/server/api/account.js
@@ -48,8 +48,8 @@ function validateUserName(username) {
         return 'You must specify a username';
     }
 
-    if (username.length < 3 || username.length > 15) {
-        return 'Username must be at least 3 characters and no more than 15 characters long';
+    if (username.length < 3 || username.length > 20) {
+        return 'Username must be at least 3 characters and no more than 20 characters long';
     }
 
     if (!username.match(/^[A-Za-z0-9_-]+$/)) {


### PR DESCRIPTION
Fixes #2069

Increases the maximum username length from 15 to 20 characters in:
- Server-side validation (`server/api/account.js`)
- Client registration validation (`client/pages/Register.jsx`)
- Profile validation (`client/Components/Profile/Profile.jsx`)
- All locale files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, consistent validation and copy change; confirm DB/schema allows 20-character usernames if not already.
> 
> **Overview**
> Raises the **maximum username length from 15 to 20 characters** across registration, profile edits, and server-side account validation so client and API stay aligned.
> 
> **`server/api/account.js`** updates `validateUserName`. **`Register.jsx`** and **`Profile.jsx`** change Yup `.max()` limits and related copy. **Locale files** update the shared registration validation string from 15 to 20. Profile already used a separate max-length message, now set to 20 in the schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb0c7940910646c119d69d22983ecd14ac628d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->