### PR TITLE
Fix if bracket lint failures

### DIFF
--- a/server/game/cards/04-MM/Purify.js
+++ b/server/game/cards/04-MM/Purify.js
@@ -13,7 +13,9 @@ class Purify extends Card {
                 gameAction: ability.actions.purge()
             },
             then: (preThenContext) => {
-                if (!preThenContext.target) return null;
+                if (!preThenContext.target) {
+                    return null;
+                }
                 let deck = preThenContext.target.controller.deck;
                 let index = deck.findIndex(
                     (card) => card.type === 'creature' && !card.hasTrait('mutant')

--- a/server/game/cards/05-DT/ExploratoryCraft.js
+++ b/server/game/cards/05-DT/ExploratoryCraft.js
@@ -13,7 +13,9 @@ class ExploratoryCraft extends Card {
                 gameAction: ability.actions.exhaust()
             },
             then: (preThenContext) => {
-                if (!preThenContext.target) return null;
+                if (!preThenContext.target) {
+                    return null;
+                }
                 return {
                     gameAction: ability.actions.draw({
                         amount: new Set(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Formatting-only edits to card ability callbacks; no logic or gameplay changes.
> 
> **Overview**
> Addresses **if-bracket** lint failures in two card ability handlers by wrapping early returns in braces.
> 
> In `Purify.js` and `ExploratoryCraft.js`, the `then` callbacks now use a multi-line `if (!preThenContext.target) { return null; }` instead of a single-line guard. **No behavior change**—only formatting to satisfy the linter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16ab4ff5b10771b89fd0c2b1c5b76a44ec6b22f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->