### PR TITLE
feat: support house enhancements in card house checks

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -685,7 +685,7 @@ class Card extends EffectSource {
         let combinedHouses = [];
 
         if (this.anyEffect('changeHouse')) {
-            combinedHouses = combinedHouses.concat(this.getEffects('changeHouse'));
+            combinedHouses = combinedHouses.concat(this.getEffects('changeHouse').flat());
         } else {
             let copyEffect = this.mostRecentEffect('copyCard');
             combinedHouses.push(copyEffect ? copyEffect.printedHouse : this.printedHouse);

--- a/server/game/cards/01-Core/AFairGame.js
+++ b/server/game/cards/01-Core/AFairGame.js
@@ -19,12 +19,18 @@ class AFairGame extends Card {
                     oppTop || 'nothing',
                     oppHand,
                     oppTop
-                        ? oppHand.filter((card) => card.hasHouse(oppTop.printedHouse)).length
+                        ? oppHand.filter((card) =>
+                              oppTop.getHouses().some((house) => card.hasHouse(house))
+                          ).length
                         : 0,
                     context.player,
                     myTop || 'nothing',
                     myHand,
-                    myTop ? myHand.filter((card) => card.hasHouse(myTop.printedHouse)).length : 0
+                    myTop
+                        ? myHand.filter((card) =>
+                              myTop.getHouses().some((house) => card.hasHouse(house))
+                          ).length
+                        : 0
                 ];
             },
             gameAction: [
@@ -42,7 +48,7 @@ class AFairGame extends Card {
                     if (oppTop) {
                         return {
                             amount: context.player.opponent.hand.filter((card) =>
-                                card.hasHouse(oppTop.printedHouse)
+                                oppTop.getHouses().some((house) => card.hasHouse(house))
                             ).length
                         };
                     }
@@ -55,7 +61,7 @@ class AFairGame extends Card {
                         return {
                             target: context.player.opponent,
                             amount: context.player.hand.filter((card) =>
-                                card.hasHouse(myTop.printedHouse)
+                                myTop.getHouses().some((house) => card.hasHouse(house))
                             ).length
                         };
                     }

--- a/server/game/cards/05-DT/OlPaddyEvilTwin.js
+++ b/server/game/cards/05-DT/OlPaddyEvilTwin.js
@@ -15,7 +15,7 @@ class OlPaddyEvilTwin extends Card {
                     controller: 'any',
                     cardCondition: (card, context) =>
                         context.preThenEvents.some((event) =>
-                            card.hasHouse(event.card.printedHouse)
+                            event.card.getHouses().some((house) => card.hasHouse(house))
                         ),
                     gameAction: ability.actions.destroy()
                 }

--- a/server/game/cards/07-GR/ImmortalGreking.js
+++ b/server/game/cards/07-GR/ImmortalGreking.js
@@ -26,12 +26,16 @@ class ImmortalGreking extends Card {
                         until: {
                             onCardLeavesPlay: (event) => event.card === context.source
                         },
-                        effect: ability.effects.changeHouse(context.source.printedHouse)
+                        effect: ability.effects.changeHouse(context.source.getHouses())
                     }))
                 ])
             },
             effect: 'take control of {1} and place it anywhere in their battleline, making it belong to {2} until {3} leaves play',
-            effectArgs: (context) => [context.target, context.source.printedHouse, context.source]
+            effectArgs: (context) => [
+                context.target,
+                context.source.getHouses().join(' and '),
+                context.source
+            ]
         });
 
         this.destroyed({

--- a/server/game/cards/07-GR/IntoTheWarp.js
+++ b/server/game/cards/07-GR/IntoTheWarp.js
@@ -33,7 +33,7 @@ class IntoTheWarp extends Card {
                     target: context.game.creaturesInPlay.filter((c) =>
                         context.preThenEvents
                             .filter((e) => e.name === 'onCardDiscarded')
-                            .map((e) => e.card.printedHouse)
+                            .flatMap((e) => e.card.getHouses())
                             .some((h) => c.hasHouse(h))
                     )
                 })),
