### PR TITLE
fix: High Priest Torvus and Decadence

### DIFF
--- a/server/game/cards/04-MM/HighPriestTorvus.js
+++ b/server/game/cards/04-MM/HighPriestTorvus.js
@@ -7,22 +7,29 @@ class HighPriestTorvus extends Card {
             optional: true,
             gameAction: ability.actions.exalt(),
             then: {
-                gameAction: ability.actions.untilPlayerTurnEnd((context) => ({
-                    when: {
-                        onCardPlayed: (event) =>
-                            event.player === context.player && event.card.type === 'action'
-                    },
-                    effect: 'return {1} to hand instead of placing it in discard pile',
-                    effectArgs: (context) => context.event.card,
-                    multipleTrigger: false,
-                    gameAction: ability.actions.cardLastingEffect((context) => ({
-                        // We don’t know where the action card will be played from, so
-                        // we allow any location.
-                        allowedLocations: 'any',
-                        target: context.event.card,
-                        effect: ability.effects.cardLocationAfterPlay('hand')
-                    }))
-                }))
+                gameAction: ability.actions.untilPlayerTurnEnd((context) => {
+                    // Capture all cards currently resolving (in 'being played')
+                    // so we don't return them to hand — only the NEXT action counts.
+                    const excludeCards = context.game.allCards.filter(
+                        (c) => c.location === 'being played'
+                    );
+                    return {
+                        when: {
+                            onCardPlayed: (event) =>
+                                event.player === context.player &&
+                                event.card.type === 'action' &&
+                                !excludeCards.includes(event.card)
+                        },
+                        effect: 'return {1} to hand instead of placing it in discard pile',
+                        effectArgs: (context) => context.event.card,
+                        multipleTrigger: false,
+                        gameAction: ability.actions.cardLastingEffect((context) => ({
+                            allowedLocations: 'any',
+                            target: context.event.card,
+                            effect: ability.effects.cardLocationAfterPlay('hand')
+                        }))
+                    };
+                })
             }
         });
     }

