### PR TITLE
fix: use url as cache key in buildCard to fix card language switch

### DIFF
--- a/client/Components/GameBoard/Messages.jsx
+++ b/client/Components/GameBoard/Messages.jsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import AmberImage from '../../assets/img/amber.png';
@@ -37,6 +38,7 @@ const getRoleTextClass = (role) => {
 };
 
 const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
+    const { i18n } = useTranslation();
     const compactChatAlertClass =
         '!mb-1 !rounded-xl !px-3 !py-2 text-sm [&_svg]:text-base [&_[data-slot="alert-content"]]:gap-0.5 [&_[data-slot="alert-description"]]:text-sm';
 
@@ -232,6 +234,10 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
                     </a>
                 );
             } else if (fragment.image && fragment.label) {
+                const cardLabel =
+                    i18n.language !== 'en' && fragment.locale && fragment.locale[i18n.language]
+                        ? fragment.locale[i18n.language].name
+                        : fragment.label;
                 messages.push(
                     <span
                         key={index++}
@@ -242,7 +248,7 @@ const Messages = ({ messages, onCardMouseOver, onCardMouseOut }) => {
                         })}
                         onMouseOut={onCardMouseOut.bind(this)}
                     >
-                        {fragment.label}
+                        {cardLabel}
                     </span>
                 );
             } else if (fragment.name && fragment.argType === 'player') {

--- a/client/archonMaker.js
+++ b/client/archonMaker.js
@@ -737,8 +737,9 @@ export const buildCard = async (
         paintFirst: 'stroke'
     };
 
-    if (!DeckCards[halfSize ? 'halfSize' : 'cards'][image]) {
-        DeckCards[halfSize ? 'halfSize' : 'cards'][image] = await loadImage(url);
+    const cacheKey = url || image;
+    if (!DeckCards[halfSize ? 'halfSize' : 'cards'][cacheKey]) {
+        DeckCards[halfSize ? 'halfSize' : 'cards'][cacheKey] = await loadImage(url);
     }
 
     const width = 300;
@@ -754,7 +755,7 @@ export const buildCard = async (
     canvas.setDimensions({ width, height }, { backstoreOnly: true });
 
     const cardImage = new fabric.Image(
-        DeckCards[halfSize ? 'halfSize' : 'cards'][image].toCanvasElement(),
+        DeckCards[halfSize ? 'halfSize' : 'cards'][cacheKey].toCanvasElement(),
         imgOptions
     );
     cardImage.scaleToWidth(width);


### PR DESCRIPTION
Fixes #2096

When a card has an alternate language image (different URL), the cache key was the image filename rather than the URL. This caused the cached image from the default language to be reused instead of loading the alternate language version when hovering over a card.

The fix uses `url` as the cache key (falling back to `image` if url is not set), ensuring each unique URL gets its own cache entry.

In the chat logs, the card name was not being translated - those now use the localized card name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client-side image caching in `buildCard` with no auth or server impact.
> 
> **Overview**
> **Fixes card language switching** when the same card filename is served from different locale paths (e.g. `/img/cards/en/...` vs `/img/cards/fr/...`).
> 
> In `buildCard`, the in-memory `DeckCards` cache was keyed only by the **`image`** filename, so the first loaded bitmap was reused after a language change even though **`url`** (from `CardImage` as `localizedImageUrl`) pointed at a different asset.
> 
> The PR keys the cache with **`url || image`**, so each distinct image URL gets its own cached `fabric.Image`, while callers without a `url` keep the previous behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0722af3ad7c541271f38e8ddd92473d4a134e1c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->