### PR TITLE
fix(client): implement half-size display for underneath cards

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -190,6 +190,7 @@ const Card = ({
                 cardSize={size}
                 cards={underneathCards}
                 className='underneath'
+                halfSize={halfSize}
                 maxCards={maxCards}
                 onCardClick={onClick}
                 onMouseOut={onMouseOut}

--- a/client/Components/GameBoard/CardImage.jsx
+++ b/client/Components/GameBoard/CardImage.jsx
@@ -174,6 +174,12 @@ const CardImage = ({ card, cardBack, size, halfSize, onMouseOver, onMouseOut }) 
     ]);
 
     if (card?.facedown) {
+        if (halfSize) {
+            // The .card-image.halfSize container clips overflow. The inner
+            // div maintains the cardback's natural 5:7 aspect ratio so the
+            // bottom is cropped rather than squished.
+            return <div className='half-size-cardback'>{cardBack || <div />}</div>;
+        }
         return cardBack || <div />;
     }
 

--- a/client/Components/GameBoard/SquishableCardPanel.jsx
+++ b/client/Components/GameBoard/SquishableCardPanel.jsx
@@ -24,10 +24,10 @@ const SquishableCardPanel = (props) => {
 
     const cardDimensions = useMemo(
         () => ({
-            width: 65 * cardSizeMultiplier,
-            height: 91 * cardSizeMultiplier
+            width: (props.halfSize ? 75 : 65) * cardSizeMultiplier,
+            height: (props.halfSize ? 75 * 0.875 : 91) * cardSizeMultiplier
         }),
-        [cardSizeMultiplier]
+        [cardSizeMultiplier, props.halfSize]
     );
 
     const overallDimensions = useMemo(
@@ -62,6 +62,7 @@ const SquishableCardPanel = (props) => {
                 cardBack={props.cardBack}
                 disableMouseOver={false}
                 canDrag={props.manualMode}
+                halfSize={props.halfSize}
                 onClick={props.onCardClick}
                 onMouseOver={props.onMouseOver}
                 onMouseOut={props.onMouseOut}
@@ -78,6 +79,7 @@ const SquishableCardPanel = (props) => {
 
     const className = classNames('squishable-card-panel', props.className, {
         [props.cardSize]: props.cardSize !== 'normal',
+        halfSize: props.halfSize,
         squish: needsSquish
     });
 
@@ -99,10 +101,12 @@ const SquishableCardPanel = (props) => {
 
 SquishableCardPanel.displayName = 'SquishableCardPanel';
 SquishableCardPanel.propTypes = {
+    cardBack: PropTypes.node,
     cardSize: PropTypes.string,
     cards: PropTypes.array,
     className: PropTypes.string,
     groupVisibleCards: PropTypes.bool,
+    halfSize: PropTypes.bool,
     manualMode: PropTypes.bool,
     maxCards: PropTypes.number,
     onCardClick: PropTypes.func,

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -488,6 +488,16 @@ pre {
     top: calc((var(--card-half-width) - var(--card-half-height)) / 2);
     border-radius: 10px;
 }
+.card-image.halfSize {
+    @apply overflow-hidden rounded-[inherit];
+}
+.half-size-cardback {
+    @apply block w-full;
+    aspect-ratio: 300 / 420;
+}
+.half-size-cardback > * {
+    @apply h-full w-full;
+}
 
 .card-name {
     font-size: 10px;
@@ -759,7 +769,6 @@ pre {
     --underneath-half-card-height: calc(
         var(--card-half-base-width) * var(--card-scale) * var(--card-half-aspect-ratio)
     );
-    margin-left: 0;
     position: relative;
     z-index: 9;
     margin-top: calc(-1 * (var(--underneath-card-height) - var(--underneath-offset)));
@@ -2113,13 +2122,15 @@ span.stat-digit {
 .squishable-card-panel {
     display: flex;
     justify-content: flex-start;
-    margin-left: 5px;
-    margin-right: 5px;
     min-height: 0;
     padding: 0px;
     position: relative;
 }
-.squishable-card-panel .card-wrapper {
+.squishable-card-panel.hand {
+    margin-left: 5px;
+    margin-right: 5px;
+}
+.squishable-card-panel.hand .card-wrapper {
     margin: 0 5px 0 0;
 }
 .squishable-card-panel.hand {

--- a/client/styles/tailwind.css
+++ b/client/styles/tailwind.css
@@ -597,6 +597,9 @@ pre {
 .game-card.new {
     --c-ring: #0dcaf0;
 }
+.underneath .game-card {
+    --c-ring: #0dcaf0;
+}
 .game-card.controlled {
     --c-ring: #ffdf14;
 }


### PR DESCRIPTION
Fixes #2703 

### Summary
Implements a half-size layout option for cards displayed underneath other cards. This ensures correct proportional scaling on the game board and prevents facedown cardback assets from squishing by preserving their natural aspect ratio and clipping the overflow.

Before:
<img width="557" height="458" alt="image" src="https://github.com/user-attachments/assets/bbc4b30a-39c9-40cf-ab7a-9391198f8039" />

After:
<img width="387" height="248" alt="image" src="https://github.com/user-attachments/assets/c99e73ee-c191-4683-9d2a-452046ecf9a7" />

### Key Changes
- **Card.jsx**: Passes the `halfSize` property to the `SquishableCardPanel` rendering `underneathCards`.
- **CardImage.jsx**: Wraps facedown cardbacks in a `.half-size-cardback` container when `halfSize` is active to maintain aspect ratio and support cropping.
- **SquishableCardPanel.jsx**:
  - Computes `cardDimensions` dynamically based on `halfSize` (adjusting baseline width to 75 and height to 65.625 instead of 65 and 91).
  - Appends the `halfSize` CSS class and forwards the prop to child cards.
  - Adds `halfSize` and `cardBack` to `propTypes`.
- **tailwind.css**:
  - Added `.card-image.halfSize` to clip overflow and inherit border-radius.
  - Added `.half-size-cardback` styling to enforce a `300 / 420` aspect ratio.
  - Scoped the general `margin-left` and `margin-right` rules under `.squishable-card-panel` specifically to `.squishable-card-panel.hand`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ad3d1ee6b889945191817f4ad60136c7334f4d70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->