### PR TITLE
fix(decks): ui tweaks for deck selection modal

### DIFF
--- a/client/Components/Decks/DeckList.jsx
+++ b/client/Components/Decks/DeckList.jsx
@@ -1,18 +1,24 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+    faCheck,
+    faFileImport,
+    faPlus,
+    faRefresh,
+    faTrash
+} from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@heroui/react';
+import debounce from 'lodash.debounce';
 import moment from 'moment';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import debounce from 'lodash.debounce';
-import { Input } from '@heroui/react';
 import Icon from '../Icon';
-import { faCheck, faFileImport, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 
+import { Constants } from '../../constants';
+import { useGetDecksQuery, useGetStandaloneDecksQuery } from '../../redux/api';
+import { cardsActions } from '../../redux/slices/cardsSlice';
+import ReactTable from '../Table/ReactTable';
 import CardBack from './CardBack';
 import DeckSetFilter from './DeckSetFilter';
-import ReactTable from '../Table/ReactTable';
-import { cardsActions } from '../../redux/slices/cardsSlice';
-import { useGetDecksQuery, useGetStandaloneDecksQuery } from '../../redux/api';
-import { Constants } from '../../constants';
 
 /**
  * @typedef DeckListProps
@@ -59,7 +65,9 @@ const DeckList = ({
     const [activeFilters, setActiveFilters] = useState(
         deckFilter ? Object.entries(deckFilter).map(normalizeFilterEntry) : []
     );
+    const [isRefreshing, setIsRefreshing] = useState(false);
     const nameFilterValue = useRef('');
+    const refetchRef = useRef(null);
 
     const decks = useSelector((state) =>
         standaloneDecks ? state.cards.standaloneDecks : state.cards.decks
@@ -306,8 +314,8 @@ const DeckList = ({
     return (
         <div className='flex h-full min-h-0 flex-col pt-4'>
             {!standaloneDecks ? (
-                <div className='mb-3 grid gap-3 lg:grid-cols-2'>
-                    <div>
+                <div className='mb-3 flex items-end gap-3'>
+                    <div className='min-w-0 flex-1'>
                         <label className='mb-1 block text-sm text-foreground'>{t('Name')}</label>
                         <Input
                             className='w-full'
@@ -320,13 +328,30 @@ const DeckList = ({
                             }}
                         />
                     </div>
-                    <DeckSetFilter
-                        expansions={expansions}
-                        label={t('Expansion')}
-                        selectedExpansions={selectedExpansions}
-                        t={t}
-                        onChange={onSetsChange}
-                    />
+                    <div className='min-w-0 flex-1'>
+                        <DeckSetFilter
+                            expansions={expansions}
+                            label={t('Expansion')}
+                            selectedExpansions={selectedExpansions}
+                            t={t}
+                            onChange={onSetsChange}
+                        />
+                    </div>
+                    {shouldUseRemoteDecks ? (
+                        <Button
+                            className='shrink-0'
+                            isIconOnly
+                            size='md'
+                            variant='tertiary'
+                            onPress={() => {
+                                setIsRefreshing(true);
+                                refetchRef.current?.();
+                                setTimeout(() => setIsRefreshing(false), 500);
+                            }}
+                        >
+                            <Icon icon={faRefresh} className={isRefreshing ? 'animate-spin' : ''} />
+                        </Button>
+                    ) : null}
                 </div>
             ) : null}
 
@@ -348,6 +373,7 @@ const DeckList = ({
                     isStriped
                     maxVisibleRows={15}
                     pageSizeOptions={[15, 25, 50]}
+                    refetchRef={refetchRef}
                     remote={shouldUseRemoteDecks}
                     defaultSort={[{ id: 'lastUpdated', desc: true }]}
                     selectedRows={selectedRows}

--- a/client/Components/Decks/DeckList.jsx
+++ b/client/Components/Decks/DeckList.jsx
@@ -314,7 +314,7 @@ const DeckList = ({
     return (
         <div className='flex h-full min-h-0 flex-col pt-4'>
             {!standaloneDecks ? (
-                <div className='mb-3 flex items-end gap-3'>
+                <div className='mb-3 flex items-end gap-3 px-1'>
                     <div className='min-w-0 flex-1'>
                         <label className='mb-1 block text-sm text-foreground'>{t('Name')}</label>
                         <Input

--- a/client/Components/Table/ReactTable.jsx
+++ b/client/Components/Table/ReactTable.jsx
@@ -1,21 +1,21 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import {
-    Button,
-    Checkbox,
-    Input,
-    ListBox,
-    Popover,
-    Select,
-    Spinner,
-    Pagination,
-    Table
-} from '@heroui/react';
 import {
     faArrowDownWideShort,
     faArrowUpShortWide,
     faFilter,
     faRefresh
 } from '@fortawesome/free-solid-svg-icons';
+import {
+    Button,
+    Checkbox,
+    Input,
+    ListBox,
+    Pagination,
+    Popover,
+    Select,
+    Spinner,
+    Table
+} from '@heroui/react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import Icon from '../Icon';
 import AlertPanel from '../Site/AlertPanel';
@@ -190,6 +190,7 @@ function ReactTable({
     onRowClick,
     onRowSelectionChange,
     pageSizeOptions = [10, 25, 50],
+    refetchRef,
     remote = false,
     getRowClassName,
     selectedRows,
@@ -259,6 +260,10 @@ function ReactTable({
     const isLoading = remote ? queryResult?.isLoading : localIsLoading;
     const isError = remote ? queryResult?.isError : localIsError;
     const refetch = remote ? queryResult?.refetch || onRefresh : onRefresh;
+
+    if (refetchRef) {
+        refetchRef.current = refetch;
+    }
 
     const remoteRows = remote ? response?.[dataProperty] || [] : [];
     const localRows = remote ? [] : data || [];

--- a/client/Components/Table/ReactTable.jsx
+++ b/client/Components/Table/ReactTable.jsx
@@ -442,7 +442,7 @@ function ReactTable({
                             </span>
                         </Button>
                     ))}
-                    {refetch ? (
+                    {refetch && !refetchRef ? (
                         <Button isIconOnly size='md' variant='tertiary' onPress={() => refetch()}>
                             <Icon icon={faRefresh} />
                         </Button>
@@ -450,7 +450,7 @@ function ReactTable({
                 </div>
             </div>
         ),
-        [buttons, refetch]
+        [buttons, refetch, refetchRef]
     );
 
     if (isLoading) {


### PR DESCRIPTION
Small tweaks to the deck selection modal - fix clipping of the search box, and put the refresh button inline, and have it rotate on click.

### Key Changes

- **Expose Table Refetch Function**: Added a `refetchRef` prop to `ReactTable` that captures the internal `refetch` function (mapping to either RTK Query's `refetch` or the `onRefresh` prop) and assigns it to `refetchRef.current`.
- **Manual Refresh Action**: Integrated a new refetch button in the `DeckList` component, conditionally rendered when `shouldUseRemoteDecks` is enabled. Clicking the button triggers the table refetch and shows a temporary `animate-spin` animation on the refresh icon for 500ms.
- **Layout Refinement**: Updated the `DeckList` filter container from a grid to a flexbox container (`flex items-end gap-3`) to accommodate the new refresh button cleanly next to search and expansion filter dropdowns.
- **Import Cleanup**: Reorganized and grouped imports in both `DeckList.jsx` and `ReactTable.jsx` for better code readability and consistency.

Current - notice the clipping on the left side of the text box and the whole row for the refresh button:
<img width="1061" height="304" alt="image" src="https://github.com/user-attachments/assets/41b965d9-6972-4ebb-9229-d6870b0ea002" />

Updated:
<img width="1061" height="401" alt="image" src="https://github.com/user-attachments/assets/cbe522e4-28ac-4bf3-a9d0-d1fa80941403" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and a small ref-based refetch hook; no auth or data-model changes beyond reusing existing remote deck queries.
> 
> **Overview**
> The deck selection modal’s **name/expansion filters** now use a horizontal **flex** row with `min-w-0 flex-1` on each field so the search input doesn’t clip, and a **refresh** control sits inline when remote decks are loaded.
> 
> **`ReactTable`** gains an optional **`refetchRef`** that receives the same `refetch` used internally (RTK Query or `onRefresh`). When `refetchRef` is provided, the table’s built-in toolbar refresh button is **hidden** so parents can place their own control.
> 
> **`DeckList`** wires that ref to an icon button that calls refetch and briefly applies **`animate-spin`** on the icon (500ms). Import ordering is cleaned up in both files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4011cb67c38871208a83336ed8e8c43da257d45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->