### PR TITLE
fix(game): Updated Entropic Swirl due to Errata Rules 18.4

### DIFF
--- a/server/game/cards/02-AoA/EntropicSwirl.js
+++ b/server/game/cards/02-AoA/EntropicSwirl.js
@@ -7,12 +7,12 @@ class EntropicSwirl extends Card {
             target: {
                 cardType: 'creature',
                 gameAction: [
-                    ability.actions.dealDamage((context) => ({
-                        amount: (context.target?.getTraits() || []).length * 2
-                    })),
                     ability.actions.gainAmber((context) => ({
                         amount: (context.target?.getTraits() || []).length,
                         target: context.player
+                    })),
+                    ability.actions.dealDamage((context) => ({
+                        amount: (context.target?.getTraits() || []).length * 2
                     }))
                 ]
             }


### PR DESCRIPTION
Only functional changes is to generate aember before damage is dealt. 

Fixes #5192.