### PR TITLE
style(lint): enforce curly braces for all control statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
         'plugin:react/recommended',
         'plugin:prettier/recommended'
     ],
-    rules: { 'react/prop-types': 'off' },
+    rules: { 'react/prop-types': 'off', curly: ['error', 'all'] },
     settings: {
         react: {
             version: 'detect'

--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -21,7 +21,9 @@ const cardMenuCoordinator = (() => {
             target?.dispatchEvent(new CustomEvent('cardmenu:open', { detail: id }));
         },
         subscribe(id, onOtherOpen) {
-            if (!target) return () => {};
+            if (!target) {
+                return () => {};
+            }
             const handler = (event) => {
                 if (event.detail !== id) {
                     onOtherOpen();

--- a/server/devtools/scenario/cli.js
+++ b/server/devtools/scenario/cli.js
@@ -27,7 +27,9 @@ function walk(dir, pattern, out = []) {
         return out;
     }
     for (const entry of entries) {
-        if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
+        if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+            continue;
+        }
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
             walk(full, pattern, out);
@@ -66,24 +68,36 @@ function collectFiles() {
 // order. Returns null for no match, otherwise { score, positions }. Lower
 // score = better (consecutive matches, earlier position, word starts).
 function fuzzyMatch(haystack, needle) {
-    if (!needle) return { score: 0, positions: [] };
+    if (!needle) {
+        return { score: 0, positions: [] };
+    }
     const hs = haystack.toLowerCase();
     // Ignore spaces in the query so "mimic gel" matches "mimicgel".
     const ne = needle.toLowerCase().replace(/\s+/g, '');
-    if (!ne) return { score: 0, positions: [] };
+    if (!ne) {
+        return { score: 0, positions: [] };
+    }
     const positions = [];
     let hi = 0;
     let score = 0;
     let lastIdx = -2;
     for (let ni = 0; ni < ne.length; ni++) {
         const ch = ne[ni];
-        while (hi < hs.length && hs[hi] !== ch) hi++;
-        if (hi >= hs.length) return null;
+        while (hi < hs.length && hs[hi] !== ch) {
+            hi++;
+        }
+        if (hi >= hs.length) {
+            return null;
+        }
         positions.push(hi);
         // Bonus for consecutive matches
-        if (hi !== lastIdx + 1) score += hi - lastIdx;
+        if (hi !== lastIdx + 1) {
+            score += hi - lastIdx;
+        }
         // Bonus for word starts
-        if (hi === 0 || /[/\s_\-.]/.test(hs[hi - 1])) score -= 2;
+        if (hi === 0 || /[/\s_\-.]/.test(hs[hi - 1])) {
+            score -= 2;
+        }
         lastIdx = hi;
         hi++;
     }
@@ -91,7 +105,9 @@ function fuzzyMatch(haystack, needle) {
 }
 
 function filterAndRank(items, query, getText) {
-    if (!query) return items.map((item) => ({ item, positions: [] }));
+    if (!query) {
+        return items.map((item) => ({ item, positions: [] }));
+    }
 
     // Items with `.fullText` + `.sep` participate in a tree: match against the
     // full path, then distribute the match positions across the ancestor
@@ -101,7 +117,9 @@ function filterAndRank(items, query, getText) {
         const ranked = [];
         for (const item of items) {
             const m = fuzzyMatch(getText(item), query);
-            if (m) ranked.push({ item, score: m.score, positions: m.positions });
+            if (m) {
+                ranked.push({ item, score: m.score, positions: m.positions });
+            }
         }
         ranked.sort((a, b) => a.score - b.score);
         return ranked;
@@ -110,9 +128,13 @@ function filterAndRank(items, query, getText) {
     const matches = new Map();
     for (let i = 0; i < items.length; i++) {
         const item = items[i];
-        if (!item || item.header) continue;
+        if (!item || item.header) {
+            continue;
+        }
         const m = fuzzyMatch(item.fullText, query);
-        if (m) matches.set(i, m);
+        if (m) {
+            matches.set(i, m);
+        }
     }
     const keep = new Set();
     const positionsByIdx = new Map();
@@ -153,7 +175,9 @@ function filterAndRank(items, query, getText) {
     }
     const out = [];
     for (let i = 0; i < items.length; i++) {
-        if (!keep.has(i)) continue;
+        if (!keep.has(i)) {
+            continue;
+        }
         out.push({ item: items[i], positions: positionsByIdx.get(i) || [] });
     }
     return out;
@@ -175,12 +199,16 @@ function highlight(text, positions, maxLen) {
             out += text[i];
         }
     }
-    if (truncated) out += '…';
+    if (truncated) {
+        out += '…';
+    }
     return out;
 }
 
 function truncatePlain(text, maxLen) {
-    if (text.length <= maxLen) return text;
+    if (text.length <= maxLen) {
+        return text;
+    }
     return text.slice(0, Math.max(0, maxLen - 1)) + '…';
 }
 
@@ -301,13 +329,17 @@ function pick({ title, items, getText, renderText }) {
             const probe = (from, step) => {
                 let i = from;
                 while (i >= 0 && i < rankedList.length) {
-                    if (!isHeader(rankedList[i])) return i;
+                    if (!isHeader(rankedList[i])) {
+                        return i;
+                    }
                     i += step;
                 }
                 return -1;
             };
             const forward = probe(start, dir);
-            if (forward !== -1) return forward;
+            if (forward !== -1) {
+                return forward;
+            }
             const backward = probe(start, -dir);
             return backward === -1 ? 0 : backward;
         };
@@ -320,14 +352,21 @@ function pick({ title, items, getText, renderText }) {
                 selectedIdx = 0;
                 viewOffset = 0;
             } else {
-                if (selectedIdx >= ranked.length) selectedIdx = ranked.length - 1;
-                if (selectedIdx < 0) selectedIdx = 0;
+                if (selectedIdx >= ranked.length) {
+                    selectedIdx = ranked.length - 1;
+                }
+                if (selectedIdx < 0) {
+                    selectedIdx = 0;
+                }
                 if (isHeader(ranked[selectedIdx])) {
                     selectedIdx = snapToSelectable(ranked, selectedIdx, 1);
                 }
-                if (selectedIdx < viewOffset) viewOffset = selectedIdx;
-                if (selectedIdx >= viewOffset + maxVisible)
+                if (selectedIdx < viewOffset) {
+                    viewOffset = selectedIdx;
+                }
+                if (selectedIdx >= viewOffset + maxVisible) {
                     viewOffset = selectedIdx - maxVisible + 1;
+                }
             }
 
             const hint = 'Type to filter · ↑/↓ navigate · Enter select · Esc back · Ctrl+C exit';
@@ -387,7 +426,9 @@ function pick({ title, items, getText, renderText }) {
         let ranked = render();
 
         const onKey = (str, key) => {
-            if (!key) return;
+            if (!key) {
+                return;
+            }
             if (key.ctrl && key.name === 'c') {
                 cleanup();
                 stdout.write('\n');
@@ -408,10 +449,14 @@ function pick({ title, items, getText, renderText }) {
             }
             if (key.name === 'up') {
                 const next = snapToSelectable(ranked, selectedIdx - 1, -1);
-                if (next !== -1 && next < selectedIdx) selectedIdx = next;
+                if (next !== -1 && next < selectedIdx) {
+                    selectedIdx = next;
+                }
             } else if (key.name === 'down') {
                 const next = snapToSelectable(ranked, selectedIdx + 1, 1);
-                if (next !== -1 && next > selectedIdx) selectedIdx = next;
+                if (next !== -1 && next > selectedIdx) {
+                    selectedIdx = next;
+                }
             } else if (key.name === 'backspace') {
                 query = query.slice(0, -1);
                 selectedIdx = 0;
@@ -452,7 +497,9 @@ function runGamenode(scenarioArg) {
 
         const stdin = process.stdin;
         readline.emitKeypressEvents(stdin, { escapeCodeTimeout: 50 });
-        if (stdin.isTTY) stdin.setRawMode(true);
+        if (stdin.isTTY) {
+            stdin.setRawMode(true);
+        }
         stdin.resume();
 
         // Resolves once the child has actually exited. Anything that wants
@@ -469,9 +516,13 @@ function runGamenode(scenarioArg) {
 
         let resolved = false;
         const finish = async (back) => {
-            if (resolved) return;
+            if (resolved) {
+                return;
+            }
             resolved = true;
-            if (stdin.isTTY) stdin.setRawMode(false);
+            if (stdin.isTTY) {
+                stdin.setRawMode(false);
+            }
             stdin.pause();
             stdin.removeListener('keypress', onKey);
             // Just SIGKILL — graceful shutdown doesn't matter in dev mode,
@@ -488,7 +539,9 @@ function runGamenode(scenarioArg) {
         };
 
         const onKey = (_str, key) => {
-            if (!key) return;
+            if (!key) {
+                return;
+            }
             if (key.ctrl && key.name === 'c') {
                 // Wait for the child to actually exit before terminating
                 // the parent, or the child gets orphaned and keeps port 9000.
@@ -605,7 +658,9 @@ async function main() {
 main().catch((err) => {
     // Restore terminal in case we crashed inside the picker.
     process.stdout.write('\x1b[?1049l\x1b[?25h');
-    if (process.stdin.isTTY) process.stdin.setRawMode(false);
+    if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+    }
     console.error(err);
     process.exit(1);
 });

--- a/server/devtools/scenario/runner.js
+++ b/server/devtools/scenario/runner.js
@@ -371,7 +371,9 @@ function runScenario(scenarioPath, { router, gameId } = {}) {
     try {
         scenarioFn.call(context);
     } catch (e) {
-        if (e !== SCENARIO_BREAK) throw e;
+        if (e !== SCENARIO_BREAK) {
+            throw e;
+        }
         hitBreak = true;
     } finally {
         if (prevExpect === undefined) {

--- a/server/game/GameActions/GainsTextBoxAction.js
+++ b/server/game/GameActions/GainsTextBoxAction.js
@@ -145,7 +145,9 @@ class GainsTextBoxAction extends CardGameAction {
         ];
         for (const sourceAbility of sourceAbilities) {
             const abilityType = sourceAbility.abilityType;
-            if (!abilityType) continue;
+            if (!abilityType) {
+                continue;
+            }
             const properties = sourceAbility.properties ? sourceAbility.properties : sourceAbility;
             if (abilityType === 'persistentEffect') {
                 // Printed keywords also live in `persistentEffects` as

--- a/server/game/cards/01-Core/ChampionsChallenge.js
+++ b/server/game/cards/01-Core/ChampionsChallenge.js
@@ -41,15 +41,20 @@ class ChampionsChallenge extends Card {
             effectArgs: (context) => {
                 const enemy = context.targets.enemy;
                 const friendly = context.targets.friendly;
-                if (!enemy && !friendly) return ['do nothing', '', '', ''];
-                if (enemy && friendly)
+                if (!enemy && !friendly) {
+                    return ['do nothing', '', '', ''];
+                }
+                if (enemy && friendly) {
                     return [
                         'destroy all enemy creatures except ',
                         enemy,
                         ' and all friendly creatures except ',
                         friendly
                     ];
-                if (enemy) return ['destroy all enemy creatures except ', enemy, '', ''];
+                }
+                if (enemy) {
+                    return ['destroy all enemy creatures except ', enemy, '', ''];
+                }
                 return ['destroy all friendly creatures except ', friendly, '', ''];
             },
             then: {

--- a/server/game/cards/04-MM/SavageClash.js
+++ b/server/game/cards/04-MM/SavageClash.js
@@ -41,15 +41,20 @@ class SavageClash extends Card {
             effectArgs: (context) => {
                 const enemy = context.targets.enemy;
                 const friendly = context.targets.friendly;
-                if (!enemy && !friendly) return ['do nothing', '', '', ''];
-                if (enemy && friendly)
+                if (!enemy && !friendly) {
+                    return ['do nothing', '', '', ''];
+                }
+                if (enemy && friendly) {
                     return [
                         'destroy all enemy creatures except ',
                         enemy,
                         ' and all friendly creatures except ',
                         friendly
                     ];
-                if (enemy) return ['destroy all enemy creatures except ', enemy, '', ''];
+                }
+                if (enemy) {
+                    return ['destroy all enemy creatures except ', enemy, '', ''];
+                }
                 return ['destroy all friendly creatures except ', friendly, '', ''];
             }
         });

--- a/server/game/cards/14-DM/ColdRopes.js
+++ b/server/game/cards/14-DM/ColdRopes.js
@@ -37,7 +37,9 @@ class ColdRopes extends Card {
                           message: '{0} uses {1} to move {3} to the {4} flank and exhaust it',
                           messageArgs: () => {
                               const t = preThenContext.target;
-                              if (!t) return [];
+                              if (!t) {
+                                  return [];
+                              }
                               const inPlay = t.controller.cardsInPlay;
                               const side =
                                   inPlay.length <= 1 || inPlay.indexOf(t) === 0 ? 'left' : 'right';

--- a/server/scripts/fetchdata/KeyForgeHalfSizeBuild.js
+++ b/server/scripts/fetchdata/KeyForgeHalfSizeBuild.js
@@ -65,9 +65,13 @@ const buildHalfSize = async (card, imgPath, filename, language) => {
     const canvasFinal = new fabric.StaticCanvas(null, { width: 300, height: 262.5 });
     canvasFinal.renderOnAddRemove = false;
     let framePath = assetsPath + `/${card.house}_Frame`;
-    if (card.type === 'upgrade') framePath += '_b';
-    else if (card.type.includes('creature')) framePath += '_c';
-    else if (card.type === 'action') framePath += '_c';
+    if (card.type === 'upgrade') {
+        framePath += '_b';
+    } else if (card.type.includes('creature')) {
+        framePath += '_c';
+    } else if (card.type === 'action') {
+        framePath += '_c';
+    }
     framePath += '.png';
 
     const frame = await loadImage(`file://${framePath}`);
@@ -87,7 +91,9 @@ const buildHalfSize = async (card, imgPath, filename, language) => {
     canvas.add(artCanvas);
     canvas.renderAll();
     const finalArt = new fabric.Image(canvas.toCanvasElement(), { left: 150, originX: 'center' });
-    if (card.type === 'upgrade') finalArt.set({ top: 19 });
+    if (card.type === 'upgrade') {
+        finalArt.set({ top: 19 });
+    }
     canvasFinal.add(finalArt);
     canvasFinal.add(frame);
     canvasFinal.add(frame);
@@ -331,7 +337,9 @@ const getCircularText = (text = '', diameter, yOffset = 0) => {
 };
 
 const getCurvedFontSize = (length) => {
-    if (length < 20) return 20;
+    if (length < 20) {
+        return 20;
+    }
     return (20 / length) * 20;
 };
 

--- a/server/scripts/generatecards/CardGenerator.js
+++ b/server/scripts/generatecards/CardGenerator.js
@@ -128,8 +128,11 @@ class CardGenerator {
                 var str = env.render(this.template, data);
                 ensureDirectoryExistence(filename);
                 fs.writeFileSync(filename, str);
-                if (complete) a.complete++;
-                else a.partial++;
+                if (complete) {
+                    a.complete++;
+                } else {
+                    a.partial++;
+                }
             } catch (err) {
                 console.log(`Failure when generating code from parsed abilities for ${card.id}`);
                 console.log(JSON.stringify(data.abilities, null, 1));
@@ -181,8 +184,9 @@ class CardGenerator {
 }
 
 function replacer(key, value) {
-    if (value === null || value === false || (Array.isArray(value) && value.length == 0))
+    if (value === null || value === false || (Array.isArray(value) && value.length == 0)) {
         return undefined;
+    }
     return value;
 }
 
@@ -316,9 +320,13 @@ function filteredController(refs, filteredController = true) {
 }
 
 function findEventListeners(abilities) {
-    if (abilities === null || typeof abilities !== 'object') return [];
+    if (abilities === null || typeof abilities !== 'object') {
+        return [];
+    }
     let listeners = Object.values(abilities).flatMap(findEventListeners);
-    if (abilities.name === 'eventCount') listeners.push(abilities.action);
+    if (abilities.name === 'eventCount') {
+        listeners.push(abilities.action);
+    }
     return _.uniq(listeners);
 }
 

--- a/server/scripts/json-data-to-card-comments.js
+++ b/server/scripts/json-data-to-card-comments.js
@@ -50,7 +50,9 @@ const cardDir = path.join(cardsRoot, folder);
 const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
 const byId = new Map();
 for (const c of data.cards) {
-    if (!byId.has(c.id)) byId.set(c.id, c);
+    if (!byId.has(c.id)) {
+        byId.set(c.id, c);
+    }
 }
 
 // PUA bonus-icon code points → plain word.
@@ -182,9 +184,15 @@ console.log(`  Updated:        ${results.updated.length}`);
 console.log(`  Unchanged:      ${results.unchanged.length}`);
 console.log(`  Skipped:        ${results.skipped.length}`);
 console.log(`  Missing in JSON:${results.missing.length}`);
-if (!flags.has('--write')) console.log('(dry run — re-run with --write to apply)');
-if (results.skipped.length) console.log('SKIPPED:\n  ' + results.skipped.join('\n  '));
-if (results.missing.length) console.log('MISSING:\n  ' + results.missing.join('\n  '));
+if (!flags.has('--write')) {
+    console.log('(dry run — re-run with --write to apply)');
+}
+if (results.skipped.length) {
+    console.log('SKIPPED:\n  ' + results.skipped.join('\n  '));
+}
+if (results.missing.length) {
+    console.log('MISSING:\n  ' + results.missing.join('\n  '));
+}
 if (flags.has('--list') && results.updated.length) {
     console.log('UPDATED:\n  ' + results.updated.join('\n  '));
 }


### PR DESCRIPTION
Enforces the ESLint `curly` rule (`['error', 'all']`) to ensure all control statements use curly braces, and updates violating single-line conditionals across client, server, and scripting files.

### Key Changes
- **ESLint Configuration**: Enabled `'curly': ['error', 'all']` in `.eslintrc.js`.
- **Client Components**: Updated conditional statements in card menu subscription helpers within `client/Components/GameBoard/Card.jsx`.
- **Scenario Devtools**: Formatted conditional exits, loop flows, and filter conditions in `server/devtools/scenario/cli.js` and `server/devtools/scenario/runner.js`.
- **Game Engine & Card Logic**: Updated conditionals in `GainsTextBoxAction.js`, `ChampionsChallenge.js` (Core), `SavageClash.js` (MM), and `ColdRopes.js` (DM).
- **Scripts**: Refactored conditional checks in asset building (`KeyForgeHalfSizeBuild.js`), card generation (`CardGenerator.js`), and comment generation (`json-data-to-card-comments.js`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style-only edits with no intended logic changes; risk is limited to accidental brace mistakes, which the diff does not suggest.
> 
> **Overview**
> Adds ESLint **`curly: ['error', 'all']`** in `.eslintrc.js` so every `if`, `continue`, and similar control flow must use block braces.
> 
> Existing single-line conditionals are updated across the repo to satisfy the rule—**client** (`Card.jsx`), **scenario devtools** (`cli.js`, `runner.js`), **game logic** (`GainsTextBoxAction.js`, card `effectArgs` in Champions Challenge / Savage Clash / Cold Ropes), and **build scripts** (half-size images, card generator, JSON comment sync). **Behavior is unchanged**; this is formatting and lint compliance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a446ef49b60624b1d12570715738a22b0aa733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->