### PR TITLE
feat(engine): introduce ReplaceDestructionAction for destruction replacement effects

### DIFF
--- a/docs/card-abilities.md
+++ b/docs/card-abilities.md
@@ -140,6 +140,8 @@ Triggered abilities that activate when the card is destroyed. These are implemen
 
 **Destruction timing.** When a card is destroyed it is first _tagged for destruction_ (its `moribund` flag is set to `true`) but it stays in play (`location === 'play area'`). All `destroyed()` abilities triggered by the same destruction window resolve while every tagged card is still in play. Only after the destroyed-ability window closes do the tagged cards move to discard via `onCardLeavesPlay`.
 
+**Destruction replacement ordering.** Replacement effects use `ability.actions.replaceDestruction()` to prevent a card's move to discard and execute alternative actions instead. All destroyed abilities (including replacements) resolve in normal player-chosen order. When `replaceDestruction` resolves, it marks the destroy event so the engine cancels it after all abilities complete — this guarantees that other destroyed abilities (e.g. Dust Imp's "Destroyed: Gain 2Æ") fire regardless of resolution order. Purifier of Souls naturally blocks replacements by preventing the destroyed ability from triggering at all.
+
 **Cascaded destructions.** When a `Destroyed:` ability causes further destructions (e.g. Soulkeeper's "Destroyed: destroy the most powerful enemy creature"), those cascaded destructions are **batched into the same destruction window** rather than opening a nested one. This means:
 
 -   The active player gets a single ordering prompt across the entire cascade
@@ -168,6 +170,64 @@ this.destroyed({
     gameAction: ability.actions.returnToHand()
 });
 ```
+
+#### Replacement effects (`replaceDestruction`)
+
+Some `Destroyed:` abilities act as **replacement effects** — they prevent the card's move to discard and do something else instead (e.g. heal it, give control to the opponent). Use `ability.actions.replaceDestruction()` as the `gameAction`:
+
+```javascript
+// Self-Bolstering Automata — Destroyed: Fully heal, exhaust, move to flank.
+this.destroyed({
+    condition: (context) => context.player.creaturesInPlay.length > 1,
+    gameAction: ability.actions.replaceDestruction({
+        gameAction: [
+            ability.actions.heal({ fully: true }),
+            ability.actions.exhaust(),
+            ability.actions.moveToFlank()
+        ]
+    })
+});
+```
+
+```javascript
+// Armageddon Cloak (upgrade) — Destroyed: Heal creature, destroy AC instead.
+this.whileAttached({
+    effect: ability.effects.gainAbility('destroyed', {
+        gameAction: ability.actions.replaceDestruction({
+            gameAction: [
+                ability.actions.heal({ fully: true }),
+                ability.actions.destroy({ target: this })
+            ]
+        })
+    })
+});
+```
+
+```javascript
+// Paradox Shield — in a `then` block, pass `event` explicitly.
+this.whileAttached({
+    effect: ability.effects.gainAbility('destroyed', {
+        gameAction: ability.actions.discard((context) => ({
+            target: context.source.controller.deck.slice(0, context.source.power)
+        })),
+        then: (preThenContext) => ({
+            alwaysTriggers: true,
+            condition: (context) => context.preThenEvents.length === preThenContext.source.power,
+            gameAction: ability.actions.replaceDestruction({
+                event: preThenContext.event,
+                gameAction: [
+                    ability.actions.heal({ fully: true }),
+                    ability.actions.destroy({ target: this })
+                ]
+            })
+        })
+    })
+});
+```
+
+Cards that use `replaceDestruction`: Armageddon Cloak, The Body Snatchers, Self-Bolstering Automata, Reassembling Automaton, Ley Earl of Hurl, Necromorph, Paradox Shield.
+
+**`event` property:** When `replaceDestruction` is used inside a `then` block, pass the leavesPlay event explicitly via the `event` property (captured from the parent context's `preThenContext.event`). In regular `destroyed()` abilities, `context.event` is used automatically.
 
 ### action()
 

--- a/server/game/GameActions.js
+++ b/server/game/GameActions.js
@@ -165,6 +165,8 @@ const Actions = {
     allocateCapture: (propertyFactory) => new GameActions.AllocateCaptureAction(propertyFactory),
     allocateDamage: (propertyFactory) => new GameActions.AllocateDamageAction(propertyFactory),
     changeEvent: (propertyFactory) => new GameActions.ChangeEventAction(propertyFactory),
+    replaceDestruction: (propertyFactory) =>
+        new GameActions.ReplaceDestructionAction(propertyFactory),
     chooseAction: (propertyFactory) => new GameActions.ChooseGameAction(propertyFactory), // choices, activePromptTitle = 'Select one'
     conditional: (propertyFactory) => new GameActions.ConditionalAction(propertyFactory),
     jointAction: (gameActions) => new GameActions.JointGameAction(gameActions), // takes an array of gameActions, not a propertyFactory

--- a/server/game/GameActions/ReplaceDestructionAction.js
+++ b/server/game/GameActions/ReplaceDestructionAction.js
@@ -1,0 +1,102 @@
+const { EVENTS } = require('../Events/types');
+const GameAction = require('./GameAction');
+
+/**
+ * Registers a destruction replacement for the current card.
+ *
+ * When used inside a `destroyed()` ability, this action:
+ *   1. Marks the destroy event as "replaced" so cancellation is deferred.
+ *   2. Stores the inner `gameAction` array on the DestroyedAbilityWindow
+ *      for deferred execution after all destroyed abilities resolve.
+ *
+ * The actual replacement actions (heal, exhaust, etc.) execute at
+ * "replacement time" — after every destroyed ability has resolved but
+ * before events are cancelled and cards move to discard. This ensures
+ * correct ordering: other destroyed abilities see the original board state.
+ */
+class ReplaceDestructionAction extends GameAction {
+    setDefaultProperties() {
+        this.gameAction = [];
+        this.event = null; // Optional: override for the leavesPlay event (needed in `then` blocks)
+    }
+
+    setup() {
+        this.name = 'replaceDestruction';
+        this.targetType = [];
+    }
+
+    setDefaultTarget(func) {
+        for (let action of this.gameAction) {
+            action.setDefaultTarget(func);
+        }
+    }
+
+    setTarget(target) {
+        for (let action of this.gameAction) {
+            action.setTarget(target);
+        }
+    }
+
+    update(context) {
+        super.update(context);
+        if (!Array.isArray(this.gameAction)) {
+            this.gameAction = [this.gameAction];
+        }
+        for (let action of this.gameAction) {
+            action.update(context);
+        }
+    }
+
+    preEventHandler(context) {
+        this.update(context);
+        for (let action of this.gameAction) {
+            action.preEventHandler(context);
+        }
+    }
+
+    hasLegalTarget(context) {
+        this.update(context);
+        return true;
+    }
+
+    canAffect(target, context) {
+        return this.gameAction.some((action) => action.canAffect(target, context));
+    }
+
+    getEventArray(context) {
+        // Determine the leavesPlay event — either explicitly passed (for
+        // `then` blocks) or from the ability context.
+        const leavesPlayEvent = this.event || context.event;
+
+        // Single event that marks the destruction as replaced and stores
+        // the pending replacement actions for deferred execution.
+        return [
+            super.createEvent(EVENTS.unnamedEvent, {}, () => {
+                if (leavesPlayEvent) {
+                    leavesPlayEvent.replacedByAction = true;
+                    const destroyEvent = leavesPlayEvent.triggeringEvent;
+                    if (destroyEvent) {
+                        destroyEvent.replaced = true;
+                        // Clear damage/fight flags so "destroyed this way"
+                        // checks (e.g. Throwing Stars) exclude replaced cards.
+                        destroyEvent.destroyedByDamageDealt = false;
+                        destroyEvent.destroyedFighting = false;
+                    }
+                }
+
+                // Store the pending replacement on the destruction window
+                // for deferred execution after all abilities resolve.
+                const window = context.game.currentDestructionWindow;
+                if (window) {
+                    window.pendingReplacements.push({
+                        actions: this.gameAction,
+                        context: context,
+                        leavesPlayEvent: leavesPlayEvent
+                    });
+                }
+            })
+        ];
+    }
+}
+
+module.exports = ReplaceDestructionAction;

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -68,6 +68,7 @@ module.exports = {
     RemoveTokenAction: require('./RemoveTokenAction'),
     RemoveAllTokensAction: require('./RemoveAllTokensAction'),
     RemoveWardAction: require('./RemoveWardAction'),
+    ReplaceDestructionAction: require('./ReplaceDestructionAction'),
     ResolveAbilityAction: require('./ResolveAbilityAction'),
     ResolveBonusIconsAction: require('./ResolveBonusIconsAction'),
     ResolveFateAction: require('./ResolveFateAction'),

--- a/server/game/cards/01-Core/ArmageddonCloak.js
+++ b/server/game/cards/01-Core/ArmageddonCloak.js
@@ -9,20 +9,12 @@ class ArmageddonCloak extends Card {
                 ability.effects.gainAbility('destroyed', {
                     effect: 'heal all damage from {0} and destroy {1} instead',
                     effectArgs: () => this,
-                    gameAction: [
-                        ability.actions.heal({ fully: true }),
-                        ability.actions.changeEvent((context) => ({
-                            event: context.event,
-                            card: this,
-                            postHandler: (context) => (context.source.moribund = false)
-                        })),
-                        ability.actions.changeEvent((context) => ({
-                            event: context.event.triggeringEvent,
-                            destroyedByDamageDealt: false,
-                            destroyedFighting: false,
-                            card: this
-                        }))
-                    ]
+                    gameAction: ability.actions.replaceDestruction({
+                        gameAction: [
+                            ability.actions.heal({ fully: true }),
+                            ability.actions.destroy({ target: this })
+                        ]
+                    })
                 })
             ]
         });

--- a/server/game/cards/03-WC/ReassemblingAutomaton.js
+++ b/server/game/cards/03-WC/ReassemblingAutomaton.js
@@ -7,20 +7,13 @@ class ReassemblingAutomaton extends Card {
             condition: (context) => context.player.creaturesInPlay.length > 1,
             effect: 'heal all damage from {0}, exhaust it and move it to a flank',
             effectArgs: () => this,
-            gameAction: [
-                ability.actions.heal({ fully: true }),
-                ability.actions.exhaust(),
-                ability.actions.moveToFlank(),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event,
-                    cancel: true,
-                    postHandler: (context) => (context.source.moribund = false)
-                })),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event.triggeringEvent,
-                    cancel: true
-                }))
-            ]
+            gameAction: ability.actions.replaceDestruction({
+                gameAction: [
+                    ability.actions.heal({ fully: true }),
+                    ability.actions.exhaust(),
+                    ability.actions.moveToFlank()
+                ]
+            })
         });
     }
 }

--- a/server/game/cards/03-WC/SelfBolsteringAutomata.js
+++ b/server/game/cards/03-WC/SelfBolsteringAutomata.js
@@ -12,25 +12,18 @@ class SelfBolsteringAutomata extends Card {
             },
             effect: 'heal all damage from {0}, exhaust it and move it to a flank',
             effectArgs: () => this,
-            gameAction: [
-                ability.actions.heal({ fully: true }),
-                ability.actions.exhaust(),
-                ability.actions.moveToFlank(),
-                // "If you do" - add counters only if exhaust and heal succeeded
-                ability.actions.conditional({
-                    condition: (context) => context.wasReady && context.hadDamage,
-                    trueGameAction: ability.actions.addPowerCounter({ amount: 2 })
-                }),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event,
-                    cancel: true,
-                    postHandler: (context) => (context.source.moribund = false)
-                })),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event.triggeringEvent,
-                    cancel: true
-                }))
-            ]
+            gameAction: ability.actions.replaceDestruction({
+                gameAction: [
+                    ability.actions.heal({ fully: true }),
+                    ability.actions.exhaust(),
+                    ability.actions.moveToFlank(),
+                    // "If you do" - add counters only if exhaust and heal succeeded
+                    ability.actions.conditional({
+                        condition: (context) => context.wasReady && context.hadDamage,
+                        trueGameAction: ability.actions.addPowerCounter({ amount: 2 })
+                    })
+                ]
+            })
         });
     }
 }

--- a/server/game/cards/07-GR/Necromorph.js
+++ b/server/game/cards/07-GR/Necromorph.js
@@ -13,20 +13,12 @@ class Necromorph extends Card {
             },
             effect: 'heal all damage from {1} and destroy {0} instead',
             effectArgs: () => this,
-            gameAction: [
-                ability.actions.heal({ fully: true }),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event,
-                    card: this,
-                    postHandler: (context) => (context.source.moribund = false)
-                })),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event.triggeringEvent,
-                    destroyedByDamageDealt: false,
-                    destroyedFighting: false,
-                    card: context.target
-                }))
-            ]
+            gameAction: ability.actions.replaceDestruction({
+                gameAction: [
+                    ability.actions.heal({ fully: true }),
+                    ability.actions.destroy((context) => ({ target: context.target }))
+                ]
+            })
         });
     }
 }

--- a/server/game/cards/07-GR/ParadoxShield.js
+++ b/server/game/cards/07-GR/ParadoxShield.js
@@ -17,20 +17,13 @@ class ParadoxShield extends Card {
                         alwaysTriggers: true,
                         condition: (context) =>
                             context.preThenEvents.length === preThenContext.source.power,
-                        gameAction: [
-                            ability.actions.heal({ fully: true }),
-                            ability.actions.changeEvent({
-                                event: preThenContext.event,
-                                card: this,
-                                postHandler: (context) => (context.source.moribund = false)
-                            }),
-                            ability.actions.changeEvent({
-                                event: preThenContext.event.triggeringEvent,
-                                destroyedByDamageDealt: false,
-                                destroyedFighting: false,
-                                card: this
-                            })
-                        ]
+                        gameAction: ability.actions.replaceDestruction({
+                            event: preThenContext.event,
+                            gameAction: [
+                                ability.actions.heal({ fully: true }),
+                                ability.actions.destroy({ target: this })
+                            ]
+                        })
                     })
                 })
             ]

--- a/server/game/cards/07-GR/TheBodySnatchers.js
+++ b/server/game/cards/07-GR/TheBodySnatchers.js
@@ -13,18 +13,17 @@ class TheBodySnatchers extends Card {
                 effect: ability.effects.gainAbility('destroyed', {
                     effect: 'heal all damage from {0} and give control to {1}',
                     effectArgs: (context) => context.source.controller.opponent,
-                    gameAction: [
-                        ability.actions.heal({ fully: true }),
-                        ability.actions.changeEvent((context) => ({
-                            event: context.event,
-                            cancel: true,
-                            postHandler: (context) => (context.source.moribund = false)
-                        })),
-                        ability.actions.cardLastingEffect((context) => ({
-                            duration: 'lastingEffect',
-                            effect: ability.effects.takeControl(context.source.controller.opponent)
-                        }))
-                    ]
+                    gameAction: ability.actions.replaceDestruction({
+                        gameAction: [
+                            ability.actions.heal({ fully: true }),
+                            ability.actions.cardLastingEffect((context) => ({
+                                duration: 'lastingEffect',
+                                effect: ability.effects.takeControl(
+                                    context.source.controller.opponent
+                                )
+                            }))
+                        ]
+                    })
                 })
             })
         });

--- a/server/game/cards/08-AS/LeyEarlOfHurl.js
+++ b/server/game/cards/08-AS/LeyEarlOfHurl.js
@@ -8,21 +8,14 @@ class LeyEarlOfHurl extends Card {
             condition: (context) => !context.source.isOnFlank(),
             effect: 'heal all damage from {0}, exhaust it, ward it and move it to a flank',
             effectArgs: () => this,
-            gameAction: [
-                ability.actions.heal({ fully: true }),
-                ability.actions.exhaust(),
-                ability.actions.ward(),
-                ability.actions.moveToFlank(),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event,
-                    cancel: true,
-                    postHandler: (context) => (context.source.moribund = false)
-                })),
-                ability.actions.changeEvent((context) => ({
-                    event: context.event.triggeringEvent,
-                    cancel: true
-                }))
-            ]
+            gameAction: ability.actions.replaceDestruction({
+                gameAction: [
+                    ability.actions.heal({ fully: true }),
+                    ability.actions.exhaust(),
+                    ability.actions.ward(),
+                    ability.actions.moveToFlank()
+                ]
+            })
         });
     }
 }

--- a/server/game/gamesteps/DestroyedAbilityWindow.js
+++ b/server/game/gamesteps/DestroyedAbilityWindow.js
@@ -34,6 +34,9 @@ class DestroyedTriggeredAbilityWindow extends ForcedTriggeredAbilityWindow {
         // Snapshot of choices after each resolution. addChoice rejects
         // any (ability, event) pair not in this set.
         this.lockedInChoices = [];
+        // Replacement actions stored by ReplaceDestructionAction during
+        // ability resolution. Executed after all abilities resolve.
+        this.pendingReplacements = [];
     }
 
     addChoice(context) {
@@ -81,10 +84,104 @@ class DestroyedTriggeredAbilityWindow extends ForcedTriggeredAbilityWindow {
         // future iterations enforce the lock-in.
         this.newlyTaggedLeavesPlayEvents.clear();
         if (result) {
+            if (this.pendingReplacements.length > 0) {
+                // Keep the window active so replacement-caused destructions
+                // (e.g. AC destroying itself) batch into this window.
+                this.game.currentDestructionWindow = this;
+                this.executeReplacementActions();
+                this.pendingReplacements = [];
+                return false; // stay in pipeline; queued steps run first
+            }
+            // No more replacements or cascaded triggers — clean up.
             this.game.currentDestructionWindow = null;
+            this.cancelReplacedEvents();
             this.discardAllTaggedCards();
         }
         return result;
+    }
+
+    // Execute pending replacement actions, deduplicating per-event.
+    // If multiple replacements target the same leavesPlayEvent (same card),
+    // the player picks one and the others expire.
+    executeReplacementActions() {
+        // Group by leavesPlayEvent — only one replacement per destruction.
+        const byEvent = new Map();
+        for (const replacement of this.pendingReplacements) {
+            const key = replacement.leavesPlayEvent;
+            if (!byEvent.has(key)) {
+                byEvent.set(key, []);
+            }
+            byEvent.get(key).push(replacement);
+        }
+
+        for (const [, replacements] of byEvent) {
+            if (replacements.length === 1) {
+                this.openReplacementEventWindow(replacements[0]);
+            } else {
+                this.promptForReplacementChoice(replacements);
+            }
+        }
+    }
+
+    openReplacementEventWindow(replacement) {
+        const events = [];
+        for (const action of replacement.actions) {
+            // Re-update targets from the stored context. The action
+            // instances may be shared (e.g. gainAbility granting the
+            // same destroyed ability to multiple creatures), so the
+            // last ability to resolve would have overwritten targets.
+            action.update(replacement.context);
+            events.push(...action.getEventArray(replacement.context));
+        }
+        if (events.length > 0) {
+            this.game.openEventWindow(events);
+        }
+    }
+
+    promptForReplacementChoice(replacements) {
+        const player = replacements[0].context.player;
+        const card = replacements[0].leavesPlayEvent.card;
+        const choices = replacements.map((r) => {
+            const grantedBy = r.context.ability.grantedBy;
+            return grantedBy ? grantedBy.name : r.context.source.name;
+        });
+        const handlers = replacements.map((r) => () => this.openReplacementEventWindow(r));
+        this.game.promptWithHandlerMenu(player, {
+            activePromptTitle: {
+                text: 'Choose which replacement effect to apply to {{card}}',
+                values: { card: card.name }
+            },
+            source: card,
+            choices: choices,
+            handlers: handlers
+        });
+    }
+
+    // Cancel leavesPlay and destroy events marked by ReplaceDestructionAction.
+    // Handles both the events in the parent EventWindow (non-batched)
+    // and batched cascaded events. Runs after all abilities resolve so
+    // cancellation doesn't interfere with other triggered abilities.
+    cancelReplacedEvents() {
+        // Non-batched events (in the parent EventWindow)
+        for (const event of this.eventWindow.event.getSimultaneousEvents()) {
+            if (event.replacedByAction) {
+                event.cancel();
+                event.card.moribund = false;
+                if (event.triggeringEvent) {
+                    event.triggeringEvent.cancel();
+                }
+            }
+        }
+        // Batched cascaded events
+        for (const destroyEvent of this.batchedDestroyEvents) {
+            if (destroyEvent.replaced) {
+                destroyEvent.cancel();
+                destroyEvent.card.moribund = false;
+                if (destroyEvent.leavesPlayEvent) {
+                    destroyEvent.leavesPlayEvent.cancel();
+                }
+            }
+        }
     }
 
     // Extends the base emitEvents to also emit for batched cascaded
@@ -127,10 +224,10 @@ class DestroyedTriggeredAbilityWindow extends ForcedTriggeredAbilityWindow {
     }
 
     // Move all tagged cards to discard now that abilities have resolved.
-    // Skips cancelled events (replacement effects) and cards already moved
-    // out of play mid-window. Attaches each destroy event as a child of
-    // the parent so the outer EventWindow's reaction phase sees the full
-    // cascade as one grouped trigger.
+    // Skips replaced/cancelled events and cards already moved out of play
+    // mid-window. Attaches each destroy event as a child of the parent so
+    // the outer EventWindow's reaction phase sees the full cascade as one
+    // grouped trigger.
     discardAllTaggedCards() {
         if (this.batchedDestroyEvents.size === 0) {
             return;
@@ -141,8 +238,7 @@ class DestroyedTriggeredAbilityWindow extends ForcedTriggeredAbilityWindow {
             leavesPlayEvents.length > 0 ? leavesPlayEvents[0].triggeringEvent : null;
 
         for (const destroyEvent of this.batchedDestroyEvents) {
-            // Skip events cancelled by an "instead" replacement effect.
-            if (destroyEvent.cancelled) {
+            if (destroyEvent.replaced || destroyEvent.cancelled) {
                 continue;
             }
             if (parentDestroyedEvent) {

--- a/test/server/abilities/destroy.spec.js
+++ b/test/server/abilities/destroy.spec.js
@@ -308,3 +308,80 @@ describe('Destroyed: ability window', function () {
         });
     });
 });
+
+describe('Armageddon Cloak - Replacement Effect Timing', function () {
+    describe('when attached creature has a Destroyed: ability', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'sanctum',
+                    inPlay: ['dust-imp'],
+                    hand: ['armageddon-cloak']
+                },
+                player2: {
+                    inPlay: ['troll']
+                }
+            });
+        });
+
+        it('should resolve Dust Imp Destroyed: ability before the replacement effect prevents discard', function () {
+            this.player1.player.optionSettings.orderForcedAbilities = false;
+            this.player2.player.optionSettings.orderForcedAbilities = false;
+            this.player1.playUpgrade(this.armageddonCloak, this.dustImp);
+            this.player1.endTurn();
+            this.player2.clickPrompt('brobnar');
+            this.player2.fightWith(this.troll, this.dustImp);
+            // Dust Imp's "Destroyed: Gain 2A" should always resolve
+            // player1 has 1 amber from AC's bonus icon + 2 from Dust Imp = 3
+            expect(this.player1.amber).toBe(3);
+            // AC replacement heals Dust Imp and destroys AC instead
+            expect(this.dustImp.location).toBe('play area');
+            expect(this.dustImp.damage).toBe(0);
+            expect(this.dustImp.moribund).toBe(false);
+            expect(this.armageddonCloak.location).toBe('discard');
+            expect(this.player2).isReadyToTakeAction();
+        });
+    });
+});
+
+describe('The Body Snatchers - Replacement Effect Timing', function () {
+    describe('when destroyed creature has its own Destroyed: ability', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    house: 'mars',
+                    hand: ['the-body-snatchers'],
+                    inPlay: ['tunk']
+                },
+                player2: {
+                    inPlay: ['dust-imp']
+                }
+            });
+            this.player1.play(this.theBodySnatchers);
+        });
+
+        it('should resolve Dust Imp Destroyed: ability even when Body Snatchers resolves first', function () {
+            this.player1.player.optionSettings.orderForcedAbilities = false;
+            this.player2.player.optionSettings.orderForcedAbilities = false;
+            this.player1.fightWith(this.tunk, this.dustImp);
+            // Body Snatchers replacement resolves after Dust Imp's ability,
+            // prompting for flank placement
+            this.player1.clickPrompt('Left');
+            // Dust Imp's "Destroyed: Gain 2A" should still resolve for the original controller
+            expect(this.player2.amber).toBe(2);
+            // Body Snatchers replacement heals and gives control to opponent (player1)
+            expect(this.dustImp.location).toBe('play area');
+            expect(this.dustImp.damage).toBe(0);
+            expect(this.player1.player.creaturesInPlay).toContain(this.dustImp);
+            expect(this.player1).isReadyToTakeAction();
+        });
+    });
+});
+
+// TODO: purifier of souls
+// TODO: Necromorph:
+//  So that would also mean multiple destruction replacments can't fully resolve, bc after the first one has been replaced, there is no more tag for destruction for the second one to replace?
+// What happens in this situation if necromorph's neighbor is warded? Does the ward just pop from attempt to leave play? But it should get through invulnerable.
+// What if the neighbor is body snatched? Can you resolve necromorph onto the neighbor, then resolve body snatchers on the neighbor to take control, and then the neighbor is moved to the discard and that counts?
+// Also the necromorphed creature does not count towards tolas/neffru/amara as a destroyed creature?
+// Away Team to remove AC

--- a/test/server/cards/07-GR/Necromorph.spec.js
+++ b/test/server/cards/07-GR/Necromorph.spec.js
@@ -18,8 +18,9 @@ describe('Necromorph', function () {
             this.player1.clickCard(this.huntingWitch);
             expect(this.player1).isReadyToTakeAction();
             expect(this.necromorph.location).toBe('play area');
-            expect(this.huntingWitch.location).toBe('discard');
+            expect.soft(this.huntingWitch.location).toBe('discard');
             expect(this.troll.damage).toBe(5);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('heals instead of getting destroyed', function () {
@@ -31,6 +32,7 @@ describe('Necromorph', function () {
             expect(this.player1).isReadyToTakeAction();
             expect(this.necromorph.location).toBe('play area');
             expect(this.necromorph.damage).toBe(0);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('destroys the chosen non-staralliance neighbor instead', function () {
@@ -40,8 +42,9 @@ describe('Necromorph', function () {
             expect(this.player1).isReadyToTakeAction();
             expect(this.necromorph.location).toBe('play area');
             expect(this.huntingWitch.location).toBe('play area');
-            expect(this.flaxia.location).toBe('discard');
+            expect.soft(this.flaxia.location).toBe('discard');
             expect(this.troll.damage).toBe(5);
+            expect(this.player1).isReadyToTakeAction();
         });
 
         it('gets destroyed with no non-staralliance neighbors', function () {
@@ -49,6 +52,7 @@ describe('Necromorph', function () {
             this.player1.fightWith(this.troll, this.necromorph);
             expect(this.player1).isReadyToTakeAction();
             expect(this.necromorph.location).toBe('discard');
+            expect(this.player1).isReadyToTakeAction();
         });
     });
 });


### PR DESCRIPTION
Fixes #4377 

### Summary

Introduces a declarative `ReplaceDestructionAction` (`replaceDestruction`) to encapsulate the logic of cards that replace their own or others' destruction (e.g., Armageddon Cloak, Reassembling Automaton). By deferring replacement execution to a post-resolution window, other `Destroyed:` triggers (like Dust Imp) are guaranteed to fire correctly before destruction is cancelled.

### Key Changes
- **`ReplaceDestructionAction`**: Implements a new declarative action to mark destruction events as replaced and queue alternative actions for deferred execution.
- **`DestroyedTriggeredAbilityWindow`**: Updated to store pending replacements, support player choice when multiple replacements target the same card, and defer execution and cancellation until all standard triggers resolve.
- **Card Refactoring**: Converted Armageddon Cloak, Reassembling Automaton, Self-Bolstering Automata, Necromorph, Paradox Shield, The Body Snatchers, and Ley Earl of Hurl to use the new declarative action.
- **Documentation & Tests**: Added detailed usage guidelines to `docs/card-abilities.md` and implemented comprehensive integration tests in `test/server/abilities/destroy.spec.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core destruction-window sequencing and event cancellation, which is timing-critical for many cards; regressions could show up as wrong discard, missed triggers, or broken “destroyed this way” checks.
> 
> **Overview**
> Introduces **`ability.actions.replaceDestruction()`** so `Destroyed:` “instead” effects mark the destroy/leaves-play events as replaced, queue the real actions (heal, move to flank, destroy upgrade, take control, etc.), and only run them **after** every `Destroyed:` trigger in the window has finished—so ordering no longer blocks other triggers (e.g. Dust Imp’s amber).
> 
> **`DestroyedAbilityWindow`** now holds `pendingReplacements`, runs replacements (with a prompt when several target the same card), cancels replaced events and clears `moribund`, and skips discard for `destroyEvent.replaced`; replacement-caused destroys stay batched in the same window.
> 
> **Seven cards** (Armageddon Cloak, Reassembling Automaton, Self-Bolstering Automata, Necromorph, Paradox Shield, The Body Snatchers, Ley Earl of Hurl) drop ad-hoc `changeEvent` / `moribund` hacks for the new action. **`docs/card-abilities.md`** documents replacement ordering and examples; **`destroy.spec.js`** adds Armageddon Cloak and Body Snatchers timing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751dd3db51fcb16c24c0e7c114f0e6db7f636fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->