@@ -43,7 +43,7 @@ class IntoTheWarp extends Card {
                     context.game.creaturesInPlay.filter((c) =>
                         context.preThenEvents
                             .filter((e) => e.name === 'onCardDiscarded')
-                            .map((e) => e.card.printedHouse)
+                            .flatMap((e) => e.card.getHouses())
                             .some((h) => c.hasHouse(h))
                     )
                 ]

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -783,7 +783,7 @@ class Player extends GameObject {
             }
 
             if (card.anyEffect('changeHouse')) {
-                cardHouses = card.getEffects('changeHouse');
+                cardHouses = card.getEffects('changeHouse').flat();
             }
 
             for (let house of cardHouses) {

--- a/test/server/cards/01-Core/AFairGame.spec.js
+++ b/test/server/cards/01-Core/AFairGame.spec.js
@@ -20,6 +20,7 @@ describe('A Fair Game', function () {
             this.player1.play(this.aFairGame);
             expect(this.player1.amber).toBe(3);
             expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it("should give the correct amount when one player doesn't have a matching card", function () {
@@ -28,6 +29,7 @@ describe('A Fair Game', function () {
             this.player1.play(this.aFairGame);
             expect(this.player1.amber).toBe(0);
             expect(this.player2.amber).toBe(2);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should not discard a card when the discard is empty, and should give no amber', function () {
@@ -39,6 +41,18 @@ describe('A Fair Game', function () {
             this.player1.play(this.aFairGame);
             expect(this.player1.amber).toBe(3);
             expect(this.player2.amber).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('should give each player the correct amount of amber when discarding a card which matches house enhancements', function () {
+            this.player1.moveCard(this.tocsin, 'deck');
+            this.player2.moveCard(this.flaxia, 'deck');
+            this.tocsin.enhancements = ['logos'];
+            this.flaxia.enhancements = ['shadows'];
+            this.player1.play(this.aFairGame);
+            expect(this.player1.amber).toBe(3);
+            expect(this.player2.amber).toBe(4);
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });

--- a/test/server/cards/05-DT/OlPaddyEvilTwin.spec.js
+++ b/test/server/cards/05-DT/OlPaddyEvilTwin.spec.js
@@ -68,6 +68,23 @@ describe("Ol' Paddy Evil Twin", function () {
                 });
             });
 
+            describe('when tide is not high and discarded card has house enhancement', function () {
+                beforeEach(function () {
+                    this.dustPixie.enhancements = ['shadows'];
+                    this.player1.reap(this.olPaddyEvilTwin);
+                });
+
+                it('should also match house enhancements of discarded card', function () {
+                    expect(this.player1).toBeAbleToSelect(this.tantadlin);
+                    expect(this.player1).toBeAbleToSelect(this.flaxia);
+                    expect(this.player1).toBeAbleToSelect(this.murmook);
+                    expect(this.player1).toBeAbleToSelect(this.chainGang);
+                    expect(this.player1).not.toBeAbleToSelect(this.senatorShrix);
+                    this.player1.clickCard(this.tantadlin);
+                    expect(this.player1).isReadyToTakeAction();
+                });
+            });
+
             describe('when tide is high and reap', function () {
                 beforeEach(function () {
                     this.player1.raiseTide();

--- a/test/server/cards/07-GR/ImmortalGreking.spec.js
+++ b/test/server/cards/07-GR/ImmortalGreking.spec.js
@@ -48,6 +48,17 @@ describe('Immortal Greking', function () {
             expect(this.player1).isReadyToTakeAction();
         });
 
+        it('makes the stolen creature also belong to house enhancements of Greking', function () {
+            this.immortalGreking.enhancements = ['logos'];
+            this.player1.playCreature(this.immortalGreking);
+            this.player1.clickCard(this.batdrone);
+            this.player1.clickCard(this.echofly);
+            this.player1.clickPrompt('Left');
+            expect(this.batdrone.hasHouse('geistoid')).toBe(true);
+            expect(this.batdrone.hasHouse('logos')).toBe(true);
+            expect(this.player1).isReadyToTakeAction();
+        });
+
         describe('after play', function () {
             beforeEach(function () {
                 this.player1.playCreature(this.immortalGreking);

--- a/test/server/cards/07-GR/IntoTheWarp.spec.js
+++ b/test/server/cards/07-GR/IntoTheWarp.spec.js
@@ -27,6 +27,7 @@ describe('Into the Warp', function () {
             expect(this.troll.location).toBe('play area');
             expect(this.poke.location).toBe('discard');
             expect(this.noddyTheThief.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('destroys creatures when only opponent discards', function () {
@@ -37,6 +38,7 @@ describe('Into the Warp', function () {
             expect(this.mother.location).toBe('play area');
             expect(this.troll.location).toBe('play area');
             expect(this.noddyTheThief.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('destroys creatures when only player discards', function () {
@@ -47,6 +49,7 @@ describe('Into the Warp', function () {
             expect(this.mother.location).toBe('discard');
             expect(this.troll.location).toBe('play area');
             expect(this.poke.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('does nothing when no player discards', function () {
@@ -57,6 +60,7 @@ describe('Into the Warp', function () {
             expect(this.urchin.location).toBe('play area');
             expect(this.mother.location).toBe('play area');
             expect(this.troll.location).toBe('play area');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('destroys no creatures when no creatures are in play', function () {
@@ -67,6 +71,7 @@ describe('Into the Warp', function () {
             this.player1.play(this.intoTheWarp);
             expect(this.poke.location).toBe('discard');
             expect(this.noddyTheThief.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('destroys no creatures when no creatures match the houses', function () {
@@ -78,6 +83,19 @@ describe('Into the Warp', function () {
             expect(this.troll.location).toBe('play area');
             expect(this.flaxia.location).toBe('discard');
             expect(this.noddyTheThief.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
+        });
+
+        it('destroys creatures matching house enhancements of discarded cards', function () {
+            this.poke.enhancements = ['brobnar'];
+            this.player1.play(this.intoTheWarp);
+            expect(this.batdrone.location).toBe('discard');
+            expect(this.urchin.location).toBe('discard');
+            expect(this.mother.location).toBe('discard');
+            expect(this.troll.location).toBe('discard');
+            expect(this.noddyTheThief.location).toBe('discard');
+            expect(this.poke.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });

--- a/test/server/cards/cancreatecards.spec.js
+++ b/test/server/cards/cancreatecards.spec.js
@@ -6,6 +6,7 @@ const localeEn = require('../../../client/locales/en.json');
 
 const card = {
     hasHouse: () => true,
+    getHouses: () => ['brobnar'],
     isOnFlank: () => true,
     neighbors: [],
     childCards: [],


### PR DESCRIPTION
Fixes #5146 

This pull request updates the game engine and card logic to respect house enhancements when performing card house checks. Instead of reading only the printed house of a card, the implementation now queries all active houses of a card via `getHouses()`, supporting cards that possess multiple houses due to enhancements or effects.

### Key Changes
* **Game Engine Core**:
  * Updated `Card.getHouses()` and `Player` house-checking logic to flatten results from `changeHouse` effects, supporting multi-house cards.
* **Card Rules Updates**:
  * **A Fair Game**: Refactored card checks to evaluate all houses returned by `getHouses()` of the top card of the deck rather than just its printed house.
  * **Ol' Paddy (Evil Twin)**: Updated the card-matching condition to check all houses of the discarded card.
  * **Immortal Greking**: Stolen creatures now gain all houses of Greking (via `changeHouse(context.source.getHouses())`), and the card's effect text formats multiple houses using "and".
  * **Into the Warp**: Uses `flatMap` on `getHouses()` to match creatures in play with any of the houses of discarded cards.
* **Testing**:
  * Added regression and unit tests for *A Fair Game*, *Ol' Paddy (Evil Twin)*, *Immortal Greking*, and *Into the Warp* verifying successful interaction with house enhancements.
  * Added mock implementation of `getHouses()` in `cancreatecards.spec.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d6478ecbc7f18b15da7277a894a668886edfc1dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->