### PR TITLE
test(08-AS): add edge case test for De-Doss vs variable power creatures

### DIFF
--- a/test/server/cards/08-AS/DeDoss.spec.js
+++ b/test/server/cards/08-AS/DeDoss.spec.js
@@ -97,4 +97,28 @@ describe('De-Doss', function () {
             expect(this.player2).isReadyToTakeAction();
         });
     });
+
+    describe("De-Doss's ability vs variable power creatures", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'logos',
+                    hand: ['de-doss'],
+                    inPlay: ['daughter']
+                },
+                player2: {
+                    hand: ['mushroom-man']
+                }
+            });
+        });
+
+        it('should not prevent opponent from playing creatures as upgrades', function () {
+            this.player1.playUpgrade(this.deDoss, this.daughter);
+            this.player1.endTurn();
+            this.player2.clickPrompt('untamed');
+            this.player2.playCreature(this.mushroomMan);
+            expect(this.mushroomMan.location).toBe('play area');
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
 });


### PR DESCRIPTION
Adds a test verifying that De-Doss does not incorrectly prevent the opponent from playing a creature whose power is variable (e.g. Mushroom Man).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or rules-engine code modified.
> 
> **Overview**
> Adds a server integration test in `DeDoss.spec.js` for **De-Doss** when the opponent tries to play a **variable-power** creature (**Mushroom Man**) while De-Doss is attached to **Daughter**.
> 
> The new scenario asserts the opponent can still **play the creature to the play area** and remains ready to act, guarding against De-Doss incorrectly blocking plays whose power is not a fixed comparison value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f335d7aa7dde5066e1805001fb977c157e33f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->