### PR TITLE
fix(client): prevent crash when sorting cards with missing names in AllianceBuilder

### DIFF
--- a/client/pages/AllianceBuilder.jsx
+++ b/client/pages/AllianceBuilder.jsx
@@ -458,7 +458,7 @@ const AllianceBuilderPage = () => {
 
         return deck.cards
             .filter((card) => card.card?.house === house && !card.isNonDeck)
-            .sort((a, b) => a.card.name.localeCompare(b.card.name))
+            .sort((a, b) => (a.card.name || '').localeCompare(b.card.name || ''))
             .map((card) => ({
                 card: card.card,
                 count: card.count || 1,


### PR DESCRIPTION
### Summary
Prevents a client-side crash in the Alliance Builder when attempting to sort deck cards that have undefined or missing names. This happens if MV has bad card data and the full deck doesn't get imported, and then an alliance is attempted to be built from it. This will silently cover the sort error instead.

### Key Changes
- Modified card sorting logic in `client/pages/AllianceBuilder.jsx` to fall back to an empty string if `card.name` is undefined.
- Prevents runtime `TypeError` when calling `localeCompare` on undefined values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive UI fix with no auth, data, or API impact.
> 
> **Overview**
> Fixes a client crash in **Alliance Builder** when hovering house chips to preview deck cards.
> 
> **`getDeckHousePreviewCards`** now sorts by `(a.card.name || '').localeCompare(b.card.name || '')` instead of calling `localeCompare` directly on `card.name`, so cards with missing or undefined names no longer throw a `TypeError` during sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c080d825a089cb4d0856e52c59b0b94ec948b6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->