--- a/test/server/cards/04-MM/HighPriestTorvus.spec.js
+++ b/test/server/cards/04-MM/HighPriestTorvus.spec.js
@@ -25,6 +25,7 @@ describe('High Priest Torvus', function () {
         it('should not return an action card to hand before reaping', function () {
             this.player1.play(this.triumph);
             expect(this.triumph.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not return an action card to hand if not opt to exalt Priest', function () {
@@ -32,6 +33,7 @@ describe('High Priest Torvus', function () {
             this.player1.clickPrompt('Done');
             this.player1.play(this.triumph);
             expect(this.triumph.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not return an action card to hand if opt to exalt Priest', function () {
@@ -47,6 +49,7 @@ describe('High Priest Torvus', function () {
             expect(this.imperium.location).toBe('discard');
             this.player1.play(this.triumph);
             expect(this.triumph.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not return a creature to hand', function () {
@@ -55,6 +58,7 @@ describe('High Priest Torvus', function () {
             expect(this.highPriestTorvus.amber).toBe(1);
             this.player1.play(this.galeatops);
             expect(this.galeatops.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not return an artifact to hand', function () {
@@ -63,6 +67,7 @@ describe('High Priest Torvus', function () {
             expect(this.highPriestTorvus.amber).toBe(1);
             this.player1.play(this.cityGates);
             expect(this.cityGates.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not return an already resolving action to hand', function () {

--- a/test/server/cards/04-MM/HighPriestTorvus.spec.js
+++ b/test/server/cards/04-MM/HighPriestTorvus.spec.js
@@ -5,7 +5,15 @@ describe('High Priest Torvus', function () {
                 player1: {
                     house: 'saurian',
                     inPlay: ['high-priest-torvus', 'senator-shrix'],
-                    hand: ['siren-horn', 'galeatops', 'imperium', 'triumph', 'city-gates']
+                    hand: [
+                        'siren-horn',
+                        'galeatops',
+                        'imperium',
+                        'triumph',
+                        'city-gates',
+                        'decadence',
+                        'wild-wormhole'
+                    ]
                 },
                 player2: {
                     inPlay: ['troll', 'flaxia'],
@@ -55,6 +63,26 @@ describe('High Priest Torvus', function () {
             expect(this.highPriestTorvus.amber).toBe(1);
             this.player1.play(this.cityGates);
             expect(this.cityGates.location).toBe('play area');
+        });
+
+        it('should not return an already resolving action to hand', function () {
+            this.player1.makeMaverick(this.wildWormhole, 'saurian');
+            this.player1.moveCard(this.decadence, 'deck');
+            this.player1.play(this.wildWormhole);
+            this.player1.clickCard(this.highPriestTorvus);
+            this.player1.clickPrompt('Exalt, ready and use');
+            this.player1.clickCard(this.highPriestTorvus);
+            expect(this.highPriestTorvus.amber).toBe(1);
+            this.player1.clickPrompt('Reap with this creature');
+            this.player1.clickCard(this.highPriestTorvus);
+            expect(this.highPriestTorvus.amber).toBe(2);
+            expect.soft(this.wildWormhole.location).toBe('discard');
+            expect.soft(this.decadence.location).toBe('discard');
+            this.player1.play(this.triumph);
+            expect.soft(this.triumph.location).toBe('hand');
+            expect.soft(this.wildWormhole.location).toBe('discard');
+            expect.soft(this.decadence.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });

--- a/test/server/cards/04-MM/HighPriestTorvus.spec.js
+++ b/test/server/cards/04-MM/HighPriestTorvus.spec.js
@@ -76,12 +76,12 @@ describe('High Priest Torvus', function () {
             this.player1.clickPrompt('Reap with this creature');
             this.player1.clickCard(this.highPriestTorvus);
             expect(this.highPriestTorvus.amber).toBe(2);
-            expect.soft(this.wildWormhole.location).toBe('discard');
-            expect.soft(this.decadence.location).toBe('discard');
+            expect(this.wildWormhole.location).toBe('discard');
+            expect(this.decadence.location).toBe('discard');
             this.player1.play(this.triumph);
-            expect.soft(this.triumph.location).toBe('hand');
-            expect.soft(this.wildWormhole.location).toBe('discard');
-            expect.soft(this.decadence.location).toBe('discard');
+            expect(this.triumph.location).toBe('hand');
+            expect(this.wildWormhole.location).toBe('discard');
+            expect(this.decadence.location).toBe('discard');
             expect(this.player1).isReadyToTakeAction();
         });
     });

--- a/test/server/cards/05-DT/Science.spec.js
+++ b/test/server/cards/05-DT/Science.spec.js
@@ -11,7 +11,8 @@ describe('Science!', function () {
                         'science',
                         'data-forge',
                         'animator',
-                        'backup-copy'
+                        'backup-copy',
+                        'wild-wormhole'
                     ]
                 },
                 player2: {
@@ -24,6 +25,7 @@ describe('Science!', function () {
         it('should not gain amber if playing action before science', function () {
             this.player1.play(this.dataForge);
             expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should gain 1 amber for each action played after science', function () {
@@ -33,6 +35,7 @@ describe('Science!', function () {
             this.player1.play(this.dataForge);
             this.player1.clickPrompt('Science!');
             expect(this.player1.amber).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not gain amber if playing creature/upgrade after science', function () {
@@ -40,12 +43,21 @@ describe('Science!', function () {
             this.player1.play(this.dextre);
             this.player1.playUpgrade(this.backupCopy, this.dextre);
             expect(this.player1.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not gain amber if playing artifact after science', function () {
             this.player1.play(this.science);
             this.player1.play(this.animator);
             expect(this.player1.amber).toBe(1);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should gain amber for already resolving action', function () {
+            this.player1.moveCard(this.science, 'deck');
+            this.player1.play(this.wildWormhole);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });

--- a/test/server/cards/06-WoE/FrostGiant.spec.js
+++ b/test/server/cards/06-WoE/FrostGiant.spec.js
@@ -53,7 +53,7 @@ describe('Frost Giant', function () {
 
             this.player1.clickPrompt('Left'); // Ganger Chieftain
             this.player1.clickCard(this.frostGiant);
-            expect.soft(this.frostGiant.exhausted).toBe(false);
+            expect(this.frostGiant.exhausted).toBe(false);
             expect(this.frostGiant.damage).toBe(1);
             this.player2.clickPrompt('untamed');
             expect(this.player2).isReadyToTakeAction();


### PR DESCRIPTION
Fixes #2737

Exclude cards currently being played from the 'return to hand' trigger so only the *next* action played after Torvus reaps is returned to hand, not the action that triggered Torvus itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-card ability filter plus test updates; no auth, data, or broad engine changes beyond play-resolution timing.
> 
> **Overview**
> Fixes **High Priest Torvus** so the “return your next action to hand” effect ignores actions already in **`being played`** when the reap/exalt effect is registered—e.g. **Decadence** played mid-**Wild Wormhole** no longer bounces to hand instead of discarding.
> 
> Adds a **Wild Wormhole + Decadence** regression in `HighPriestTorvus.spec.js`, **`isReadyToTakeAction()`** assertions across Torvus and **Science!** specs, a **Science!** case that nested actions from wormhole still grant amber, and tightens one **Frost Giant** expectation from `expect.soft` to `expect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7726e32535ba0ced33b350d64b1548638eb24cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->