### PR TITLE
fix: Blorb incorrect retrieval (#5160)

### DIFF
--- a/server/game/cards/06-WoE/Blorb.js
+++ b/server/game/cards/06-WoE/Blorb.js
@@ -14,6 +14,7 @@ class Blorb extends Card {
                 cardType: 'artifact',
                 cardCondition: (card) => card.name === 'Blorb Hive',
                 location: 'discard',
+                controller: 'self',
                 gameAction: ability.actions.returnToHand({
                     location: 'discard'
                 })

--- a/test/server/cards/06-WoE/Blorb.spec.js
+++ b/test/server/cards/06-WoE/Blorb.spec.js
@@ -42,4 +42,30 @@ describe('Blorb', function () {
             expect(this.toad.location).toBe('discard');
         });
     });
+
+    describe("Stolen Blorb's destruction", function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    token: 'blorb',
+                    house: 'mars',
+                    inPlay: ['blorb:toad', 'blypyp']
+                },
+                player2: {
+                    amber: 5,
+                    token: 'blorb',
+                    inPlay: ['troll'],
+                    discard: ['blorb-hive']
+                }
+            });
+
+            this.toad = this.blorb;
+        });
+
+        it('should not return blorb-hive from the opponents discard pile', function () {
+            this.player1.fightWith(this.blorb, this.troll);
+            this.player1.clickCard(this.blorbHive);
+            expect(this.blorbHive.location).toBe('discard');
+        });
+    });
 });

--- a/test/server/cards/06-WoE/Blorb.spec.js
+++ b/test/server/cards/06-WoE/Blorb.spec.js
@@ -20,6 +20,8 @@ describe('Blorb', function () {
         it('should not be able to reap', function () {
             this.player1.clickCard(this.blorb);
             expect(this.player1).not.toHavePrompt('Reap with this Creature');
+            this.player1.clickPrompt('Cancel');
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('should evaluate the destroyed ability without a selected target', function () {
@@ -33,6 +35,7 @@ describe('Blorb', function () {
                 gameActions = destroyedAbility.getGameActions(context);
             }).not.toThrow();
             expect(gameActions).toEqual([]);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('bring back Blorb Hive when destroyed', function () {
@@ -40,6 +43,7 @@ describe('Blorb', function () {
             this.player1.clickCard(this.blorbHive);
             expect(this.blorbHive.location).toBe('hand');
             expect(this.toad.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 
@@ -58,14 +62,13 @@ describe('Blorb', function () {
                     discard: ['blorb-hive']
                 }
             });
-
-            this.toad = this.blorb;
         });
 
         it('should not return blorb-hive from the opponents discard pile', function () {
             this.player1.fightWith(this.blorb, this.troll);
             this.player1.clickCard(this.blorbHive);
             expect(this.blorbHive.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });


### PR DESCRIPTION
The blorb destroyed affect now only checks the discard of the controller instead of any discard.